### PR TITLE
fix: 동아리 소개 문구 예외 처리

### DIFF
--- a/src/entities/club/ui/club-item.tsx
+++ b/src/entities/club/ui/club-item.tsx
@@ -5,7 +5,7 @@ import FavoriteButton from '@/shared/ui/favorite-button';
 
 interface ClubItemProps {
   title: string;
-  description: string;
+  description?: string;
   isFavorite?: boolean;
   logo?: string;
   category?: string;
@@ -39,7 +39,7 @@ function ClubItem({
 
       <div className="flex flex-row justify-between">
         <div className="line-clamp-2 overflow-hidden pr-7 text-[12px] break-words lg:text-xs">
-          {description}
+          {description || '동아리 소개 정보가 없습니다.'}
         </div>
       </div>
 

--- a/src/shared/model/type.ts
+++ b/src/shared/model/type.ts
@@ -29,7 +29,7 @@ export interface ClubType {
   name: string;
   category: ClubCategory;
   affiliation: ClubAffiliation;
-  description: string;
+  description?: string;
   recruitStartDate: string;
   recruitEndDate: string;
   logo: string;

--- a/src/views/club/model/type.ts
+++ b/src/views/club/model/type.ts
@@ -5,7 +5,7 @@ export interface ClubDetailType {
   name: string;
   category: string;
   affiliation: string;
-  description: string;
+  description?: string;
   recruitStartDate: string;
   recruitEndDate: string;
   logo: string;

--- a/src/views/club/ui/club-detail-page.tsx
+++ b/src/views/club/ui/club-detail-page.tsx
@@ -22,13 +22,19 @@ async function ClubDetailPage({ params }: DetailParams) {
         logo={data.logo}
         status={data.status}
       />
-      <p className="mb-3 text-sm leading-[1.4] whitespace-pre-wrap text-black lg:pt-10 lg:text-lg">
-        <span
-          dangerouslySetInnerHTML={{
-            __html: convertLinkText(data.description),
-          }}
-        />
-      </p>
+      {data.description ? (
+        <p className="mb-3 text-sm leading-[1.4] whitespace-pre-wrap text-black lg:pt-10 lg:text-lg">
+          <span
+            dangerouslySetInnerHTML={{
+              __html: convertLinkText(data.description),
+            }}
+          />
+        </p>
+      ) : (
+        <p className="py-30 text-center text-gray-500">
+          동아리 소개 정보가 없습니다.
+        </p>
+      )}
       <ClubDetailCommentWidget clubId={Number(id)} />
     </div>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

[#184 ] fix: 동아리 소개 문구 예외 처리

## 📝작업 내용

- 동아리 소개 문구가 없을 시 대체 텍스트 제공

### 스크린샷 (선택)
<img width="1842" height="861" alt="image" src="https://github.com/user-attachments/assets/86a81f29-0a1b-46f6-8c00-2a2f50a88723" />

<img width="367" height="768" alt="image" src="https://github.com/user-attachments/assets/ea34ce80-c178-4ffd-9930-b864f171551e" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
