### PR TITLE
feat: recruit 페이지 관련 ui제작 및 api 연동 완료

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-slot": "^1.2.3",
     "@sentry/nextjs": "^9.34.0",
     "@storybook/experimental-addon-test": "8.6.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "ky": "^1.8.1",
     "lucide-react": "^0.525.0",
     "next": "15.3.4",
     "next-auth": "^4.24.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-avatar':
+        specifier: ^1.1.10
+        version: 1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.8)(react@19.1.0)
@@ -23,6 +26,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      ky:
+        specifier: ^1.8.1
+        version: 1.8.1
       lucide-react:
         specifier: ^0.525.0
         version: 0.525.0(react@19.1.0)
@@ -1056,6 +1062,19 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.8
 
+  '@radix-ui/react-avatar@1.1.10':
+    resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -1065,8 +1084,57 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3172,6 +3240,10 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
+  ky@1.8.1:
+    resolution: {integrity: sha512-7Bp3TpsE+L+TARSnnDpk3xg8Idi8RwSLdj6CMbNWoOARIrGrbuLGusV0dYwbZOm4bB3jHNxSw8Wk/ByDqJEnDw==}
+    engines: {node: '>=18'}
+
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
 
@@ -4323,6 +4395,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
@@ -5389,15 +5466,62 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
 
+  '@radix-ui/react-context@1.1.2(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
   '@radix-ui/react-slot@1.2.3(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
@@ -7831,6 +7955,8 @@ snapshots:
 
   kleur@3.0.3: {}
 
+  ky@1.8.1: {}
+
   language-subtag-registry@0.3.23: {}
 
   language-tags@1.0.9:
@@ -9008,6 +9134,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.5.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   util@0.12.5:
     dependencies:

--- a/src/app/(main)/club/page.tsx
+++ b/src/app/(main)/club/page.tsx
@@ -1,0 +1,9 @@
+function Page() {
+  return (
+    <div>
+      <h1>Clubs</h1>
+    </div>
+  );
+}
+
+export default Page;

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 
-export default function Home() {
+function Page() {
   return (
     <div className="grid min-h-screen grid-rows-[20px_1fr_20px] items-center justify-items-center gap-16 p-8 pb-20 font-[family-name:var(--font-geist-sans)] sm:p-20">
       <main className="row-start-2 flex flex-col items-center gap-[32px] sm:items-start">
@@ -101,3 +101,5 @@ export default function Home() {
     </div>
   );
 }
+
+export default Page;

--- a/src/app/(main)/recruit/layout.tsx
+++ b/src/app/(main)/recruit/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '모꼬지 | 세종대학교의 모든 동아리',
+  description: '세종대학교 동아리 통합 플랫폼',
+};
+
+export default function Layout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <main className="p-25 pt-19">{children}</main>;
+}

--- a/src/app/(main)/recruit/page.tsx
+++ b/src/app/(main)/recruit/page.tsx
@@ -1,7 +1,8 @@
 import RecruitPage from '@/views/recruit/recruit-page';
+import { RecruitItemListProps } from '@/widgets/recruit/model/type';
 
