### PR TITLE
feat: footer 추가

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -4,6 +4,7 @@ import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import Header from '@/shared/ui/Header';
 import { SessionProvider } from 'next-auth/react';
+import Footer from '@/shared/ui/Footer';
 
 export default function MainLayout({
   children,
@@ -12,20 +13,23 @@ export default function MainLayout({
 }) {
   return (
     <SessionProvider>
-      <Header />
-      <ToastContainer
-        position="top-right"
-        autoClose={3000}
-        hideProgressBar={false}
-        newestOnTop={false}
-        closeOnClick
-        rtl={false}
-        pauseOnFocusLoss
-        draggable
-        pauseOnHover
-        theme="light"
-      />
-      {children}
+      <div className="flex min-h-screen flex-col">
+        <Header />
+        <ToastContainer
+          position="top-right"
+          autoClose={3000}
+          hideProgressBar={false}
+          newestOnTop={false}
+          closeOnClick
+          rtl={false}
+          pauseOnFocusLoss
+          draggable
+          pauseOnHover
+          theme="light"
+        />
+        <main className="flex-grow">{children}</main>
+        <Footer />
+      </div>
     </SessionProvider>
   );
 }

--- a/src/shared/ui/Footer.tsx
+++ b/src/shared/ui/Footer.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+function Footer() {
+  return (
+    <footer className="flex h-[74px] w-full items-center justify-center gap-10 text-sm text-[#545454]">
+      <p className="cursor-default">
+        COPYRIGHT @ 2025 모꼬지. ALL RIGHT RESERVERD.
+      </p>
+      <Link href="/bug-report" className="underline">
+        버그 제보
+      </Link>
+    </footer>
+  );
+}
+
+export default Footer;


### PR DESCRIPTION
## #️⃣연관된 이슈

[#35 ] footer 추가

## 📝작업 내용

footer 추가

### 스크린샷 (선택)

<img width="1898" height="642" alt="image" src="https://github.com/user-attachments/assets/47291c22-16a2-472b-b502-6abcc8388c8c" />

<img width="1918" height="857" alt="image" src="https://github.com/user-attachments/assets/f132f2ea-c8c4-4453-8eb3-c92c9caa1252" />

## 💬리뷰 요구사항(선택)

footer 추가해두었습니다
버그 제보 페이지는 아직 존재하지 않아서 임시로 경로 설정해두었고,
간혹 main의 height가 뷰포트를 꽉 채우지 못하는 경우를 대비해서 Sticky Footer 레이아웃으로 수정해두었습니다.