### PR TITLE
fix: 운영 서버 프로세스 종료 이슈 수정

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -11,6 +11,7 @@ import UserInfoType from './entities/my/model/type';
 
 // TODO: 추후 루시아로 변경
 export const { auth, handlers, signIn, signOut } = NextAuth({
+  debug: process.env.NODE_ENV === 'development',
   secret: process.env.NEXTAUTH_SECRET,
   session: {
     maxAge: 60 * 60 * 24 * 3,
@@ -53,7 +54,10 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
             user: userData.data.user,
           };
         } catch (error) {
-          console.error('[authorize error]', error);
+          console.error(
+            '[authorize error]',
+            error instanceof Error ? error.message : 'Unknown error',
+          );
           return null;
         }
       },
@@ -103,7 +107,10 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
             role: rolesData.data.role,
           };
         } catch (error) {
-          console.error('[role fetch error]', error);
+          console.error(
+            '[role fetch error]',
+            error instanceof Error ? error.message : 'Unknown error',
+          );
           return {
             accessToken: user.accessToken,
             refreshToken: user.refreshToken,
@@ -131,7 +138,10 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
             expiresAt: getTokenExpiration(data.data.accessToken),
           };
         } catch (error) {
-          console.error('[refresh error]', error);
+          console.error(
+            '[refresh error]',
+            error instanceof Error ? error.message : 'Unknown error',
+          );
           return null;
         }
       }


### PR DESCRIPTION
## #️⃣연관된 이슈

[#411 ] fix: 운영 서버 프로세스 종료 이슈 수정

## 📝작업 내용

<img width="1567" height="124" alt="image" src="https://github.com/user-attachments/assets/9e8adead-4f51-4eb8-bc30-8f4a846bd9e6" />

문제상황은 다음과 같습니다.

1. `unhealthy` 상태의 컨테이너가 존재함.
2. CREATED시점과 STATUS의 시점이 다름 ⇒ 재시작 이슈

<img width="1770" height="113" alt="image" src="https://github.com/user-attachments/assets/e0eedc4e-44a3-4177-b31c-75d8b5898f18" />

이번 이슈에서 문제가 되었던 prod 서버의 컨테이너를 살펴보면(`docker inspect`),

`FailingStreak`  : 2384 ⇒ 헬스체크 2384번 실패
`Output`  : wget: can't connect to remote host: Connection refused ⇒ 연결 거부

두가지 주요 문제점이 확인되었습니다. 이러한 상황을 일으킨 원인을 찾고자 해당 컨테이너의 로그를 자세히 살펴보면,
<img width="994" height="413" alt="image" src="https://github.com/user-attachments/assets/2b31ec6f-b9de-4880-9633-82d7bddbe927" />
<img width="970" height="103" alt="image" src="https://github.com/user-attachments/assets/a3a1b1e5-3ae0-47b5-9fde-2401e620194c" />

1. [auth][error] JWTSessionError: Read more… ⇒ 리프레쉬 토큰 검증 과정에서 에러 발생
2. [auth][cause]: RangeError: Maximum call stack size exceeded ⇒ 에러 내용을 로깅하려는데, token의 자기 자신을 순환 참조하는 구조로 인해 무한 재귀 발생
3. FATAL ERROR: Ineffective mark-compacts… ⇒ 메모리 부족 다운(OOM)

이렇게 총 세가지 에러사항을 확인할 수 있었습니다.

### 서버가 다운되었던 과정

1. 로그인 토큰 관련 에러가 발생하면서 해당 에러에 대한 로그를 남기려고 함.
2. 로그로 남기려는 객체(token)에 자기 참조가 존재해 순환 구조가 생성됨.
3. 무한 루프에 빠진 에러 로그를 객체화하며 메모리를 순식간에 잡아먹음.
4. 메모리 초과로 Node.js 프로세스 다운
5. docker daemon이 지속적으로 헬스 체크를 하다가 이 순간 연결 거부 응답을 받음.
6. 설정된 임계치를 넘어서는 순간 해당 컨테이너를 삭제하고 재시작.

### 시도한 해결법

NextAuth의 debug 모드가 프로덕션에서도 켜져 있어서, 토큰 에러 발생 시 내부적으로 순환 참조 객체를 로깅하려다 OOM 발생했다고 파악되어,
```javascript
debug: process.env.NODE_ENV === 'development',
```
해당 옵션을 수정하였습니다.
배포 환경에서는 토큰 에러가 발생해도 NextAuth가 내부 로깅을 시도하지 않으므로 순환 참조 문제가 발생하지 않고, 메모리 초과가 발생하지 않을 것으로 예상됩니다.
