### PR TITLE
hotfix: 카테고리 검색 오류 수정

### DIFF
--- a/src/shared/model/type.ts
+++ b/src/shared/model/type.ts
@@ -49,6 +49,11 @@ export interface FavoriteList {
   pagination: Pagination;
 }
 
+export interface ClubSearchResponse {
+  clubs: ClubType[];
+  pagination: Pagination;
+}
+
 export const ClubCategoryLabel: Record<ClubCategory, string> = {
   [ClubCategory.CULTURAL_ART]: '문화/예술🎨',
   [ClubCategory.ACADEMIC_CULTURAL]: '학술/교양📚',

--- a/src/widgets/search/api/searchClubs.ts
+++ b/src/widgets/search/api/searchClubs.ts
@@ -1,9 +1,16 @@
-import { ApiResponse, ClubList } from '@/shared/model/type';
+import {
+  ClubCategory,
+  ClubAffiliation,
+  ClubSearchResponse,
+} from '@/shared/model/type';
 import serverApi from '@/shared/api/server-api';
 import ErrorHandler from '@/shared/lib/error-message';
 
 interface SearchClubsParams {
-  keyword: string;
+  keyword?: string;
+  category?: ClubCategory;
+  affiliation?: ClubAffiliation;
+  recruitStatus?: string;
   page?: number;
   size?: number;
 }
@@ -11,21 +18,26 @@ interface SearchClubsParams {
 async function searchClubs(params: SearchClubsParams) {
   const searchParams = new URLSearchParams();
 
-  searchParams.set('keyword', params.keyword);
+  searchParams.set('keyword', params.keyword || '');
+  searchParams.set('category', params.category || '');
+  searchParams.set('affiliation', params.affiliation || '');
+  searchParams.set('recruitStatus', params.recruitStatus || '');
   searchParams.set('page', String(params.page || 1));
   searchParams.set('size', String(params.size || 10));
 
   try {
-    const response: ApiResponse<ClubList> = await serverApi
-      .get('clubs', {
+    const response = await serverApi
+      .get('clubs/search', {
         searchParams,
+        next: { tags: ['clubs-search'] },
       })
-      .json();
+      .json<{ data: ClubSearchResponse }>();
 
     return {
-      clubs: response.data?.clubs || [],
-      status: response.status,
       ok: true,
+      message: '성공',
+      data: response.data,
+      status: 200,
     };
   } catch (e) {
     return ErrorHandler(e as Error);


### PR DESCRIPTION
## #️⃣연관된 이슈

#389 

## 📝작업 내용

- 카테고리 검색 클릭 시 오류가 나는 문제 수정 
-> 이는 enum 문제가 있었던 거라 관련해서 수정했습니다.

- 검색 기능에서 뜨는 리스트 중 클릭 시 오류가 뜨는 문제 수정
-> 이는 검색 결과 리스트는 /clubs API를 통해 조회하는 반면에 클릭해서 들어가지는 상세페이지는 /recruitments API에서 데이터를 조회하고 있어 모집공고가 없는 동아리에 대해서는 클릭했을때 오류가 뜨고 있는 것 같습니다.
-> 해당 사항은 카톡으로도 얘기를 했던 부분이고 현재는 검색결과에서 모집공고 없는 동아리를 제거하여 띄우도록 임시로 수정해둔 상태입니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

* 카톡에 이미 작성한 내용인데 한번 더 여쭤봅니다 !

위에서 언급한 문제에 대해서 이를 해결하기 위해 검색 결과 리스트를 /recruitments API를 기준으로 통일하고자했습니다. 이렇게 하게되면 검색결과 리스트에 모집공고가 존재하는 동아리만 노출되기 때문에 클릭 시 오류가 발생하는 문제를 방지할 수 있을 것 같습니다.

현재는 /recruitments에는 keyword 검색 파라미터가 없는데 백엔드에서 /recruitments API 에도 검색 가능하도록 keyword parmas를 추가해주시면 이 문제가 해결 될 것 같은데 이에 대해 어떻게 생각하시나요?