-function Page() {
-  return <RecruitPage />;
+function Page({ searchParams }: RecruitItemListProps) {
+  return <RecruitPage searchParams={searchParams} />;
 }
 
 export default Page;

--- a/src/app/(main)/recruit/page.tsx
+++ b/src/app/(main)/recruit/page.tsx
@@ -1,0 +1,7 @@
+import RecruitPage from '@/views/recruit/recruit-page';
+
+function Page() {
+  return <RecruitPage />;
+}
+
+export default Page;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,109 +1,107 @@
-// import nextAuth from 'next-auth';
-// import CredentialsProvider from 'next-auth/providers/credentials';
-// import ky from 'ky';
-// import { LoginResponse } from '@/features/login/model/loginType';
+import nextAuth from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+import ky from 'ky';
 
-// export const { auth, handlers, signIn, signOut } = nextAuth({
-//   secret: '1004',
-//   providers: [
-//     CredentialsProvider({
-//       // 이 부분은 자체 로그인 로직을 구현합니다.
-//       name: 'credentials',
-//       credentials: {
-//         email: { label: '이메일', type: 'text' },
-//         password: { label: '비밀번호', type: 'password' },
-//         target: { label: 'target', type: 'text' },
-//       },
+export const { auth, handlers, signIn, signOut } = nextAuth({
+  secret: '1004',
+  providers: [
+    CredentialsProvider({
+      name: 'credentials',
+      credentials: {
+        email: { label: '이메일', type: 'text' },
+        password: { label: '비밀번호', type: 'password' },
+        target: { label: 'target', type: 'text' },
+      },
 
-//       async authorize(credentials): Promise<any> {
-//         const { email, password, target } = credentials || {};
-//         try {
-//           let response;
-//           if (target === 'user') {
-//             response = await ky.post(
-//               `${process.env.NEXT_PUBLIC_API_URL}/api/b2b-service/consumer/login`,
-//               {
-//                 json: {
-//                   email,
-//                   password,
-//                 },
-//               },
-//             );
-//             const data: LoginResponse = await response.json();
-//             if (data) {
-//               // 유저 정보와 토큰을 NextAuth.js 세션에 저장합니다.
-//               return {
-//                 consumerSeq: data.data.consumerSeq,
-//                 accessToken: data.data.accessToken,
-//                 refreshToken: data.data.refreshToken,
-//                 uniqueType: data.data.consumerUniqueType,
-//                 name: data.data.consumerName,
-//                 role: 'consumer',
-//               };
-//             }
-//           }
-//           if (target === 'vendor') {
-//             response = await ky.post(
-//               `${process.env.NEXT_PUBLIC_API_URL}/api/b2b-service/vendor/login`,
-//               {
-//                 json: {
-//                   email,
-//                   password,
-//                 },
-//                 headers: {
-//                   'Content-Type': 'application/json',
-//                 },
-//               },
-//             );
-//             const data: LoginResponse = await response.json();
-//             if (data) {
-//               // 유저 정보와 토큰을 NextAuth.js 세션에 저장합니다.
-//               return {
-//                 vendorSeq: data.data.vendorSeq,
-//                 accessToken: data.data.accessToken,
-//                 refreshToken: data.data.refreshToken,
-//                 uniqueType: data.data.vendorUniqueType,
-//                 name: data.data.vendorName,
-//                 role: 'vendor',
-//               };
-//             }
-//           }
+      async authorize(credentials): Promise<any> {
+        const { email, password, target } = credentials || {};
+        try {
+          let response;
+          if (target === 'user') {
+            response = await ky.post(
+              `${process.env.NEXT_PUBLIC_API_URL}/api/b2b-service/consumer/login`,
+              {
+                json: {
+                  email,
+                  password,
+                },
+              },
+            );
+            const data: any = await response.json();
+            if (data) {
+              // 유저 정보와 토큰을 NextAuth.js 세션에 저장합니다.
+              return {
+                consumerSeq: data.data.consumerSeq,
+                accessToken: data.data.accessToken,
+                refreshToken: data.data.refreshToken,
+                uniqueType: data.data.consumerUniqueType,
+                name: data.data.consumerName,
+                role: 'consumer',
+              };
+            }
+          }
+          if (target === 'vendor') {
+            response = await ky.post(
+              `${process.env.NEXT_PUBLIC_API_URL}/api/b2b-service/vendor/login`,
+              {
+                json: {
+                  email,
+                  password,
+                },
+                headers: {
+                  'Content-Type': 'application/json',
+                },
+              },
+            );
+            const data: any = await response.json();
+            if (data) {
+              // 유저 정보와 토큰을 NextAuth.js 세션에 저장합니다.
+              return {
+                vendorSeq: data.data.vendorSeq,
+                accessToken: data.data.accessToken,
+                refreshToken: data.data.refreshToken,
+                uniqueType: data.data.vendorUniqueType,
+                name: data.data.vendorName,
+                role: 'vendor',
+              };
+            }
+          }
 
-//           return null;
-//         } catch (error) {
-//           console.error('로그인 실패:', error);
-//           return null;
-//         }
-//       },
-//     }),
-//   ],
-//   callbacks: {
-//     jwt: async ({ token, user }: any) => {
-//       if (user) {
-//         return {
-//           ...token,
-//           accessToken: user.accessToken,
-//           refreshToken: user.refreshToken,
-//           consumerSeq: user.consumerSeq,
-//           vendorSeq: user.vendorSeq,
-//           uniqueType: user.uniqueType,
-//           name: user.name,
-//           role: user.role,
-//         };
-//       }
-//       return token;
-//     },
-//     session: async ({ session, token }: any) => {
-//       return {
-//         ...session,
-//         accessToken: token.accessToken,
-//         refreshToken: token.refreshToken,
-//         consumerSeq: token.consumerSeq,
-//         vendorSeq: token.vendorSeq,
-//         uniqueType: token.uniqueType,
-//         name: token.name,
-//         role: token.role,
-//       };
-//     },
-//   },
-// });
+          return null;
+        } catch (error) {
+          console.error('로그인 실패:', error);
+          return null;
+        }
+      },
+    }),
+  ],
+  callbacks: {
+    jwt: async ({ token, user }: any) => {
+      if (user) {
+        return {
+          ...token,
+          accessToken: user.accessToken,
+          refreshToken: user.refreshToken,
+          consumerSeq: user.consumerSeq,
+          vendorSeq: user.vendorSeq,
+          uniqueType: user.uniqueType,
+          name: user.name,
+          role: user.role,
+        };
+      }
+      return token;
+    },
+    session: async ({ session, token }: any) => {
+      return {
+        ...session,
+        accessToken: token.accessToken,
+        refreshToken: token.refreshToken,
+        consumerSeq: token.consumerSeq,
+        vendorSeq: token.vendorSeq,
+        uniqueType: token.uniqueType,
+        name: token.name,
+        role: token.role,
+      };
+    },
+  },
+});

--- a/src/entities/recruit/lib/getDateUtil.ts
+++ b/src/entities/recruit/lib/getDateUtil.ts
@@ -1,0 +1,25 @@
+function getDateUtil(recruitEndDate: string | undefined) {
+  if (recruitEndDate === undefined) {
+    return false;
+  }
+  const koreaYearEnd = new Date(
+    Date.UTC(new Date().getFullYear(), 11, 31, 14, 59, 59),
+  );
+
+  const recruitEnd = new Date(recruitEndDate);
+  const isEndOfYear =
+    recruitEnd.getFullYear() === koreaYearEnd.getFullYear() &&
+    recruitEnd.getMonth() === koreaYearEnd.getMonth() &&
+    recruitEnd.getDate() === koreaYearEnd.getDate();
+
+  return isEndOfYear;
+}
+
+export function formatToMonthDay(dateStr: string | Date): string {
+  const date = new Date(dateStr);
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  return `${month}-${day}`;
+}
+
+export default getDateUtil;

--- a/src/entities/recruit/ui/favorite-button.tsx
+++ b/src/entities/recruit/ui/favorite-button.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useState } from 'react';
+import { StarIcon, Star } from 'lucide-react';
+
+function FavoriteButton({ isFavorite }: { isFavorite: boolean }) {
+  const [filled, setFilled] = useState(isFavorite);
+
+  return (
+    <button
+      onClick={() => setFilled(!filled)}
+      aria-label="즐겨찾기 토글"
+      className="absolute right-5 bottom-5 text-black transition-colors duration-200"
+    >
+      {filled ? (
+        <StarIcon fill="black" stroke="black" className="h-6 w-6" />
+      ) : (
+        <Star className="h-6 w-6" />
+      )}
+    </button>
+  );
+}
+
+export default FavoriteButton;

