### PR TITLE
feat: 가상 윈도우를 통한 dom 랜더 개선

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -40,6 +40,9 @@ let nextConfig: NextConfig = {
         /\/api\/auth\/session/, // NextAuth 세션 체크 무시
       ],
     },
+    fetches: {
+      fullUrl: true,
+    },
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@sentry/nextjs": "^9.34.0",
     "@storybook/experimental-addon-test": "8.6.12",
+    "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-virtual": "^3.13.12",
     "@vercel/speed-insights": "^1.2.0",
     "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@sentry/nextjs": "^9.34.0",
     "@storybook/experimental-addon-test": "8.6.12",
+    "@tanstack/react-virtual": "^3.13.12",
     "@vercel/speed-insights": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -52,7 +53,7 @@
     "react-toastify": "^11.0.5",
     "require-in-the-middle": "^7.5.2",
     "tailwind-merge": "^3.3.1",
-    "to-do-pin": "0.0.30",
+    "to-do-pin": "0.0.33",
     "web-vitals": "^5.1.0",
     "winston": "^3.17.0"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:chrome": "playwright test --project=Chromium",
     "test:firefox": "playwright test --project=Firefox",
     "test:safari": "playwright test --project=WebKit",
-    "test:ui": "playwright test --ui"
+    "test:ui": "playwright test --ui",
+    "test:codegen": "playwright codegen http://localhost:3000"
   },
   "dependencies": {
     "@microsoft/clarity": "^1.0.0",
@@ -53,7 +54,7 @@
     "react-toastify": "^11.0.5",
     "require-in-the-middle": "^7.5.2",
     "tailwind-merge": "^3.3.1",
-    "to-do-pin": "0.0.33",
+    "to-do-pin": "0.0.37",
     "web-vitals": "^5.1.0",
     "winston": "^3.17.0"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
   },
   use: {
     headless: false,
+    launchOptions: {
+      args: ['--disable-cache'],
+    },
   },
 
   projects: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,13 +105,8 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
       to-do-pin:
