### PR TITLE
chore: 소유권 인증 메타태그 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,6 +50,9 @@ const pretendard = localFont({
 export const metadata: Metadata = {
   title: '모꼬지 | 세종대 동아리',
   description: '세종대 동아리 통합 플랫폼',
+  other: {
+    'naver-site-verification': '150a4435ae2108c4b46284bb245f020da60c9069',
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## #️⃣연관된 이슈

chore: 소유권 인증 메타태그 추가

## 📝작업 내용

네이버 서치어드바이저에 웹사이트 소유 인증을 하기 위한 메타태그 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
