### PR TITLE
chore: docker Buildx 설정 추가 및 빌드 캐시 에러 수정

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Set lower case owner name
         run: |
           echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}


### PR DESCRIPTION
## #️⃣연관된 이슈

[#398] chore: docker Buildx 설정 추가 및 빌드 캐시 에러 수정

## 📝작업 내용

`docker/build-push-action`에서 type=gha 캐시 옵션을 사용하려 했으나, 이를 지원하는 Buildx 빌더(docker-container 드라이버)가 구성되지 않아 빌드가 실패하는 문제를 확인했습니다.

이를 해결하기 위해 `setup-buildx-action` 단계를 추가하여 GitHub Actions의 캐시 기능을 정상적으로 이용할 수 있도록 빌드 환경을 개선했습니다.