-<<<<<<< HEAD
-        specifier: 0.0.33
-        version: 0.0.33(lucide-react@0.525.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react-router-dom@7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
-=======
         specifier: 0.0.37
         version: 0.0.37(lucide-react@0.525.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react-router-dom@7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
->>>>>>> develop
       web-vitals:
         specifier: ^5.1.0
         version: 5.1.0
@@ -6277,13 +6272,8 @@ packages:
     resolution: {integrity: sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==}
     engines: {node: '>= 0.4'}
 
-<<<<<<< HEAD
-  to-do-pin@0.0.33:
-    resolution: {integrity: sha512-d2VwSYuVP9I4yEkFXG7MV2SEEYo5gR6h59dUIgllcroDKoqz7qwf1gdiSe0wLoPVkd5npLyvOLb8usLOjMoFMw==}
-=======
   to-do-pin@0.0.37:
     resolution: {integrity: sha512-y4TUmkI7RF9X7pxJmYnzp99V8/duG9kQbh0yUwqXt/r8dtOHrtpUsong9LEN0EO3gTV4jgz4Gob91m0cme2+ng==}
->>>>>>> develop
     peerDependencies:
       lucide-react: '>=0.544.0'
       react: '>=18'
@@ -13326,11 +13316,7 @@ snapshots:
       safe-buffer: 5.2.1
       typed-array-buffer: 1.0.3
 
-<<<<<<< HEAD
-  to-do-pin@0.0.33(lucide-react@0.525.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react-router-dom@7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1):
-=======
   to-do-pin@0.0.37(lucide-react@0.525.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react-router-dom@7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1):
->>>>>>> develop
     dependencies:
       lucide-react: 0.525.0(react@19.1.1)
       react: 19.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@storybook/experimental-addon-test':
         specifier: 8.6.12
         version: 8.6.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
+      '@tanstack/react-virtual':
+        specifier: ^3.13.12
+        version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@vercel/speed-insights':
         specifier: ^1.2.0
         version: 1.2.0(next@15.3.4(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
@@ -102,8 +105,8 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
       to-do-pin:
-        specifier: 0.0.30
-        version: 0.0.30(lucide-react@0.525.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react-router-dom@7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+        specifier: 0.0.33
+        version: 0.0.33(lucide-react@0.525.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react-router-dom@7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       web-vitals:
         specifier: ^5.1.0
         version: 5.1.0
@@ -2675,6 +2678,15 @@ packages:
 
   '@tailwindcss/postcss@4.1.11':
     resolution: {integrity: sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA==}
+
+  '@tanstack/react-virtual@3.13.12':
+    resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.13.12':
+    resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -6260,8 +6272,8 @@ packages:
     resolution: {integrity: sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==}
     engines: {node: '>= 0.4'}
 
-  to-do-pin@0.0.30:
-    resolution: {integrity: sha512-nJ1XGjI1Gon/7IsOl//XLm99qmBA9zUd947kRQuRJM2SycwDGnhc4FMf+eRb31Az4YxeviPmN2+K26hGwDbqiw==}
+  to-do-pin@0.0.33:
+    resolution: {integrity: sha512-d2VwSYuVP9I4yEkFXG7MV2SEEYo5gR6h59dUIgllcroDKoqz7qwf1gdiSe0wLoPVkd5npLyvOLb8usLOjMoFMw==}
     peerDependencies:
       lucide-react: '>=0.544.0'
       react: '>=18'
@@ -9395,6 +9407,14 @@ snapshots:
       '@tailwindcss/oxide': 4.1.11
       postcss: 8.5.6
       tailwindcss: 4.1.11
+
+  '@tanstack/react-virtual@3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.12
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+
+  '@tanstack/virtual-core@3.13.12': {}
 
   '@testing-library/dom@10.4.0':
     dependencies:
@@ -13296,7 +13316,7 @@ snapshots:
       safe-buffer: 5.2.1
       typed-array-buffer: 1.0.3
 
-  to-do-pin@0.0.30(lucide-react@0.525.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react-router-dom@7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1):
+  to-do-pin@0.0.33(lucide-react@0.525.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react-router-dom@7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
       lucide-react: 0.525.0(react@19.1.1)
       react: 19.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@storybook/experimental-addon-test':
         specifier: 8.6.12
         version: 8.6.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
+      '@tanstack/react-query':
+        specifier: ^5.90.2
+        version: 5.90.2(react@19.1.1)
       '@tanstack/react-virtual':
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -2678,6 +2681,14 @@ packages:
 
   '@tailwindcss/postcss@4.1.11':
     resolution: {integrity: sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA==}
+
+  '@tanstack/query-core@5.90.2':
+    resolution: {integrity: sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==}
+
+  '@tanstack/react-query@5.90.2':
+    resolution: {integrity: sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tanstack/react-virtual@3.13.12':
     resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
@@ -9407,6 +9418,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.11
       postcss: 8.5.6
       tailwindcss: 4.1.11
+
+  '@tanstack/query-core@5.90.2': {}
+
+  '@tanstack/react-query@5.90.2(react@19.1.1)':
+    dependencies:
+      '@tanstack/query-core': 5.90.2
+      react: 19.1.1
 
   '@tanstack/react-virtual@3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,13 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
       to-do-pin:
+<<<<<<< HEAD
         specifier: 0.0.33
         version: 0.0.33(lucide-react@0.525.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react-router-dom@7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+=======
+        specifier: 0.0.37
+        version: 0.0.37(lucide-react@0.525.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react-router-dom@7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+>>>>>>> develop
       web-vitals:
         specifier: ^5.1.0
         version: 5.1.0
@@ -6272,8 +6277,13 @@ packages:
     resolution: {integrity: sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==}
     engines: {node: '>= 0.4'}
 
+<<<<<<< HEAD
   to-do-pin@0.0.33:
     resolution: {integrity: sha512-d2VwSYuVP9I4yEkFXG7MV2SEEYo5gR6h59dUIgllcroDKoqz7qwf1gdiSe0wLoPVkd5npLyvOLb8usLOjMoFMw==}
+=======
+  to-do-pin@0.0.37:
+    resolution: {integrity: sha512-y4TUmkI7RF9X7pxJmYnzp99V8/duG9kQbh0yUwqXt/r8dtOHrtpUsong9LEN0EO3gTV4jgz4Gob91m0cme2+ng==}
+>>>>>>> develop
     peerDependencies:
       lucide-react: '>=0.544.0'
       react: '>=18'
@@ -13316,7 +13326,11 @@ snapshots:
       safe-buffer: 5.2.1
       typed-array-buffer: 1.0.3
 
+<<<<<<< HEAD
   to-do-pin@0.0.33(lucide-react@0.525.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react-router-dom@7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1):
+=======
+  to-do-pin@0.0.37(lucide-react@0.525.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react-router-dom@7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1):
+>>>>>>> develop
     dependencies:
       lucide-react: 0.525.0(react@19.1.1)
       react: 19.1.1

--- a/src/_providers/query-provider.tsx
+++ b/src/_providers/query-provider.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import queryClient from '../shared/lib/query-client';
+
+export default function QueryProvider({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/src/app/(main)/club/page.tsx
+++ b/src/app/(main)/club/page.tsx
@@ -1,7 +1,7 @@
 import ClubPage from '@/views/club/ui/club-page';
 import { RecruitItemListProps } from '@/widgets/recruit/model/type';
 
-export const revalidate = 800;
+export const revalidate = 1800;
 
 function Page({ searchParams }: RecruitItemListProps) {
   return <ClubPage searchParams={searchParams} />;

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -4,6 +4,7 @@ import Footer from '@/shared/ui/Footer';
 import { SessionProvider } from 'next-auth/react';
 import { ToDoPinProvider } from 'to-do-pin';
 import 'to-do-pin/index.css';
+import QueryProvider from '@/_providers/query-provider';
 
 export default function MainLayout({
   children,
@@ -14,8 +15,10 @@ export default function MainLayout({
     <div className="flex min-h-screen flex-col">
       <ToDoPinProvider>
         <SessionProvider refetchOnWindowFocus={false} refetchInterval={50 * 60}>
-          <Header />
-          <main className="flex-grow">{children}</main>
+          <QueryProvider>
+            <Header />
+            <main className="flex-grow">{children}</main>
+          </QueryProvider>
         </SessionProvider>
       </ToDoPinProvider>
       <Footer />

--- a/src/app/(main)/recruit/page.tsx
+++ b/src/app/(main)/recruit/page.tsx
@@ -1,10 +1,9 @@
 import RecruitPage from '@/views/recruit/ui/recruit-page';
-import { RecruitmentSearchParams } from '@/shared/model/recruit-type';
 
 function Page({
   searchParams,
 }: {
-  searchParams: Promise<RecruitmentSearchParams>;
+  searchParams: Promise<{ page?: string; size?: string; category?: string }>;
 }) {
   return <RecruitPage searchParams={searchParams} />;
 }

--- a/src/app/(main)/recruit/page.tsx
+++ b/src/app/(main)/recruit/page.tsx
@@ -1,8 +1,7 @@
 import RecruitPage from '@/views/recruit/ui/recruit-page';
-import { RecruitItemListProps } from '@/widgets/recruit/model/type';
 
-function Page({ searchParams }: RecruitItemListProps) {
-  return <RecruitPage searchParams={searchParams} />;
+function Page() {
+  return <RecruitPage />;
 }
 
 export default Page;

--- a/src/app/(main)/recruit/page.tsx
+++ b/src/app/(main)/recruit/page.tsx
@@ -1,9 +1,12 @@
 import RecruitPage from '@/views/recruit/ui/recruit-page';
+import { RecruitmentSearchParams } from '@/shared/model/recruit-type';
+
+export const revalidate = 1800;
 
 function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ page?: string; size?: string; category?: string }>;
+  searchParams: Promise<RecruitmentSearchParams>;
 }) {
   return <RecruitPage searchParams={searchParams} />;
 }

--- a/src/app/(main)/recruit/page.tsx
+++ b/src/app/(main)/recruit/page.tsx
@@ -1,6 +1,11 @@
 import RecruitPage from '@/views/recruit/ui/recruit-page';
+import { RecruitmentSearchParams } from '@/shared/model/recruit-type';
 
-function Page({ searchParams }: { searchParams: RecruitItemListProps }) {
+function Page({
+  searchParams,
+}: {
+  searchParams: Promise<RecruitmentSearchParams>;
+}) {
   return <RecruitPage searchParams={searchParams} />;
 }
 

--- a/src/app/(main)/recruit/page.tsx
+++ b/src/app/(main)/recruit/page.tsx
@@ -1,7 +1,7 @@
 import RecruitPage from '@/views/recruit/ui/recruit-page';
 
-function Page() {
-  return <RecruitPage />;
+function Page({ searchParams }: { searchParams: RecruitItemListProps }) {
+  return <RecruitPage searchParams={searchParams} />;
 }
 
 export default Page;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -328,7 +328,7 @@ html {
 
 /*radix bug 수정 css*/
 [data-scroll-locked][data-scroll-locked] {
-  overflow-y: scroll !important;
+  overflow: visible !important;
   padding-right: 0 !important;
   margin-right: 0 !important;
 }

--- a/src/entities/club/ui/club-detail-header.tsx
+++ b/src/entities/club/ui/club-detail-header.tsx
@@ -4,7 +4,6 @@ import RadiusTag from '@/shared/ui/radius-tag';
 import { ClubCategoryToLabel, RecruitStatus } from '@/shared/model/type';
 import Link from 'next/link';
 import ClickLogo from '@/shared/ui/click-logo';
-import { Session } from 'next-auth';
 
 interface ClubDetailHeaderProps {
   title: string;
@@ -16,7 +15,6 @@ interface ClubDetailHeaderProps {
   isFavorite?: boolean;
   logo: string;
   status: RecruitStatus;
-  session: Session | null;
 }
 
 function ClubDetailHeader({
@@ -29,7 +27,6 @@ function ClubDetailHeader({
   logo,
   isFavorite,
   status,
-  session,
 }: ClubDetailHeaderProps) {
   return (
     <>
@@ -59,7 +56,6 @@ function ClubDetailHeader({
         instagram={instagram}
         clubId={clubId}
         isFavorite={isFavorite || false}
-        session={session}
       />
     </>
   );

--- a/src/entities/club/ui/club-detail-header.tsx
+++ b/src/entities/club/ui/club-detail-header.tsx
@@ -16,7 +16,7 @@ interface ClubDetailHeaderProps {
   isFavorite?: boolean;
   logo: string;
   status: RecruitStatus;
-  session?: Session;
+  session: Session | null;
 }
 
 function ClubDetailHeader({
@@ -59,7 +59,7 @@ function ClubDetailHeader({
         instagram={instagram}
         clubId={clubId}
         isFavorite={isFavorite || false}
-        session={session || undefined}
+        session={session}
       />
     </>
   );

--- a/src/entities/club/ui/club-item-skeleton.tsx
+++ b/src/entities/club/ui/club-item-skeleton.tsx
@@ -1,6 +1,6 @@
 function ClubItemSkeleton() {
   return (
-    <div className="relative flex min-h-[90px] w-[100%] animate-pulse flex-col gap-2 rounded-lg bg-[#F8F8F8] p-3 text-[#474747] lg:min-h-[180px] lg:w-auto lg:p-5">
+    <div className="relative flex min-h-[140px] w-[100%] animate-pulse flex-col gap-2 rounded-lg bg-[#F8F8F8] p-3 text-[#474747] lg:min-h-[198px] lg:w-auto lg:p-5">
       <div className="mb-2 flex flex-row items-center justify-between lg:mb-8">
         <div className="flex flex-row items-center gap-4">
           <div className="h-12 w-12 rounded-full bg-gray-300 lg:h-14 lg:w-14" />

--- a/src/entities/club/ui/club-item.tsx
+++ b/src/entities/club/ui/club-item.tsx
@@ -11,7 +11,6 @@ interface ClubItemProps {
   logo?: string;
   category?: string;
   clubId: string;
-  session: Session | null;
 }
 
 function ClubItem({
@@ -21,10 +20,9 @@ function ClubItem({
   logo,
   category,
   clubId,
-  session,
 }: ClubItemProps) {
   return (
-    <div className="relative flex min-h-[90px] w-[100%] flex-col gap-2 rounded-lg bg-[#F8F8F8] p-3 text-[#474747] transition-shadow duration-300 hover:shadow-[0_0_20px_1px_rgba(0,0,0,0.2)] lg:min-h-[180px] lg:w-auto lg:p-5">
+    <div className="relative flex min-h-[140px] w-[100%] flex-col gap-2 rounded-lg bg-[#F8F8F8] p-3 text-[#474747] transition-shadow duration-300 hover:shadow-[0_0_20px_1px_rgba(0,0,0,0.2)] lg:min-h-[198px] lg:w-auto lg:p-5">
       <div className="mb-2 flex flex-row items-center justify-between lg:mb-8">
         <div className="flex flex-row items-center gap-4">
           <Avatar className="size-12 lg:size-14">
@@ -49,7 +47,6 @@ function ClubItem({
         isFavorite={isFavorite || false}
         clubId={clubId}
         customClass="absolute bottom-4 right-4 scale-80 lg:scale-100"
-        session={session}
       />
     </div>
   );

--- a/src/entities/club/ui/club-item.tsx
+++ b/src/entities/club/ui/club-item.tsx
@@ -11,7 +11,7 @@ interface ClubItemProps {
   logo?: string;
   category?: string;
   clubId: string;
-  session?: Session;
+  session: Session | null;
 }
 
 function ClubItem({

--- a/src/entities/error/ui/error-page.tsx
+++ b/src/entities/error/ui/error-page.tsx
@@ -25,7 +25,7 @@ export default function ErrorPage({
       <h1 className="mb-2 text-3xl font-bold text-gray-700">
         {title || defaultTitle}
       </h1>
-      <p className="mb-4 text-gray-500">{message || defaultMessage}</p>
+      <p className="mb-4 text-gray-800">{message || defaultMessage}</p>
       {showHomeButton && (
         <Link
           href="/"
@@ -34,7 +34,7 @@ export default function ErrorPage({
           홈으로 돌아가기
         </Link>
       )}
-      <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-2xl text-gray-500">
+      <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-2xl text-gray-800">
         {/* SVG 느낌표 아이콘 */}
         <svg
           width="20"

--- a/src/entities/recruit-detail/ui/recruit-detail-header.tsx
+++ b/src/entities/recruit-detail/ui/recruit-detail-header.tsx
@@ -17,7 +17,7 @@ interface RecruitDetailHeaderProps {
   createdAt: string;
   logo: string;
   status: RecruitStatus;
-  session?: Session;
+  session: Session | null;
 }
 
 function RecruitDetailHeader({

--- a/src/entities/recruit-detail/ui/recruit-detail-header.tsx
+++ b/src/entities/recruit-detail/ui/recruit-detail-header.tsx
@@ -4,7 +4,6 @@ import RecruitDetailHeaderControl from '@/features/club-detail/ui/club-detail-he
 import RadiusTag from '@/shared/ui/radius-tag';
 import { ClubCategoryToLabel, RecruitStatus } from '@/shared/model/type';
 import ClickLogo from '@/shared/ui/click-logo';
-import { Session } from 'next-auth';
 
 interface RecruitDetailHeaderProps {
   title: string;
@@ -17,7 +16,6 @@ interface RecruitDetailHeaderProps {
   createdAt: string;
   logo: string;
   status: RecruitStatus;
-  session: Session | null;
 }
 
 function RecruitDetailHeader({
@@ -31,7 +29,6 @@ function RecruitDetailHeader({
   logo,
   createdAt,
   status,
-  session,
 }: RecruitDetailHeaderProps) {
   const [date, time] = (createdAt || '').split('T');
   return (
@@ -69,7 +66,6 @@ function RecruitDetailHeader({
         instagram={instagram}
         clubId={clubId}
         isFavorite={isFavorite || false}
-        session={session}
       />
     </>
   );

--- a/src/entities/recruit/ui/recruit-item.tsx
+++ b/src/entities/recruit/ui/recruit-item.tsx
@@ -48,9 +48,9 @@ function RecruitItem({
         <RadiusTag status={status} className="lg:text-[16px]" />
       </div>
       <div className="flex flex-col justify-between gap-2">
-        <h4 className="overflow-hidden pr-7 text-[12px] font-bold break-words text-ellipsis whitespace-nowrap lg:text-xs">
+        <h2 className="overflow-hidden pr-7 text-[12px] font-bold break-words text-ellipsis whitespace-nowrap lg:text-xs">
           [{title}]
-        </h4>
+        </h2>
         <p className="overflow-hidden pr-7 text-[12px] break-words text-ellipsis whitespace-nowrap lg:text-xs">
           {description}
         </p>

--- a/src/entities/recruit/ui/recruit-item.tsx
+++ b/src/entities/recruit/ui/recruit-item.tsx
@@ -4,7 +4,6 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
 import RadiusTag from '@/shared/ui/radius-tag';
 import { RecruitStatus } from '@/shared/model/type';
 import FavoriteButton from '@/shared/ui/favorite-button';
-import { Session } from 'next-auth';
 import PeriodSection from './period-section';
 
 interface RecruitItemProps {
@@ -17,7 +16,7 @@ interface RecruitItemProps {
   logo?: string;
   clubId: string;
   status: RecruitStatus;
-  session: Session | null;
+  height?: number;
 }
 
 function RecruitItem({
@@ -30,10 +29,13 @@ function RecruitItem({
   logo,
   clubId,
   status,
-  session,
+  height = 198,
 }: RecruitItemProps) {
   return (
-    <div className="relative flex min-h-[90px] w-[100%] flex-col gap-2 rounded-lg bg-[#F8F8F8] p-3 text-[#474747] transition-shadow duration-300 hover:shadow-[0_0_20px_1px_rgba(0,0,0,0.2)] lg:min-h-[180px] lg:w-auto lg:p-5">
+    <div
+      style={{ height }}
+      className="relative flex w-[100%] flex-col gap-2 rounded-lg bg-[#F8F8F8] p-3 text-[#474747] transition-shadow duration-300 hover:shadow-[0_0_20px_1px_rgba(0,0,0,0.2)] lg:w-auto lg:p-5"
+    >
       <div className="mb-2 flex flex-row items-center justify-between lg:mb-8">
         <div className="flex flex-row items-center gap-4">
           <Avatar className="size-12 lg:size-14">
@@ -59,7 +61,6 @@ function RecruitItem({
         isFavorite={isFavorite || false}
         clubId={clubId}
         customClass="absolute bottom-4 right-4 scale-80 lg:scale-100"
-        session={session}
       />
     </div>
   );

--- a/src/entities/recruit/ui/recruit-item.tsx
+++ b/src/entities/recruit/ui/recruit-item.tsx
@@ -17,7 +17,7 @@ interface RecruitItemProps {
   logo?: string;
   clubId: string;
   status: RecruitStatus;
-  session?: Session;
+  session: Session | null;
 }
 
 function RecruitItem({

--- a/src/features/club-detail/ui/club-detail-header-control.tsx
+++ b/src/features/club-detail/ui/club-detail-header-control.tsx
@@ -8,7 +8,7 @@ interface ClubDetailHeaderControlProps {
   instagram: string;
   clubId: number;
   isFavorite: boolean;
-  session?: Session;
+  session: Session | null;
 }
 function ClubDetailHeaderControl({
   instagram,

--- a/src/features/club-detail/ui/club-detail-header-control.tsx
+++ b/src/features/club-detail/ui/club-detail-header-control.tsx
@@ -2,19 +2,16 @@
 
 import Image from 'next/image';
 import FavoriteButton from '@/shared/ui/favorite-button';
-import { Session } from 'next-auth';
 
 interface ClubDetailHeaderControlProps {
   instagram: string;
   clubId: number;
   isFavorite: boolean;
-  session: Session | null;
 }
 function ClubDetailHeaderControl({
   instagram,
   isFavorite,
   clubId,
-  session,
 }: ClubDetailHeaderControlProps) {
   return (
     <div className="mt-5 mb-5 flex w-full flex-row items-center gap-2 lg:gap-3.5">
@@ -23,7 +20,6 @@ function ClubDetailHeaderControl({
           clubId={clubId.toString()}
           isFavorite={isFavorite}
           customClass="flex items-center justify-center cursor-pointer"
-          session={session}
         />{' '}
       </div>
       <button

--- a/src/features/header/ui/header-login.tsx
+++ b/src/features/header/ui/header-login.tsx
@@ -1,15 +1,18 @@
 'use client';
 
 import Link from 'next/link';
-import { useSession, signOut } from 'next-auth/react';
+import { signOut } from 'next-auth/react';
 import { useState, useRef } from 'react';
 import { Button } from '@/shared/ui/button';
 import Image from 'next/image';
 import LoginModal from '@/widgets/login/ui/login-modal';
 import router from 'next/router';
 
-function HeaderLogin() {
-  const { data: session, status } = useSession();
+interface HeaderLoginProps {
+  userName: string;
+}
+
+function HeaderLogin({ userName }: HeaderLoginProps) {
   const [showDropdown, setShowDropdown] = useState(false);
   const [isLoginOpen, setIsLoginOpen] = useState(false);
   const hideTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -29,16 +32,14 @@ function HeaderLogin() {
 
   return (
     <span className="absolute right-[22%] rounded-sm bg-[#F4F4F4] p-2 px-4 text-xs font-light text-[#9C9C9C] lg:right-[15%] lg:text-sm">
-      {status === 'authenticated' && session?.user ? (
+      {userName ? (
         <div
           className="relative flex flex-col gap-1 font-semibold whitespace-nowrap"
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >
           <div className="flex items-center gap-2">
-            <span className="cursor-pointer font-bold">
-              {session.user.name}님!
-            </span>
+            <span className="cursor-pointer font-bold">{userName}님!</span>
             안녕하세요
           </div>
 

--- a/src/features/header/ui/header-login.tsx
+++ b/src/features/header/ui/header-login.tsx
@@ -6,7 +6,7 @@ import { useState, useRef } from 'react';
 import { Button } from '@/shared/ui/button';
 import Image from 'next/image';
 import LoginModal from '@/widgets/login/ui/login-modal';
-import router from 'next/router';
+import { useRouter } from 'next/navigation';
 
 interface HeaderLoginProps {
   userName: string;
@@ -16,6 +16,7 @@ function HeaderLogin({ userName }: HeaderLoginProps) {
   const [showDropdown, setShowDropdown] = useState(false);
   const [isLoginOpen, setIsLoginOpen] = useState(false);
   const hideTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const router = useRouter();
 
   const handleMouseEnter = () => {
     if (hideTimerRef.current) {

--- a/src/shared/api/server-api.ts
+++ b/src/shared/api/server-api.ts
@@ -2,6 +2,12 @@ import ky from 'ky';
 
 const serverApi = ky.create({
   prefixUrl: process.env.NEXT_PUBLIC_API_URL,
+  fetch: (input, init) =>
+    fetch(input, {
+      ...init,
+      cache: 'force-cache',
+      next: { revalidate: 3000 },
+    }),
 });
 
 export default serverApi;

--- a/src/shared/lib/query-client.ts
+++ b/src/shared/lib/query-client.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import { QueryClient } from '@tanstack/react-query';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+export default queryClient;

--- a/src/shared/model/recruit-type.ts
+++ b/src/shared/model/recruit-type.ts
@@ -1,7 +1,3 @@
 export interface RecruitmentSearchParams {
-  searchParams: {
-    page?: string;
-    size?: string;
-    category?: string;
-  };
+  searchParams: Promise<{ page: string; size: string; category: string }>;
 }

--- a/src/shared/model/recruit-type.ts
+++ b/src/shared/model/recruit-type.ts
@@ -1,0 +1,7 @@
+export interface RecruitmentSearchParams {
+  searchParams: {
+    page?: string;
+    size?: string;
+    category?: string;
+  };
+}

--- a/src/shared/model/recruit-type.ts
+++ b/src/shared/model/recruit-type.ts
@@ -1,3 +1,5 @@
 export interface RecruitmentSearchParams {
-  searchParams: Promise<{ page: string; size: string; category: string }>;
+  page: string;
+  size: string;
+  category: string;
 }

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -58,7 +58,7 @@ async function Header() {
             )}
         </nav>
         <div className="ml-auto flex flex-shrink-0 items-center gap-1 sm:gap-2 lg:gap-3">
-          <HeaderLogin />
+          <HeaderLogin userName={session?.user?.name || ''} />
           <HeaderSearch />
           <MoblieHeader
             sessionRole={role}

--- a/src/shared/ui/category-nav-button.tsx
+++ b/src/shared/ui/category-nav-button.tsx
@@ -44,7 +44,7 @@ function CategorySelect() {
 
   return (
     <Select value={active} onValueChange={handleChange}>
-      <SelectTrigger>
+      <SelectTrigger aria-label="카테고리 선택" className="mb-0">
         <SelectValue placeholder="전체" />
       </SelectTrigger>
       <SelectContent position="popper">

--- a/src/shared/ui/favorite-button.tsx
+++ b/src/shared/ui/favorite-button.tsx
@@ -12,7 +12,7 @@ interface FavoriteButtonProps {
   isFavorite: boolean;
   clubId: string;
   customClass?: string;
-  session?: Session;
+  session: Session | null;
 }
 
 function FavoriteButton({
@@ -27,14 +27,17 @@ function FavoriteButton({
     () =>
       throttle(async () => {
         if (!session) {
+          console.log('로그인 후 이용하실 수 있습니다.');
           toast.dismiss();
           toast.error('로그인 후 이용하실 수 있습니다.');
           return;
         }
         try {
           if (!favorite) {
+            console.log('즐겨찾기 추가');
             await postFavorite(Number(clubId));
           } else {
+            console.log('즐겨찾기 삭제');
             await deleteFavorite(Number(clubId));
           }
           setFavorite((prev) => !prev);

--- a/src/shared/ui/favorite-button.tsx
+++ b/src/shared/ui/favorite-button.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from 'react';
 import { toast } from 'react-toastify';
 import throttle from 'lodash/throttle';
-import { Session } from 'next-auth';
+import { useSession } from 'next-auth/react';
 import FavoriteThread from './favorite-thread';
 import postFavorite from '../api/post-favorite';
 import deleteFavorite from '../api/delete-favorite';
@@ -12,32 +12,27 @@ interface FavoriteButtonProps {
   isFavorite: boolean;
   clubId: string;
   customClass?: string;
-  session: Session | null;
 }
 
 function FavoriteButton({
   isFavorite,
   clubId,
   customClass,
-  session,
 }: FavoriteButtonProps) {
   const [favorite, setFavorite] = useState(isFavorite);
+  const { data: session } = useSession();
 
   const handleToggle = useMemo(
     () =>
       throttle(async () => {
         if (!session) {
-          console.log('로그인 후 이용하실 수 있습니다.');
-          toast.dismiss();
           toast.error('로그인 후 이용하실 수 있습니다.');
           return;
         }
         try {
           if (!favorite) {
-            console.log('즐겨찾기 추가');
             await postFavorite(Number(clubId));
           } else {
-            console.log('즐겨찾기 삭제');
             await deleteFavorite(Number(clubId));
           }
           setFavorite((prev) => !prev);

--- a/src/shared/ui/item-list-skeleton-loading.tsx
+++ b/src/shared/ui/item-list-skeleton-loading.tsx
@@ -7,25 +7,30 @@ interface ItemListSkeletonLoadingProps {
   title: string;
   description: string;
   size?: number;
+  header?: boolean;
 }
 
 function ItemListSkeletonLoading({
   title,
   description,
   size = 9,
+  header = false,
 }: ItemListSkeletonLoadingProps) {
   const splicedSkeletonList = SkeletonList.slice(
     0,
     Math.min(size, SkeletonList.length),
   );
   return (
-    <ul className="grid w-auto grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {splicedSkeletonList.map((item) => (
-        <li key={item} className="w-full">
-          <ClubItemSkeleton />
-        </li>
-      ))}
-    </ul>
+    <>
+      {header && <SectionHeader title={title} description={description} />}
+      <ul className="grid w-auto grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {splicedSkeletonList.map((item) => (
+          <li key={item} className="w-full">
+            <ClubItemSkeleton />
+          </li>
+        ))}
+      </ul>
+    </>
   );
 }
 

--- a/src/shared/ui/item-list-skeleton-loading.tsx
+++ b/src/shared/ui/item-list-skeleton-loading.tsx
@@ -19,16 +19,13 @@ function ItemListSkeletonLoading({
     Math.min(size, SkeletonList.length),
   );
   return (
-    <>
-      <SectionHeader title={title} description={description} />
-      <ul className="grid w-auto grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {splicedSkeletonList.map((item) => (
-          <li key={item} className="w-full">
-            <ClubItemSkeleton />
-          </li>
-        ))}
-      </ul>
-    </>
+    <ul className="grid w-auto grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {splicedSkeletonList.map((item) => (
+        <li key={item} className="w-full">
+          <ClubItemSkeleton />
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/src/shared/ui/section-header.tsx
+++ b/src/shared/ui/section-header.tsx
@@ -10,9 +10,12 @@ function SectionHeader({
   children?: ReactNode;
 }) {
   return (
-    <header className="mt-10 mb-10 w-full lg:mt-[79px] lg:mb-18" id="top">
+    <header
+      className="mt-10 mb-10 h-[164px] w-full lg:mt-[79px] lg:mb-18"
+      id="top"
+    >
       <nav className="mb-4 flex flex-row justify-between lg:mb-8">
-        <h1 className="text-md mr-2 font-extrabold text-[#00E457] lg:text-2xl">
+        <h1 className="text-md mr-2 h-[36px] font-extrabold text-[#00E457] lg:text-2xl">
           {title}
         </h1>
         {children}

--- a/src/views/club/ui/club-detail-page.tsx
+++ b/src/views/club/ui/club-detail-page.tsx
@@ -5,14 +5,12 @@ import { DetailParams } from '@/shared/model/type';
 import getParams from '@/shared/util/getParams';
 import ClubDetailHeader from '@/entities/club/ui/club-detail-header';
 import convertLinkText from '@/entities/recruit-detail/util/convetLinkText';
-import { auth } from '@/auth';
 import ErrorBoundaryUi from '@/shared/ui/error-boundary-ui';
 
 async function ClubDetailPage({ params }: DetailParams) {
   const { id } = await getParams({ params });
   const data = await getClubDetail(id);
 
-  const session = await auth();
   if (data?.status === 404 || !data.data) {
     notFound();
   }
@@ -33,7 +31,6 @@ async function ClubDetailPage({ params }: DetailParams) {
         isFavorite={data.data.isFavorite}
         logo={data.data.logo}
         status={data.data.status}
-        session={session}
       />
       {data.data.description ? (
         <p className="mb-3 text-sm leading-[1.4] whitespace-pre-wrap text-black lg:pt-10 lg:text-lg">

--- a/src/views/club/ui/club-detail-page.tsx
+++ b/src/views/club/ui/club-detail-page.tsx
@@ -33,7 +33,7 @@ async function ClubDetailPage({ params }: DetailParams) {
         isFavorite={data.data.isFavorite}
         logo={data.data.logo}
         status={data.data.status}
-        session={session || undefined}
+        session={session}
       />
       {data.data.description ? (
         <p className="mb-3 text-sm leading-[1.4] whitespace-pre-wrap text-black lg:pt-10 lg:text-lg">

--- a/src/views/club/ui/club-page.tsx
+++ b/src/views/club/ui/club-page.tsx
@@ -14,6 +14,7 @@ function ClubPage({ searchParams }: RecruitItemListProps) {
             <ItemListSkeletonLoading
               title="전체 동아리"
               description="우리 학교엔 이런 동아리들이 있어요."
+              header
             />
           }
         >

--- a/src/views/recruit/ui/recruit-detail-page.tsx
+++ b/src/views/recruit/ui/recruit-detail-page.tsx
@@ -43,7 +43,7 @@ async function RecruitDetailPage({ params }: DetailParams) {
         createdAt={data.data.createdAt}
         logo={data.data.logo}
         status={data.data.status}
-        session={session || undefined}
+        session={session}
       />
       <RecruitDetailWidget
         isManageClub={isManageClub}

--- a/src/views/recruit/ui/recruit-detail-page.tsx
+++ b/src/views/recruit/ui/recruit-detail-page.tsx
@@ -5,16 +5,14 @@ import getParams from '@/shared/util/getParams';
 import RecruitDetailHeader from '@/entities/recruit-detail/ui/recruit-detail-header';
 import RecruitDetailWidget from '@/widgets/recruit-detail/ui/recruit-detail-widget';
 import getClubManageInfo from '@/shared/api/manage-api';
-import { auth } from '@/auth';
 import ErrorBoundaryUi from '@/shared/ui/error-boundary-ui';
 
 async function RecruitDetailPage({ params }: DetailParams) {
   const { id } = await getParams({ params });
 
-  const [getClubManageInfoRes, data, session] = await Promise.all([
+  const [getClubManageInfoRes, data] = await Promise.all([
     getClubManageInfo(),
     getRecruitDetail(id),
-    auth(),
   ]);
 
   if (data?.status === 404 || !data.data) {
@@ -43,7 +41,6 @@ async function RecruitDetailPage({ params }: DetailParams) {
         createdAt={data.data.createdAt}
         logo={data.data.logo}
         status={data.data.status}
-        session={session}
       />
       <RecruitDetailWidget
         isManageClub={isManageClub}

--- a/src/views/recruit/ui/recruit-page.tsx
+++ b/src/views/recruit/ui/recruit-page.tsx
@@ -3,11 +3,12 @@ import RecruitItemList from '@/widgets/recruit/ui/recruit-item-list';
 import ScrollTopButton from '@/features/recruit/ui/scroll-top-button';
 import { Suspense } from 'react';
 import ItemListSkeletonLoading from '@/shared/ui/item-list-skeleton-loading';
+import { RecruitmentSearchParams } from '@/shared/model/recruit-type';
 
 async function RecruitPage({
   searchParams,
 }: {
-  searchParams: Promise<{ page?: string; size?: string; category?: string }>;
+  searchParams: Promise<RecruitmentSearchParams>;
 }) {
   return (
     <>

--- a/src/views/recruit/ui/recruit-page.tsx
+++ b/src/views/recruit/ui/recruit-page.tsx
@@ -1,16 +1,29 @@
 import RecruitHeader from '@/entities/recruit/ui/recruit-header';
 import RecruitItemList from '@/widgets/recruit/ui/recruit-item-list';
 import ScrollTopButton from '@/features/recruit/ui/scroll-top-button';
-import { auth } from '@/auth';
+import { RecruitItemListProps } from '@/widgets/recruit/model/type';
+import { Suspense } from 'react';
+import ItemListSkeletonLoading from '@/shared/ui/item-list-skeleton-loading';
 
-async function RecruitPage() {
-  const session = await auth();
-
+async function RecruitPage({
+  searchParams,
+}: {
+  searchParams: RecruitItemListProps;
+}) {
   return (
     <>
       <div className="w-full sm:w-4xl lg:w-6xl">
         <RecruitHeader />
-        <RecruitItemList session={session} />
+        <Suspense
+          fallback={
+            <ItemListSkeletonLoading
+              title="모집 공고"
+              description="모집 공고를 불러오는 중입니다."
+            />
+          }
+        >
+          <RecruitItemList searchParams={searchParams} />
+        </Suspense>
       </div>
       <ScrollTopButton />
     </>

--- a/src/views/recruit/ui/recruit-page.tsx
+++ b/src/views/recruit/ui/recruit-page.tsx
@@ -1,14 +1,13 @@
 import RecruitHeader from '@/entities/recruit/ui/recruit-header';
 import RecruitItemList from '@/widgets/recruit/ui/recruit-item-list';
 import ScrollTopButton from '@/features/recruit/ui/scroll-top-button';
-import { RecruitmentSearchParams } from '@/shared/model/recruit-type';
 import { Suspense } from 'react';
 import ItemListSkeletonLoading from '@/shared/ui/item-list-skeleton-loading';
 
 async function RecruitPage({
   searchParams,
 }: {
-  searchParams: Promise<RecruitmentSearchParams>;
+  searchParams: Promise<{ page?: string; size?: string; category?: string }>;
 }) {
   return (
     <>

--- a/src/views/recruit/ui/recruit-page.tsx
+++ b/src/views/recruit/ui/recruit-page.tsx
@@ -1,14 +1,14 @@
 import RecruitHeader from '@/entities/recruit/ui/recruit-header';
 import RecruitItemList from '@/widgets/recruit/ui/recruit-item-list';
 import ScrollTopButton from '@/features/recruit/ui/scroll-top-button';
-import { RecruitItemListProps } from '@/widgets/recruit/model/type';
+import { RecruitmentSearchParams } from '@/shared/model/recruit-type';
 import { Suspense } from 'react';
 import ItemListSkeletonLoading from '@/shared/ui/item-list-skeleton-loading';
 
 async function RecruitPage({
   searchParams,
 }: {
-  searchParams: RecruitItemListProps;
+  searchParams: Promise<RecruitmentSearchParams>;
 }) {
   return (
     <>

--- a/src/views/recruit/ui/recruit-page.tsx
+++ b/src/views/recruit/ui/recruit-page.tsx
@@ -1,28 +1,16 @@
 import RecruitHeader from '@/entities/recruit/ui/recruit-header';
 import RecruitItemList from '@/widgets/recruit/ui/recruit-item-list';
-import { RecruitItemListProps } from '@/widgets/recruit/model/type';
 import ScrollTopButton from '@/features/recruit/ui/scroll-top-button';
-import { Suspense } from 'react';
-import ItemListSkeletonLoading from '@/shared/ui/item-list-skeleton-loading';
+import { auth } from '@/auth';
 
-function RecruitPage({ searchParams }: RecruitItemListProps) {
+async function RecruitPage() {
+  const session = await auth();
+
   return (
     <>
       <div className="w-full sm:w-4xl lg:w-6xl">
-        <Suspense
-          fallback={
-            <ItemListSkeletonLoading
-              data-testid="skeleton"
-              title="모집 공고"
-              description={
-                '관심 있는 동아리의 최신 모집 공고를\n한눈에 확인할 수 있어요.'
-              }
-            />
-          }
-        >
-          <RecruitHeader />
-          <RecruitItemList searchParams={searchParams} />
-        </Suspense>
+        <RecruitHeader />
+        <RecruitItemList session={session} />
       </div>
       <ScrollTopButton />
     </>

--- a/src/views/recruit/ui/recruit-page.tsx
+++ b/src/views/recruit/ui/recruit-page.tsx
@@ -12,6 +12,7 @@ function RecruitPage({ searchParams }: RecruitItemListProps) {
         <Suspense
           fallback={
             <ItemListSkeletonLoading
+              data-testid="skeleton"
               title="모집 공고"
               description={
                 '관심 있는 동아리의 최신 모집 공고를\n한눈에 확인할 수 있어요.'

--- a/src/widgets/club/ui/club-item-list.tsx
+++ b/src/widgets/club/ui/club-item-list.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import ClubItem from '@/entities/club/ui/club-item';
 import getClubList from '@/widgets/recruit/api/getClubList';
 import { RecruitItemListProps } from '@/widgets/recruit/model/type';
-import { auth } from '@/auth';
 import ClubCustomErrorBoundary from './club-custom-error-boundary';
 
 async function ClubItemList({ searchParams }: RecruitItemListProps) {
@@ -14,8 +13,6 @@ async function ClubItemList({ searchParams }: RecruitItemListProps) {
     category: (await searchParams).category?.toUpperCase() as ClubCategory,
     recruitStatus: (await searchParams).recruitStatus,
   });
-
-  const session = await auth();
 
   if (!res.ok) {
     return <ClubCustomErrorBoundary />;
@@ -40,7 +37,6 @@ async function ClubItemList({ searchParams }: RecruitItemListProps) {
               isFavorite={item.isFavorite}
               logo={item.logo}
               clubId={String(item.id)}
-              session={session}
             />
           </Link>
         </li>

--- a/src/widgets/club/ui/club-item-list.tsx
+++ b/src/widgets/club/ui/club-item-list.tsx
@@ -40,7 +40,7 @@ async function ClubItemList({ searchParams }: RecruitItemListProps) {
               isFavorite={item.isFavorite}
               logo={item.logo}
               clubId={String(item.id)}
-              session={session || undefined}
+              session={session}
             />
           </Link>
         </li>

--- a/src/widgets/favorite/ui/favorite-item-section.tsx
+++ b/src/widgets/favorite/ui/favorite-item-section.tsx
@@ -48,7 +48,7 @@ async function FavoriteItemSection({ page, size }: FavoriteItemSectionProps) {
               category={item.category}
               isFavorite={item.isFavorite}
               logo={item.logo}
-              session={session || undefined}
+              session={session}
             />
           </Link>
         ))}

--- a/src/widgets/favorite/ui/favorite-item-section.tsx
+++ b/src/widgets/favorite/ui/favorite-item-section.tsx
@@ -48,7 +48,6 @@ async function FavoriteItemSection({ page, size }: FavoriteItemSectionProps) {
               category={item.category}
               isFavorite={item.isFavorite}
               logo={item.logo}
-              session={session}
             />
           </Link>
         ))}

--- a/src/widgets/recruit/api/getClubList.ts
+++ b/src/widgets/recruit/api/getClubList.ts
@@ -41,8 +41,6 @@ async function getClubList(params: GetRecruitListParams) {
       response = await serverApi
         .get('clubs', {
           searchParams,
-          cache: 'force-cache',
-          next: { revalidate: 300, tags: ['clubs'] },
         })
         .json<ApiResponse<ClubList>>();
     }

--- a/src/widgets/recruit/api/getClubRecruitClientList.ts
+++ b/src/widgets/recruit/api/getClubRecruitClientList.ts
@@ -1,0 +1,49 @@
+// src/shared/api/client/getClubRecruitList.ts
+import { ApiResponse, ClubCategory } from '@/shared/model/type';
+import ky from 'ky';
+import { RecruitmentResponse } from '@/widgets/recruit/model/type';
+import { Session } from 'next-auth';
+
+async function getClubRecruitClientList({
+  page,
+  size,
+  category,
+  session,
+}: {
+  page: number;
+  size: number;
+  category?: ClubCategory;
+  session: Session | null;
+}) {
+  const params = new URLSearchParams();
+
+  params.set('page', String(page));
+  params.set('size', String(size));
+
+  if (category) params.set('category', category);
+
+  let res;
+  if (!session?.accessToken) {
+    res = await ky.get(
+      `${process.env.NEXT_PUBLIC_API_URL}/recruitments?${params.toString()}`,
+    );
+  } else {
+    res = await ky.get(
+      `${process.env.NEXT_PUBLIC_API_URL}/recruitments?${params.toString()}`,
+      {
+        headers: {
+          Authorization: `Bearer ${session?.accessToken}`,
+        },
+      },
+    );
+  }
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch recruitments');
+  }
+
+  const data: ApiResponse<RecruitmentResponse> = await res.json();
+  return data.data;
+}
+
+export default getClubRecruitClientList;

--- a/src/widgets/recruit/api/getClubRecruitList.ts
+++ b/src/widgets/recruit/api/getClubRecruitList.ts
@@ -42,8 +42,6 @@ async function getClubRecruitList({
       response = await serverApi
         .get('recruitments', {
           searchParams,
-          cache: 'force-cache',
-          next: { revalidate: 300, tags: ['recruitments'] },
         })
         .json();
     }

--- a/src/widgets/recruit/model/useClubRecruitList.ts
+++ b/src/widgets/recruit/model/useClubRecruitList.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { ClubCategory } from '@/shared/model/type';
+import { Session } from 'next-auth';
+import getClubRecruitClientList from '../api/getClubRecruitClientList';
+
+function useClubRecruitList({
+  page,
+  size,
+  category,
+  session,
+}: {
+  page: number;
+  size: number;
+  category?: ClubCategory;
+  session: Session | null;
+}) {
+  return useSuspenseQuery({
+    queryKey: ['recruitments', page, size, category],
+    queryFn: () => getClubRecruitClientList({ page, size, category, session }),
+    staleTime: 1000 * 60 * 30,
+  });
+}
+
+export default useClubRecruitList;

--- a/src/widgets/recruit/ui/recruit-item-client-list.tsx
+++ b/src/widgets/recruit/ui/recruit-item-client-list.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useId, useMemo, useRef } from 'react';
+import { useWindowVirtualizer } from '@tanstack/react-virtual';
+import Link from 'next/link';
+import RecruitItem from '@/entities/recruit/ui/recruit-item';
+import { Session } from 'next-auth';
+
+interface RecruitItemClientListProps {
+  recruitments: any[];
+  session?: Session;
+}
+
+export default function RecruitItemClientList({
+  recruitments,
+  session,
+}: RecruitItemClientListProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const id = useId();
+
+  // ===== 레이아웃 상수 =====
+  const COLUMNS = 3 as const;
+  const CARD_HEIGHT = 150; // 카드 고정 높이(px) - 필요시 조정
+  const GAP_X = 16; // 열(가로) 간격
+  const GAP_Y = 30; // 행(세로) 간격
+  const ROW_PAD_Y = 8; // 행 상/하 패딩
+  // rowHeight = 카드높이 + 상/하 패딩 + (행 간격)
+  const ROW_HEIGHT = CARD_HEIGHT + ROW_PAD_Y * 2 + GAP_Y;
+
+  const rowCount = useMemo(
+    () => Math.ceil(recruitments.length / COLUMNS),
+    [recruitments.length],
+  );
+
+  const rowVirtualizer = useWindowVirtualizer({
+    count: rowCount,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 8,
+    scrollMargin: 0,
+  });
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        position: 'relative',
+        width: '100%',
+      }}
+    >
+      <div
+        style={{
+          height: rowVirtualizer.getTotalSize(),
+          width: '100%',
+          position: 'relative',
+        }}
+      >
+        {rowVirtualizer.getVirtualItems().map((vr) => {
+          const startIndex = vr.index * COLUMNS;
+          const rowItems = recruitments.slice(startIndex, startIndex + COLUMNS);
+
+          return (
+            <div
+              key={vr.index}
+              data-row-index={vr.index}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${vr.start}px)`,
+                display: 'grid',
+                gridTemplateColumns: `repeat(${COLUMNS}, minmax(0, 1fr))`,
+                columnGap: GAP_X,
+                rowGap: GAP_Y,
+                padding: `${ROW_PAD_Y}px 8px`,
+                boxSizing: 'border-box',
+              }}
+            >
+              {rowItems.map((item) => (
+                <Link
+                  key={item.id}
+                  href={`/recruit/${item.id}`}
+                  style={{ display: 'block', height: CARD_HEIGHT }}
+                >
+                  <div style={{ height: '100%' }}>
+                    <RecruitItem
+                      title={item.title}
+                      name={item.club.name || ''}
+                      startDate={item.recruitStart}
+                      endDate={item.recruitEnd}
+                      description={item.club.description}
+                      isFavorite={item.isFavorite}
+                      logo={item.club.logo}
+                      clubId={String(item.club.id)}
+                      status={item.status}
+                      session={session}
+                    />
+                  </div>
+                </Link>
+              ))}
+
+              {/* 마지막 행 채우기(3개 미만일 때 높이 유지) */}
+              {rowItems.length < COLUMNS &&
+                Array.from({ length: COLUMNS - rowItems.length }).map(() => (
+                  <div
+                    key={`${id}-${vr.index}`}
+                    style={{ height: CARD_HEIGHT }}
+                  />
+                ))}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/widgets/recruit/ui/recruit-item-client-list.tsx
+++ b/src/widgets/recruit/ui/recruit-item-client-list.tsx
@@ -1,24 +1,20 @@
 'use client';
 
-import {
-  useId,
-  useMemo,
-  useRef,
-  useState,
-  useEffect,
-  useLayoutEffect,
-} from 'react';
+import { useId, useMemo, useRef, useState, useLayoutEffect } from 'react';
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import Link from 'next/link';
 import RecruitItem from '@/entities/recruit/ui/recruit-item';
+import { Session } from 'next-auth';
 import { Recruitment } from '../model/type';
 
 interface RecruitItemClientListProps {
   recruitments: Recruitment[];
+  session?: Session | nu;
 }
 
 export default function RecruitItemClientList({
   recruitments,
+  session,
 }: RecruitItemClientListProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const id = useId();
@@ -110,6 +106,7 @@ export default function RecruitItemClientList({
                       logo={item.club.logo}
                       clubId={String(item.club.id)}
                       status={item.status}
+                      session={session}
                     />
                   </div>
                 </Link>

--- a/src/widgets/recruit/ui/recruit-item-client-list.tsx
+++ b/src/widgets/recruit/ui/recruit-item-client-list.tsx
@@ -9,7 +9,7 @@ import { Recruitment } from '../model/type';
 
 interface RecruitItemClientListProps {
   recruitments: Recruitment[];
-  session?: Session | nu;
+  session: Session | null;
 }
 
 export default function RecruitItemClientList({

--- a/src/widgets/recruit/ui/recruit-item-client-list.tsx
+++ b/src/widgets/recruit/ui/recruit-item-client-list.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { useId, useMemo, useRef, useState, useEffect } from 'react';
+import {
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  useEffect,
+  useLayoutEffect,
+} from 'react';
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import Link from 'next/link';
 import RecruitItem from '@/entities/recruit/ui/recruit-item';
@@ -20,7 +27,7 @@ export default function RecruitItemClientList({
   const [columns, setColumns] = useState(3);
   const [cardHeight, setCardHeight] = useState(160);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     function handleResize() {
       if (window.innerWidth < 640) {
         setColumns(1); // 모바일 (sm 미만)

--- a/src/widgets/recruit/ui/recruit-item-client-list.tsx
+++ b/src/widgets/recruit/ui/recruit-item-client-list.tsx
@@ -1,124 +1,105 @@
 'use client';
 
-import { useId, useMemo, useRef, useState, useLayoutEffect } from 'react';
+import { useId, useRef, useState, useEffect } from 'react';
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import Link from 'next/link';
 import RecruitItem from '@/entities/recruit/ui/recruit-item';
-import { Session } from 'next-auth';
 import { Recruitment } from '../model/type';
 
 interface RecruitItemClientListProps {
   recruitments: Recruitment[];
-  session: Session | null;
+  initialColumns?: number;
+  initialCardHeight?: number;
+}
+
+function getColumnsAndHeight(width: number) {
+  if (width < 640) return { columns: 1, cardHeight: 140 };
+  if (width < 1024) return { columns: 2, cardHeight: 140 };
+  return { columns: 3, cardHeight: 198 };
 }
 
 export default function RecruitItemClientList({
   recruitments,
-  session,
+  initialColumns = 3,
+  initialCardHeight = 198,
 }: RecruitItemClientListProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const id = useId();
 
-  // ===== 반응형 컬럼 계산 =====
-  const [columns, setColumns] = useState(3);
-  const [cardHeight, setCardHeight] = useState(160);
+  const [columns, setColumns] = useState(initialColumns);
+  const [cardHeight, setCardHeight] = useState(initialCardHeight);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     function handleResize() {
-      if (window.innerWidth < 640) {
-        setColumns(1); // 모바일 (sm 미만)
-        setCardHeight(120);
-      } else if (window.innerWidth < 1024) {
-        setColumns(2); // 태블릿 (md~lg)
-        setCardHeight(120);
-      } else {
-        setColumns(3); // 데스크탑
-        setCardHeight(160);
-      }
+      const { columns: newColumns, cardHeight: newHeight } =
+        getColumnsAndHeight(window.innerWidth);
+      setColumns(newColumns);
+      setCardHeight(newHeight);
     }
+
     handleResize();
+
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  const GAP_X = 16;
-  const GAP_Y = 30;
-  const ROW_PAD_Y = 8;
-  const ROW_HEIGHT = cardHeight + ROW_PAD_Y * 2 + GAP_Y;
-
-  const rowCount = useMemo(
-    () => Math.ceil((recruitments?.length ?? 0) / columns),
-    [recruitments, columns],
-  );
+  const GAP_Y = 20;
+  const rowCount = Math.ceil((recruitments?.length ?? 0) / columns);
 
   const rowVirtualizer = useWindowVirtualizer({
     count: rowCount,
-    estimateSize: () => ROW_HEIGHT,
-    overscan: 8,
+    estimateSize: () => cardHeight + GAP_Y,
+    overscan: 6,
     scrollMargin: 0,
   });
 
   return (
-    <div ref={containerRef} className="relative w-full">
-      <div
-        style={{
-          height: rowVirtualizer.getTotalSize(),
-          width: '100%',
-          position: 'relative',
-        }}
-      >
-        {rowVirtualizer.getVirtualItems().map((vr) => {
-          const startIndex = vr.index * columns;
-          const rowItems = recruitments.slice(startIndex, startIndex + columns);
+    <div
+      ref={containerRef}
+      className="relative w-full"
+      style={{
+        height: rowVirtualizer.getTotalSize(),
+      }}
+    >
+      {rowVirtualizer.getVirtualItems().map((vr) => {
+        const startIndex = vr.index * columns;
+        const rowItems = recruitments.slice(startIndex, startIndex + columns);
 
-          return (
-            <div
-              key={vr.index}
-              data-row-index={vr.index}
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                width: '100%',
-                transform: `translateY(${vr.start}px)`,
-                display: 'grid',
-                gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
-                columnGap: GAP_X,
-                rowGap: GAP_Y,
-                padding: `${ROW_PAD_Y}px 8px`,
-                boxSizing: 'border-box',
-              }}
-            >
-              {rowItems.map((item) => (
-                <Link
-                  key={item.id}
-                  href={`/recruit/${item.id}`}
-                  style={{ display: 'block', height: cardHeight }}
-                >
-                  <div style={{ height: '100%' }}>
-                    <RecruitItem
-                      title={item.title}
-                      name={item.club.name || ''}
-                      startDate={item.recruitStart}
-                      endDate={item.recruitEnd}
-                      description={item.club.description}
-                      isFavorite={item.isFavorite}
-                      logo={item.club.logo}
-                      clubId={String(item.club.id)}
-                      status={item.status}
-                      session={session}
-                    />
-                  </div>
-                </Link>
+        return (
+          <div
+            key={vr.index}
+            data-row-index={vr.index}
+            className="absolute top-0 left-0 box-border grid w-full"
+            style={{
+              transform: `translateY(${vr.start}px)`,
+              gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+              marginBottom: `${GAP_Y}px`,
+              columnGap: '20px',
+            }}
+          >
+            {rowItems.map((item) => (
+              <Link key={item.id} href={`/recruit/${item.id}`}>
+                <RecruitItem
+                  title={item.title}
+                  name={item.club.name || ''}
+                  startDate={item.recruitStart}
+                  endDate={item.recruitEnd}
+                  description={item.club.description}
+                  isFavorite={item.isFavorite}
+                  logo={item.club.logo}
+                  clubId={String(item.club.id)}
+                  status={item.status}
+                  height={cardHeight}
+                />
+              </Link>
+            ))}
+            {rowItems.length < columns &&
+              Array.from({ length: columns - rowItems.length }).map(() => (
+                <div key={id} style={{ height: `${cardHeight}px` }} />
               ))}
-              {rowItems.length < columns &&
-                Array.from({ length: columns - rowItems.length }).map(() => (
-                  <div key={id} style={{ height: cardHeight }} />
-                ))}
-            </div>
-          );
-        })}
-      </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/widgets/recruit/ui/recruit-item-list.tsx
+++ b/src/widgets/recruit/ui/recruit-item-list.tsx
@@ -1,19 +1,20 @@
 import { ClubCategory } from '@/shared/model/type';
 import ErrorBoundaryUi from '@/shared/ui/error-boundary-ui';
 import { auth } from '@/auth';
-import { RecruitmentSearchParams } from '@/shared/model/recruit-type';
 import RecruitItemClientList from './recruit-item-client-list';
 import getClubRecruitList from '../api/getClubRecruitList';
 
 async function RecruitItemList({
   searchParams,
 }: {
-  searchParams: Promise<RecruitmentSearchParams>;
+  searchParams: Promise<{ page?: string; size?: string; category?: string }>;
 }) {
+  const params = await searchParams;
+
   const res = await getClubRecruitList({
-    page: Number((await searchParams).page || 1),
-    size: Number((await searchParams).size || 1000),
-    category: (await searchParams).category?.toUpperCase() as ClubCategory,
+    page: Number(params.page || 1),
+    size: Number(params.size || 1000),
+    category: params.category?.toUpperCase() as ClubCategory,
   });
   const session = await auth();
 

--- a/src/widgets/recruit/ui/recruit-item-list.tsx
+++ b/src/widgets/recruit/ui/recruit-item-list.tsx
@@ -1,17 +1,23 @@
 import { ClubCategory } from '@/shared/model/type';
 import ErrorBoundaryUi from '@/shared/ui/error-boundary-ui';
-
+import { auth } from '@/auth';
+import { RecruitmentSearchParams } from '@/shared/model/recruit-type';
 import RecruitItemClientList from './recruit-item-client-list';
 import getClubRecruitList from '../api/getClubRecruitList';
 
-async function RecruitItemList({ searchParams }: { searchParams: any }) {
+async function RecruitItemList({
+  searchParams,
+}: {
+  searchParams: Promise<RecruitmentSearchParams>;
+}) {
   const res = await getClubRecruitList({
     page: Number((await searchParams).page || 1),
     size: Number((await searchParams).size || 1000),
     category: (await searchParams).category?.toUpperCase() as ClubCategory,
   });
+  const session = await auth();
 
-  if (!res.ok) {
+  if (!res.ok || !res.data) {
     return <ErrorBoundaryUi />;
   }
 
@@ -23,7 +29,12 @@ async function RecruitItemList({ searchParams }: { searchParams: any }) {
     );
   }
 
-  return <RecruitItemClientList recruitments={res.data?.recruitments} />;
+  return (
+    <RecruitItemClientList
+      recruitments={res.data?.recruitments}
+      session={session}
+    />
+  );
 }
 
 export default RecruitItemList;

--- a/src/widgets/recruit/ui/recruit-item-list.tsx
+++ b/src/widgets/recruit/ui/recruit-item-list.tsx
@@ -1,28 +1,21 @@
-'use client';
-
 import { ClubCategory } from '@/shared/model/type';
 import ErrorBoundaryUi from '@/shared/ui/error-boundary-ui';
-import { Suspense } from 'react';
-import ItemListSkeletonLoading from '@/shared/ui/item-list-skeleton-loading';
-import { useSearchParams } from 'next/navigation';
-import { Session } from 'next-auth';
-import RecruitItemClientList from './recruit-item-client-list';
-import useClubRecruitList from '../model/useClubRecruitList';
 
-function RecruitItemList({ session }: { session: Session | null }) {
-  const params = useSearchParams();
-  const { data } = useClubRecruitList({
-    page: Number(params.get('page') || 1),
-    size: Number(params.get('size') || 1000),
-    category: params.get('category')?.toUpperCase() as ClubCategory,
-    session,
+import RecruitItemClientList from './recruit-item-client-list';
+import getClubRecruitList from '../api/getClubRecruitList';
+
+async function RecruitItemList({ searchParams }: { searchParams: any }) {
+  const res = await getClubRecruitList({
+    page: Number((await searchParams).page || 1),
+    size: Number((await searchParams).size || 1000),
+    category: (await searchParams).category?.toUpperCase() as ClubCategory,
   });
 
-  if (!data) {
+  if (!res.ok) {
     return <ErrorBoundaryUi />;
   }
 
-  if (data?.recruitments.length === 0) {
+  if (res.data?.recruitments.length === 0) {
     return (
       <p className="mt-30 w-full text-center text-sm font-bold text-[#00E457]">
         모집 공고가 없습니다.
@@ -30,18 +23,7 @@ function RecruitItemList({ session }: { session: Session | null }) {
     );
   }
 
-  return (
-    <Suspense
-      fallback={
-        <ItemListSkeletonLoading
-          title="모집 공고"
-          description="모집 공고를 불러오는 중입니다."
-        />
-      }
-    >
-      <RecruitItemClientList recruitments={data?.recruitments} />
-    </Suspense>
-  );
+  return <RecruitItemClientList recruitments={res.data?.recruitments} />;
 }
 
 export default RecruitItemList;

--- a/tests/e2e/manual.spec.ts
+++ b/tests/e2e/manual.spec.ts
@@ -1,6 +1,0 @@
-import { test } from '@playwright/test';
-
-test('Safari 브라우저 열기', async ({ page }) => {
-  await page.goto('/'); // baseURL에 설정된 3000으로 이동
-  await page.pause(); // 🔥 여기서 멈추고 내가 직접 조작 가능
-});

--- a/tests/e2e/recruit.spec.ts
+++ b/tests/e2e/recruit.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test('recruit page skeleton vs loaded', async ({ page }) => {
+  await page.goto('http://localhost:3000/');
+
+  // "모집 공고" 클릭 → recruit 페이지 이동
+  await page
+    .getByRole('navigation')
+    .getByRole('link', { name: '모집 공고' })
+    .click();
+
+  // 스켈레톤이 보일 때 스냅샷
+  await page.waitForSelector('[data-testid="skeleton"]'); // ← 스켈레톤에 testid 달아두면 편함
+  expect(await page.screenshot()).toMatchSnapshot('recruit-skeleton.png');
+  // 스켈레톤이 사라질 때까지 대기
+  await page.waitForSelector('[data-testid="skeleton"]', { state: 'detached' });
+
+  // 실제 컨텐츠가 보일 때 스냅샷
+  await page.waitForSelector('[data-testid="recruit-card"]');
+  expect(await page.screenshot()).toMatchSnapshot('recruit-loaded.png');
+});

--- a/tests/storybook/visual.test.ts
+++ b/tests/storybook/visual.test.ts
@@ -1,31 +1,31 @@
-import fs from 'fs';
-import path from 'path';
-import { test, expect } from '@playwright/test';
+// import fs from 'fs';
+// import path from 'path';
+// import { test, expect } from '@playwright/test';
 
-// Storybook build 결과물 경로
-const indexPath = path.join(__dirname, '../storybook-static/index.json');
-const data = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+// // Storybook build 결과물 경로
+// const indexPath = path.join(__dirname, '../storybook-static/index.json');
+// const data = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
 
-type StoryEntry = {
-  id: string;
-  title: string;
-  name: string;
-  importPath: string;
-};
+// type StoryEntry = {
+//   id: string;
+//   title: string;
+//   name: string;
+//   importPath: string;
+// };
 
-// docs 제외
-const stories: StoryEntry[] = (
-  Object.values(data.entries) as StoryEntry[]
-).filter(
-  (story) =>
-    !story.id.includes('--docs') && !story.importPath.includes('/docs/'),
-);
+// // docs 제외
+// const stories: StoryEntry[] = (
+//   Object.values(data.entries) as StoryEntry[]
+// ).filter(
+//   (story) =>
+//     !story.id.includes('--docs') && !story.importPath.includes('/docs/'),
+// );
 
-// eslint-disable-next-line no-restricted-syntax
-for (const story of stories) {
-  test(`${story.title}/${story.name} looks correct`, async ({ page }) => {
-    await page.goto(`http://localhost:6006/iframe.html?id=${story.id}`);
-    const root = page.locator('body');
-    expect(await root.screenshot()).toMatchSnapshot(`${story.id}.png`);
-  });
-}
+// // eslint-disable-next-line no-restricted-syntax
+// for (const story of stories) {
+//   test(`${story.title}/${story.name} looks correct`, async ({ page }) => {
+//     await page.goto(`http://localhost:6006/iframe.html?id=${story.id}`);
+//     const root = page.locator('body');
+//     expect(await root.screenshot()).toMatchSnapshot(`${story.id}.png`);
+//   });
+// }


### PR DESCRIPTION
## #️⃣연관된 이슈

feat: 가상 윈도우를 통한 dom 랜더 개선

## 📝작업 내용

1. 가상 윈도우를 통해 dom의 개수를 줄였습니다.
2. 캐싱시간을 30분으로 늘렸습니다. (next.config에서 캐싱 확인 설정 추가)
3. 리스트 아이템의 크기를 수정했습니다. css 세부 조정

### 스크린샷 (선택)
최종 스펙
<img width="1995" height="1291" alt="스크린샷 2025-10-03 224239" src="https://github.com/user-attachments/assets/0bd09c48-94f8-4d15-853d-4b356172e70c" />

개선 전 측정 결과
<img width="1374" height="1372" alt="스크린샷 2025-10-01 181315" src="https://github.com/user-attachments/assets/5a1eb4b8-acd5-4a4b-af76-ad2e1a2aa418" />


## 💬리뷰 요구사항(선택)

리액트 쿼리 도입 하기전에 브랜치를 따로 파서 실행해 보고 비교해 본 결과 
리액트 쿼리의 코드 복잡성만 늘고 성능에 큰 차이가 없어 도입하지 않았습니다. 또한 다음의 글을 참고했습니다.
https://velog.io/@cnsrn1874/you-might-not-need-react-query


