### PR TITLE
refactor: header 검색 버그 수정 및 일부 코드 리팩토링

### DIFF
--- a/src/features/header/ui/header-login.tsx
+++ b/src/features/header/ui/header-login.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import Link from 'next/link';
+
+function HeaderLogin() {
+  const { data: session } = useSession();
+
+  return (
+    <span className="text-base font-light text-[#9C9C9C]">
+      {session?.user?.name ? (
+        <span className="flex gap-2 font-semibold whitespace-nowrap">
+          <span className="font-bold text-gray-400">
+            {session?.user?.name}님!
+          </span>
+          안녕하세요
+        </span>
+      ) : (
+        <Link href="/login" className="whitespace-nowrap">
+          로그인
+        </Link>
+      )}
+    </span>
+  );
+}
+
+export default HeaderLogin;

--- a/src/features/header/ui/header-search.tsx
+++ b/src/features/header/ui/header-search.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import Image from 'next/image';
+import { useEffect, useRef, useState } from 'react';
+
+function HeaderSearch() {
+  const [showSearch, setShowSearch] = useState(false);
+  const wrapperRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(event.target as Node)
+      ) {
+        setShowSearch(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    if (!showSearch) {
+      wrapperRef.current?.reset();
+    }
+  }, [showSearch]);
+
+  return (
+    <form
+      action="/search"
+      method="GET"
+      ref={wrapperRef}
+      className="flex items-center"
+    >
+      <input
+        type="text"
+        name="q"
+        placeholder="검색어를 입력해주세요"
+        className={`border- z-10 border-b-2 px-2 py-2 text-sm transition-all duration-300 ease-in-out outline-none focus-within:border-[#00E804] ${showSearch ? 'mr-2 w-52 opacity-100' : 'w-0 overflow-hidden opacity-0'}`}
+        autoComplete="off"
+      />
+      <button
+        type={showSearch ? 'submit' : 'button'}
+        onClick={(e) => {
+          if (!showSearch) {
+            e.preventDefault();
+            setShowSearch(true);
+          }
+        }}
+        className="flex items-center justify-center"
+      >
+        <Image
+          src="/header/search.svg"
+          alt="검색"
+          width={20}
+          height={20}
+          className="cursor-pointer"
+        />
+      </button>
+    </form>
+  );
+}
+
+export default HeaderSearch;

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -99,7 +99,7 @@ function Header() {
           >
             <input
               type="text"
-              name="keyword"
+              name="q"
               placeholder="검색어를 입력해주세요"
               className={`border- z-10 border-b-2 px-2 py-2 text-sm transition-all duration-300 ease-in-out outline-none focus-within:border-[#00E804] ${showSearch ? 'mr-2 w-52 opacity-100' : 'w-0 overflow-hidden opacity-0'}`}
               autoComplete="off"

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -1,38 +1,10 @@
-'use client';
-
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
-import Image from 'next/image';
-import React, { useEffect, useRef, useState } from 'react';
-import { useSession } from 'next-auth/react';
+import React from 'react';
+import HeaderSearch from '@/features/header/ui/header-search';
+import HeaderLogin from '@/features/header/ui/header-login';
 import NavButton from './nav-button';
 
 function Header() {
-  const pathname = usePathname();
-  const { data: session } = useSession();
-  const [showSearch, setShowSearch] = useState(false);
-  const wrapperRef = useRef<HTMLFormElement>(null);
-
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (
-        wrapperRef.current &&
-        !wrapperRef.current.contains(event.target as Node)
-      ) {
-        setShowSearch(false);
-      }
-    }
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  useEffect(() => {
-    if (!showSearch) {
-      wrapperRef.current?.reset();
-    }
-  }, [showSearch]);
-
   return (
     <>
       <div className="h-[65px]" />
@@ -50,79 +22,15 @@ function Header() {
           <span>Mokkoji</span>
         </Link>
         <nav className="scrollbar-hide flex h-full items-center gap-4 overflow-auto whitespace-nowrap">
-          <NavButton
-            label="전체 동아리"
-            href="/club/all"
-            active={pathname === '/club/all'}
-          />
-          <NavButton
-            label="모집 공고"
-            href="/recruit"
-            active={pathname.startsWith('/recruit')}
-          />
-          <NavButton
-            label="즐겨찾기"
-            href="/favorite"
-            active={pathname === '/favorite'}
-          />
-          <NavButton
-            label="동아리 등록"
-            href="/club-register"
-            active={pathname === '/club-register'}
-          />
-          <NavButton
-            label="고객센터"
-            href="/support"
-            active={pathname === '/support'}
-          />
+          <NavButton label="전체 동아리" href="/club/all" />
+          <NavButton label="모집 공고" href="/recruit" />
+          <NavButton label="즐겨찾기" href="/favorite" />
+          <NavButton label="동아리 등록" href="/club-register" />
+          <NavButton label="고객센터" href="/support" />
         </nav>
         <div className="ml-auto flex items-center gap-3.5">
-          <span className="text-base font-light text-[#9C9C9C]">
-            {session?.user?.name ? (
-              <span className="flex gap-2 font-semibold whitespace-nowrap">
-                <span className="font-bold text-gray-400">
-                  {session?.user?.name}님!
-                </span>
-                안녕하세요
-              </span>
-            ) : (
-              <Link href="/login" className="whitespace-nowrap">
-                로그인
-              </Link>
-            )}
-          </span>
-          <form
-            action="/search"
-            method="GET"
-            ref={wrapperRef}
-            className="flex items-center"
-          >
-            <input
-              type="text"
-              name="q"
-              placeholder="검색어를 입력해주세요"
-              className={`border- z-10 border-b-2 px-2 py-2 text-sm transition-all duration-300 ease-in-out outline-none focus-within:border-[#00E804] ${showSearch ? 'mr-2 w-52 opacity-100' : 'w-0 overflow-hidden opacity-0'}`}
-              autoComplete="off"
-            />
-            <button
-              type={showSearch ? 'submit' : 'button'}
-              onClick={(e) => {
-                if (!showSearch) {
-                  e.preventDefault();
-                  setShowSearch(true);
-                }
-              }}
-              className="flex items-center justify-center"
-            >
-              <Image
-                src="/header/search.svg"
-                alt="검색"
-                width={20}
-                height={20}
-                className="cursor-pointer"
-              />
-            </button>
-          </form>
+          <HeaderLogin />
+          <HeaderSearch />
         </div>
       </header>
     </>

--- a/src/shared/ui/nav-button.tsx
+++ b/src/shared/ui/nav-button.tsx
@@ -3,20 +3,18 @@
 import React from 'react';
 import clsx from 'clsx';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 interface NavButtonProps {
   label: string;
   navProps?: string;
-  active?: boolean;
   href: string;
 }
 
-export default function NavButton({
-  label,
-  active = false,
-  navProps,
-  href,
-}: NavButtonProps) {
+export default function NavButton({ label, navProps, href }: NavButtonProps) {
+  const pathname = usePathname();
+  const active = pathname.startsWith(href);
+
   return (
     <Link
       href={href}


### PR DESCRIPTION
## #️⃣연관된 이슈

[#49 ] refactor: header 검색 버그 수정 및 일부 코드 리팩토링

## 📝작업 내용

- 헤더 검색 버그 수정
- 로그인/검색바 컴포넌트 분리
- 클라이언트 컴포넌트 최소화 및 헤더 서버 컴포넌트로 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 검색 이슈는 파라미터는 `q=string`으로 요청해야하는데, `key=string`으로 요청하고 있었습니다.
- 로그인과 검색바 부분 컴포넌트로 분리하면서 클라이언트 선언도 가져갔습니다.
- 헤더 컴포넌트에서 메뉴 버튼 컴포넌트로 pathname을 옮겨서 서버 컴포넌트로 변경하였습니다.