--- a/src/entities/recruit/ui/nav-section.tsx
+++ b/src/entities/recruit/ui/nav-section.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import NavButton from '@/shared/ui/nav-button';
+import { usePathname, useSearchParams } from 'next/navigation';
+
+const navItems = [
+  { label: '중앙동아리', value: 'central_club' },
+  { label: '기타동아리', value: 'department_club' },
+  { label: '소모임', value: '' },
+];
+
+export default function NavSection() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const affiliation = searchParams.get('affiliation');
+
+  return (
+    <div className="mr-12 flex flex-row gap-4">
+      {navItems.map(({ label, value }) => (
+        <NavButton
+          key={value ?? 'none'}
+          label={label}
+          href={`/recruit?affiliation=${value}`}
+          navProps="pb-2"
+          active={pathname === '/recruit' && (affiliation ?? '') === value}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/entities/recruit/ui/period-section.tsx
+++ b/src/entities/recruit/ui/period-section.tsx
@@ -1,0 +1,22 @@
+import getDateUtil, {
+  formatToMonthDay,
+} from '@/entities/recruit/lib/getDateUtil';
+
+interface PeriodSectionProps {
+  startDate: string;
+  endDate: string;
+}
+
+function PeriodSection({ startDate, endDate }: PeriodSectionProps) {
+  const isEndOfYear = getDateUtil(endDate);
+
+  return isEndOfYear ? (
+    <span className="text-center text-xs font-semibold">상시모집</span>
+  ) : (
+    <span className="text-center text-xs font-semibold">
+      {`모집기간: ${formatToMonthDay(startDate)} ~ ${formatToMonthDay(endDate)}`}
+    </span>
+  );
+}
+
+export default PeriodSection;

--- a/src/entities/recruit/ui/recruit-header.tsx
+++ b/src/entities/recruit/ui/recruit-header.tsx
@@ -1,21 +1,11 @@
-import NavButton from '@/shared/ui/nav-button';
+import NavSection from './nav-section';
 
 function RecruitHeader() {
   return (
     <header className="mb-15">
       <nav className="mb-5 flex flex-row justify-between">
         <h1 className="text-xl font-bold text-[#00E457]">모집 공고</h1>
-        <div className="mr-12 flex flex-row gap-4">
-          <NavButton
-            label="중앙동아리"
-            href="/recruit?affiliation=CENTRAL_CLUB"
-          />
-          <NavButton
-            label="기타동아리"
-            href="/recruit?affiliation=DEPARTMENT_CLUB"
-          />
-          <NavButton label="소모임" href="/recruit" />
-        </div>
+        <NavSection />
       </nav>
       <h2 className="mt-2 mb-3 text-3xl font-bold text-[474747]">
         관심 있는 동아리의 최신공고를

--- a/src/entities/recruit/ui/recruit-header.tsx
+++ b/src/entities/recruit/ui/recruit-header.tsx
@@ -1,0 +1,29 @@
+import NavButton from '@/shared/ui/nav-button';
+
+function RecruitHeader() {
+  return (
+    <header className="mb-15">
+      <nav className="mb-5 flex flex-row justify-between">
+        <h1 className="text-xl font-bold text-[#00E457]">모집 공고</h1>
+        <div className="mr-12 flex flex-row gap-4">
+          <NavButton
+            label="중앙동아리"
+            href="/recruit?affiliation=CENTRAL_CLUB"
+          />
+          <NavButton
+            label="기타동아리"
+            href="/recruit?affiliation=DEPARTMENT_CLUB"
+          />
+          <NavButton label="소모임" href="/recruit" />
+        </div>
+      </nav>
+      <h2 className="mt-2 mb-3 text-3xl font-bold text-[474747]">
+        관심 있는 동아리의 최신공고를
+        <br />
+        한눈에 확인할 수 있어요.
+      </h2>
+    </header>
+  );
+}
+
+export default RecruitHeader;

--- a/src/entities/recruit/ui/recruit-item.tsx
+++ b/src/entities/recruit/ui/recruit-item.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
+import RadiusTag from '@/shared/ui/radius-tag';
+import PeriodSection from './period-section';
+import FavoriteButton from './favorite-button';
+
+interface RecruitItemProps {
+  title: string;
+  startDate: string;
+  endDate: string;
+  description: string;
+  isFavorite?: boolean;
+  imgUrl?: string;
+}
+
+function RecruitItem({
+  title,
+  startDate,
+  endDate,
+  description,
+  isFavorite,
+  imgUrl,
+}: RecruitItemProps) {
+  return (
+    <div className="relative h-[200px] w-auto rounded-sm bg-[#F8F8F8] p-5">
+      <div className="mb-8 flex flex-row items-center justify-between">
+        <div className="flex flex-row items-center gap-2">
+          <Avatar className="size-12">
+            <AvatarImage src={imgUrl} />
+            <AvatarFallback>{title}</AvatarFallback>
+          </Avatar>
+          <div>
+            <PeriodSection startDate={startDate} endDate={endDate} />
+            <h1 className="text-xl font-bold">{title}</h1>
+          </div>
+        </div>
+        <RadiusTag label="모집중" className="bg-[#00E457] text-white" />
+      </div>
+      <div className="flex flex-row justify-between">
+        <div className="w-[250px] text-sm break-words whitespace-normal">
+          {description}
+        </div>
+      </div>
+      <FavoriteButton isFavorite={isFavorite || false} />
+    </div>
+  );
+}
+
+export default RecruitItem;

--- a/src/shared/api/server-api.ts
+++ b/src/shared/api/server-api.ts
@@ -1,0 +1,45 @@
+import ky, { HTTPError } from 'ky';
+import { auth } from '@/auth';
+
+const serverApi = ky.create({
+  prefixUrl: process.env.NEXT_PUBLIC_API_URL,
+  hooks: {
+    beforeRequest: [
+      // TODO: 추후 구현
+      // async (req) => {
+      //   if (!req.headers.get('Authorization')) {
+      //     const session = await auth();
+      //     req.headers.set('Authorization', `Bearer ${session?.accessToken}`);
+      //   }
+      // },
+    ],
+    beforeError: [
+      async (error) => {
+        console.log(error);
+        if (error instanceof HTTPError) {
+          switch (error.response.status) {
+            case 400:
+              throw new Error('잘못된 요청입니다.');
+            case 401:
+              throw new Error('인증이 만료되었습니다.');
+            case 403:
+              throw new Error('권한이 없습니다.');
+            case 404:
+              throw new Error('요청한 자원을 찾을 수 없습니다.');
+            case 409:
+              throw new Error('이미 등록된 솔루션입니다.');
+            case 500:
+              throw new Error('서버 오류가 발생했습니다. 다시 시도해주세요.');
+            default:
+              throw new Error(
+                '알 수 없는 오류가 발생했습니다. 다시 시도해주세요.',
+              );
+          }
+        }
+        throw new Error('알 수 없는 오류가 발생했습니다. 다시 시도해주세요.');
+      },
+    ],
+  },
+});
+
+export default serverApi;

--- a/src/shared/model/type.ts
+++ b/src/shared/model/type.ts
@@ -1,0 +1,36 @@
+export interface ApiResponse<T> {
+  status: number;
+  message: string | undefined;
+  data: T;
+  error: string | undefined;
+}
+
+export enum ClubCategory {
+  CULTURAL_ART = 'CULTURAL_ART',
+  ACADEMIC_CULTURAL = 'ACADEMIC_CULTURAL',
+  VOLUNTEER_SOCIAL = 'VOLUNTEER_SOCIAL',
+  SPORTS = 'SPORTS',
+  RELIGIOUS = 'RELIGIOUS',
+  SOCIAL = 'SOCIAL',
+}
+
+export enum ClubAffiliation {
+  CENTRAL_CLUB = 'CENTRAL_CLUB',
+  DEPARTMENT_CLUB = 'DEPARTMENT_CLUB',
+}
+
+export interface ClubList {
+  clubs: ClubType[];
+}
+
+export interface ClubType {
+  id: number;
+  name: string;
+  category: ClubCategory;
+  affiliation: ClubAffiliation;
+  description: string;
+  recruitStartDate: string;
+  recruitEndDate: string;
+  imageURL: string;
+  isFavorite: boolean | undefined;
+}

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -2,7 +2,9 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import Image from 'next/image';
 import React from 'react';
+import NavButton from './nav-button';
 
 function Header() {
   const pathname = usePathname();
@@ -15,33 +17,32 @@ function Header() {
         Mokkoji
       </Link>
       <nav className="flex h-full items-center">
-        <Link
-          href="/clubs"
-          className={`flex h-full items-center px-3.25 no-underline ${pathname === '/clubs' ? 'border-b-3' : ''}`}
-        >
-          전체 동아리
-        </Link>
-        <Link
+        <NavButton
+          label="전체 동아리"
+          href="/club"
+          active={pathname === '/club'}
+        />
+        <NavButton
+          label="모집 공고"
           href="/recruit"
-          className={`relative flex h-full items-center px-3.25 no-underline ${pathname === '/recruit' ? 'border-b-3' : ''}`}
-        >
-          모집 공고
-        </Link>
-        <Link
+          active={pathname === '/recruit'}
+        />
+        <NavButton
+          label="즐겨찾기"
           href="/favorite"
-          className={`flex h-full items-center px-3.25 no-underline ${pathname === '/favorite' ? 'border-b-3' : ''}`}
-        >
-          즐겨찾기
-        </Link>
+          active={pathname === '/favorite'}
+        />
       </nav>
       <div className="ml-auto flex items-center gap-3.5">
         <span className="text-base font-light text-[#9C9C9C]">
           <span className="font-semibold">모꼬지님!</span> 안녕하세요
         </span>
-        <img
+        <Image
           src="/header/search.svg"
           alt="검색"
-          className="h-5 w-5 cursor-pointer"
+          width={20}
+          height={20}
+          className="cursor-pointer"
         />
       </div>
     </header>

--- a/src/shared/ui/avatar.tsx
+++ b/src/shared/ui/avatar.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import * as React from 'react';
+import * as AvatarPrimitive from '@radix-ui/react-avatar';
+import cn from '@/shared/lib/utils';
+
+function Avatar({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root>) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      className={cn(
+        'relative flex size-8 shrink-0 overflow-hidden rounded-full',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn('aspect-square size-full', className)}
+      {...props}
+    />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        'bg-muted flex size-full items-center justify-center rounded-full',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/src/shared/ui/nav-button.stories.tsx
+++ b/src/shared/ui/nav-button.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import NavButton from './nav-button';
+
+const meta: Meta<typeof NavButton> = {
+  title: 'Components/NavButton',
+  component: NavButton,
+};
+
+export default meta;
+type Story = StoryObj<typeof NavButton>;
+
+export const Active: Story = {
+  args: {
+    label: '모집 공고',
+    href: '#',
+    active: true,
+  },
+};
+
+export const Inactive: Story = {
+  args: {
+    label: '모집 공고',
+    href: '#',
+    active: false,
+  },
+};

--- a/src/shared/ui/nav-button.tsx
+++ b/src/shared/ui/nav-button.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import React from 'react';
+import clsx from 'clsx';
+import Link from 'next/link';
+
+interface NavButtonProps {
+  label: string;
+  navProps?: string;
+  active?: boolean;
+  href: string;
+}
+
+export default function NavButton({
+  label,
+  active = false,
+  navProps,
+  href,
+}: NavButtonProps) {
+  return (
+    <Link
+      href={href}
+      className={clsx(
+        'flex h-full items-center px-3.25 no-underline',
+        navProps,
+        active ? 'border-b-2 border-black' : '',
+      )}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/src/shared/ui/radius-tag.tsx
+++ b/src/shared/ui/radius-tag.tsx
@@ -1,0 +1,21 @@
+import clsx from 'clsx';
+
+interface RadiusTagProps {
+  className?: string;
+  label: string;
+}
+
+function RadiusTag({ className, label }: RadiusTagProps) {
+  return (
+    <span
+      className={clsx(
+        'h-[30px] w-[50px] rounded-full p-2 text-center text-xs',
+        className,
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+export default RadiusTag;

--- a/src/views/recruit/recruit-page.tsx
+++ b/src/views/recruit/recruit-page.tsx
@@ -1,0 +1,13 @@
+import RecruitHeader from '@/entities/recruit/ui/recruit-header';
+import RecruitItemList from '@/widgets/recruit/ui/recruit-item-list';
+
+function RecruitPage() {
+  return (
+    <div>
+      <RecruitHeader />
+      <RecruitItemList />
+    </div>
+  );
+}
+
+export default RecruitPage;

--- a/src/views/recruit/recruit-page.tsx
+++ b/src/views/recruit/recruit-page.tsx
@@ -1,11 +1,12 @@
 import RecruitHeader from '@/entities/recruit/ui/recruit-header';
 import RecruitItemList from '@/widgets/recruit/ui/recruit-item-list';
+import { RecruitItemListProps } from '@/widgets/recruit/model/type';
 
-function RecruitPage() {
+function RecruitPage({ searchParams }: RecruitItemListProps) {
   return (
     <div>
       <RecruitHeader />
-      <RecruitItemList />
+      <RecruitItemList searchParams={searchParams} />
     </div>
   );
 }

--- a/src/widgets/recruit/api/getRecruitList.ts
+++ b/src/widgets/recruit/api/getRecruitList.ts
@@ -1,0 +1,45 @@
+import {
+  ApiResponse,
+  ClubCategory,
+  ClubList,
+  ClubAffiliation,
+} from '@/shared/model/type';
+import serverApi from '@/shared/api/server-api';
+
+interface GetRecruitListParams {
+  page: number;
+  size: number;
+  keyword: string | undefined;
+  category: ClubCategory | undefined;
+  affiliation: ClubAffiliation | undefined;
+  recruitStatus: string | undefined;
+}
+
+async function getRecruitList(params: GetRecruitListParams) {
+  const rawParams = {
+    page: params.page,
+    size: params.size,
+    keyword: params.keyword,
+    category: params.category,
+    affiliation: params.affiliation,
+    recruitStatus: params.recruitStatus,
+  };
+
+  const searchParams = new URLSearchParams();
+
+  Object.entries(rawParams).forEach(([key, value]) => {
+    if (value !== undefined) {
+      searchParams.set(key, String(value));
+    }
+  });
+
+  const response: ApiResponse<ClubList> = await serverApi
+    .get('clubs', {
+      searchParams,
+    })
+    .json();
+
+  return response.data.clubs;
+}
+
+export default getRecruitList;

--- a/src/widgets/recruit/model/type.ts
+++ b/src/widgets/recruit/model/type.ts
@@ -1,0 +1,10 @@
+export interface RecruitItemListProps {
+  searchParams: Promise<{
+    page?: string;
+    size?: string;
+    keyword?: string;
+    category?: string;
+    affiliation?: string;
+    recruitStatus?: string;
+  }>;
+}

--- a/src/widgets/recruit/ui/recruit-item-list.tsx
+++ b/src/widgets/recruit/ui/recruit-item-list.tsx
@@ -1,0 +1,33 @@
+import RecruitItem from '@/entities/recruit/ui/recruit-item';
+import getRecruitList from '../api/getRecruitList';
+
+async function RecruitItemList() {
+  const data = await getRecruitList({
+    page: 1,
+    size: 10,
+    keyword: undefined,
+    category: undefined,
+    affiliation: undefined,
+    recruitStatus: undefined,
+  });
+  console.log('recruitData', data);
+
+  return (
+    <ul className="grid w-auto grid-cols-3 gap-4">
+      {data.map((item) => (
+        <li key={item.id}>
+          <RecruitItem
+            title={item.name}
+            startDate={item.recruitStartDate}
+            endDate={item.recruitEndDate}
+            description={item.description}
+            isFavorite={item.isFavorite}
+            imgUrl={item.imageURL}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default RecruitItemList;

--- a/src/widgets/recruit/ui/recruit-item-list.tsx
+++ b/src/widgets/recruit/ui/recruit-item-list.tsx
@@ -1,16 +1,21 @@
 import RecruitItem from '@/entities/recruit/ui/recruit-item';
+import { ClubAffiliation, ClubCategory } from '@/shared/model/type';
 import getRecruitList from '../api/getRecruitList';
+import { RecruitItemListProps } from '../model/type';
 
-async function RecruitItemList() {
+async function RecruitItemList({ searchParams }: RecruitItemListProps) {
+  console.log('searchParams', await searchParams);
+
   const data = await getRecruitList({
-    page: 1,
-    size: 10,
-    keyword: undefined,
-    category: undefined,
-    affiliation: undefined,
-    recruitStatus: undefined,
+    page: Number((await searchParams).page || 1),
+    size: Number((await searchParams).size || 10),
+    keyword: (await searchParams).keyword?.toUpperCase() || '',
+    category: (await searchParams).category?.toUpperCase() as ClubCategory,
+    affiliation: (
+      await searchParams
+    ).affiliation?.toUpperCase() as ClubAffiliation,
+    recruitStatus: (await searchParams).recruitStatus,
   });
-  console.log('recruitData', data);
 
   return (
     <ul className="grid w-auto grid-cols-3 gap-4">


### PR DESCRIPTION
## #️⃣연관된 이슈

feat: recruit 페이지 관련 ui제작 및 api 연동 완료

## 📝작업 내용

1. 스토리북 공용 컴포넌트 제작
2. 카테고리별 페이지 api 연동
3. 공고 페이지 ui 구현

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/743ee99b-7793-42dc-b38d-a0985b87c2b7)

## 💬리뷰 요구사항(선택)

서버 컴포넌트로 만들기 위해 쿼리 파라미터를 가져오는 과정에서 app라우터 부터 프롭스 드릴링이 일어나는데 
해결책 생각나면 이야기 해주세요 

컨텍스트 프로바이더는 클라이언트 컴포넌트에 쓸 수 있어서 안됨 
세션 스토레지 저장은 별로인 것 같음