### PR TITLE
chore: 워크플로우 호출 권한 수정

### DIFF
--- a/.github/workflows/deploy-dev-docker.yml
+++ b/.github/workflows/deploy-dev-docker.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   deploy-docker:
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/deploy-docker.yml
     with:
       env: dev

--- a/.github/workflows/deploy-prod-docker.yml
+++ b/.github/workflows/deploy-prod-docker.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   deploy-docker:
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/deploy-docker.yml
     with:
       env: prod


### PR DESCRIPTION
## #️⃣연관된 이슈

[#398] chore: 워크플로우 호출 권한 수정

## 📝작업 내용

재사용 가능한 워크플로우(여기서는 deploy-prod/dev-docker.yml 입니다) 호출 시, 상위 파일에서 하위 파일로 권한이 자동 상속되지 않는 문제를 발견했습니다.

호출하는 메인 워크플로우(deploy-dev-docker.yml)에 permissions: packages: write 설정을 명시적으로 추가하여 GHCR에 안전하게 이미지를 푸시할 수 있도록 보안 설정을 강화했습니다.
