### PR TITLE
hotfix: 중복 코드 삭제

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,16 +72,6 @@ export default function RootLayout({
             {children}
           </ToDoPinProvider>
         </SessionProvider>
-
-        <Script id="clarity" strategy="afterInteractive">
-          {`
-    (function(c,l,a,r,i,t,y){
-        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-    })(window, document, "clarity", "script", "syrzmy8y1c");
-  `}
-        </Script>
       </body>
     </html>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

#473 

## 📝작업 내용

clarity 연동 코드가 없는 줄 알고 새로 코드를 추가했는데 배포 후 보니 충돌이 난다고 하여 코드를 뒤저보니까 기존에 존재하는 것 발견했습니다.
그로인해 중복으로 추가 한 코드 삭제 진행했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
