### PR TITLE
[#398] chore: 배포 방식 변경 (SCP -> GHCR) 및 메모리 부족 이슈 해결

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -42,23 +42,39 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build Docker image
+      - name: Set lower case owner name
         run: |
-          docker build \
-            --build-arg NODE_ENV=production \
-            -t ${{ env.DOCKER_IMAGE_NAME }}:${{ inputs.env }} \
-            -t ${{ env.DOCKER_IMAGE_NAME }}:${{ inputs.env }}-${{ github.sha }} \
-            .
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
 
-      - name: Save Docker image
-        run: docker save ${{ env.DOCKER_IMAGE_NAME }}:${{ inputs.env }} | gzip > mokkoji-fe-next-${{ inputs.env }}.tar.gz
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          build-args: |
+            NODE_ENV=production
+          tags: |
+            ghcr.io/${{ env.OWNER_LC }}/mokkoji-fe-next:${{ inputs.env }}
+            ghcr.io/${{ env.OWNER_LC }}/mokkoji-fe-next:${{ inputs.env }}-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Prepare deployment files
         run: |
@@ -67,13 +83,12 @@ jobs:
           cp -r nginx deploy_files/
           rm -rf deploy_files/nginx/active
           cp -r scripts deploy_files/
-          cp mokkoji-fe-next-${{ inputs.env }}.tar.gz deploy_files/
 
       - name: Create .env file
         run: |
           cat > deploy_files/.env << EOF
-          DOCKER_IMAGE_PROD=${{ env.DOCKER_IMAGE_NAME }}:prod
-          DOCKER_IMAGE_DEV=${{ env.DOCKER_IMAGE_NAME }}:dev
+          DOCKER_IMAGE_PROD=ghcr.io/${{ env.OWNER_LC }}/mokkoji-fe-next:prod
+          DOCKER_IMAGE_DEV=ghcr.io/${{ env.OWNER_LC }}/mokkoji-fe-next:dev
           NEXT_PUBLIC_API_URL_PROD=${{ secrets.NEXT_PUBLIC_API_URL_PROD }}
           NEXT_PUBLIC_API_URL_DEV=${{ secrets.NEXT_PUBLIC_API_URL_DEV }}
           NEXT_PUBLIC_S3_DOMAIN_PROD=${{ secrets.NEXT_PUBLIC_S3_DOMAIN_PROD }}
@@ -112,28 +127,32 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
-          envs: APP_DIR
-          script: |
-            set -e
-            cd "$APP_DIR"
+          envs: APP_DIR, GITHUB_TOKEN
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          set -e
+          cd "$APP_DIR"
 
-            echo "Loading Docker image"
-            docker load < mokkoji-fe-next-${{ inputs.env }}.tar.gz
-            rm mokkoji-fe-next-${{ inputs.env }}.tar.gz
+          echo "Logging into GHCR..."
+          echo $GITHUB_TOKEN | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-            echo "Ensuring Nginx is running"
-            if ! docker ps --filter "name=mokkoji-nginx" --filter "status=running" | grep -q mokkoji-nginx; then
-              echo "Starting Nginx container"
-              docker-compose up -d nginx
-              sleep 5
-            fi
+          echo "Pulling latest images..."
+          docker-compose pull
 
-            echo "Running Blue-Green deployment"
-            chmod +x scripts/deploy-${{ inputs.env }}.sh
-            bash scripts/deploy-${{ inputs.env }}.sh
+          echo "Ensuring Nginx is running"
+          if ! docker ps --filter "name=mokkoji-nginx" --filter "status=running" | grep -q mokkoji-nginx; then
+            echo "Starting Nginx container"
+            docker-compose up -d nginx
+            sleep 5
+          fi
 
-            echo "Cleaning up old images"
-            docker image prune -af
+          echo "Running Blue-Green deployment"
+          chmod +x scripts/deploy-${{ inputs.env }}.sh
+          bash scripts/deploy-${{ inputs.env }}.sh
+
+          echo "Cleaning up old images"
+          docker image prune -af
 
       - name: Verify deployment
         uses: appleboy/ssh-action@v1.0.3
@@ -160,4 +179,3 @@ jobs:
         if: always()
         run: |
           rm -rf deploy_files
-          rm -f mokkoji-fe-next-${{ inputs.env }}.tar.gz


### PR DESCRIPTION
## #️⃣연관된 이슈

[#398 ] 빌드 시 서버 다운 및 502 에러 발생

## 📝작업 내용

EC2 프리티어 환경에서 배포 빌드 시 발생하던 메모리 부족(OOM) 현상 및 502 Bad Gateway 에러를 해결하기 위해, 기존의 이미지 전송 방식(SCP)을 GitHub Container Registry(GHCR) 기반의 Pull 방식으로 전환하였습니다.

기존에는 `docker save`로 빌드 파일은 압축하여 `.tar.gz`의 형태로 EC2에 전송하였습니다(SCP). 이 과정을 통해 저희가 생성해둔 인스턴스에서는 해당 파일을 저장하고 `docker load`(압축 해제)를 하면서 사용중인 프로세스의 메모리를 상당량 필요로 하게 됩니다. 이 과정에서 할당해둔 메모리의 한계 값을 넘어가게 되면, OS가 시스템 유지를 위해 가장 많이 쓰는 프로세스(현 상황에서는 dev 서버였습니다)를 죽이게 됩니다.
즉, 메모리를 늘리거나 재배포 시에 임시로 가용할 수 있는 자원을 빌려오거나 다른 방법을 채택해야했습니다.
근본적으로 해결하기 위해서 무거운 파일(.tar.gz)를 넘기지 않고, github actions에서 `docker push`를 이용해 GHCR 저장소에 보관한 뒤, EC2에서는 `docker pull`을 통해 변경된 레이어만 효율적으로 다운로드 할 수 있도록 설정하였습니다.

추가적으로 해당 프로젝트 레포지토리의 관리 권한이 없어 `GITHUB_TOKEN`을 사용해 패키지 저장소에 접근할 수 있도록 권한을 부여하였습니다.
Docker 이미지 명명 규칙을 위해 Repository Owner 이름(저의 경우 ChangwooJ => changwooj)을 소문자로 처리하는 Step 추가하였습니다.

## 💬리뷰 요구사항(선택)

해당 방법 외에 더 효과적인 방법이 있다면 공유부탁드리겠습니다!!
