### PR TITLE
refactor: 상세페이지 스타일링 수정

### DIFF
--- a/src/entities/club-detail/ui/club-detail-tabs.tsx
+++ b/src/entities/club-detail/ui/club-detail-tabs.tsx
@@ -94,7 +94,7 @@ function ClubDetailTabs({
   };
 
   return (
-    <div className="mt-8 lg:mt-16">
+    <div className="mt-8 lg:mt-12">
       <div className="mb-8 flex justify-center border-b border-b-[#D6D6D6] pb-3 lg:mb-12">
         {TABS.map((tab) => {
           const isSelected = tab.key === activeTab;

--- a/src/entities/club-detail/ui/recruit-detail-header.tsx
+++ b/src/entities/club-detail/ui/recruit-detail-header.tsx
@@ -43,7 +43,7 @@ function RecruitDetailHeader({
 
   return (
     <header className="w-full cursor-default">
-      <div className="mb-4 flex flex-row items-center gap-3.5 lg:mb-8 lg:gap-4">
+      <div className="flex flex-row items-center gap-3.5 lg:mb-5 lg:gap-4">
         <ClickLogo logo={logo} title={title} />
         <div className="flex min-w-0 items-center gap-2">
           <h1 className="text-2xl font-bold whitespace-nowrap lg:text-4xl">
@@ -59,14 +59,14 @@ function RecruitDetailHeader({
       <div className="flex flex-col items-start gap-7 lg:flex-row lg:items-center lg:text-xl">
         <RadiusTag
           recruitStatus={status}
-          className="shrink-0 px-3 py-2 text-xs whitespace-nowrap lg:px-4 lg:py-3 lg:text-[14px]"
+          className="shrink-0 px-3 py-2 text-xs whitespace-nowrap lg:px-4 lg:py-2.5 lg:text-[14px]"
         />
-        <div className="flex flex-col gap-1 lg:gap-2">
+        <div className="flex flex-col">
           <PeriodSection
             startDate={startDate}
             endDate={endDate}
             decoration={false}
-            className="text-sm whitespace-nowrap lg:text-lg"
+            className="mt-1 text-sm whitespace-nowrap lg:text-lg"
             isAlwaysRecruiting={isAlwaysRecruiting}
           />
           <div className="mr-auto shrink-0">

--- a/src/entities/club-detail/ui/recruit-detail-view.tsx
+++ b/src/entities/club-detail/ui/recruit-detail-view.tsx
@@ -66,7 +66,7 @@ function RecruitDetailView({
       {!isRecentRecruitment && (
         <button
           onClick={goLatest}
-          className="text-primary-500 border-primary-500 -mt-5 mb-10 ml-auto flex cursor-pointer items-center gap-3 border-b text-sm"
+          className="border-primary-500 -mt-5 mb-10 ml-auto flex cursor-pointer items-center gap-3 border-b text-sm text-[#22CF64]"
         >
           <Image src="/detail/speaker.svg" alt="알림" width={16} height={16} />
           <span>최신 모집 공고 바로가기</span>

--- a/src/features/club-detail/ui/navigate-recruit-form.tsx
+++ b/src/features/club-detail/ui/navigate-recruit-form.tsx
@@ -24,7 +24,7 @@ function NavigateRecruitForm({
       className={cn(
         'mb-21 flex h-[120px] w-[120px] scale-60 flex-col items-center justify-center gap-1.5 rounded-full text-[17px] lg:mb-0 lg:scale-100',
         isDisabled
-          ? 'cursor-not-allowed bg-[#AAF9C8] text-white'
+          ? 'cursor-not-allowed bg-[#D8F6E3] text-white'
           : 'cursor-pointer bg-gradient-to-r from-[#4AF38A] to-[#32E2D0] text-black transition hover:brightness-105',
       )}
     >

--- a/src/views/club/ui/club-detail-page.tsx
+++ b/src/views/club/ui/club-detail-page.tsx
@@ -41,7 +41,7 @@ async function ClubDetailPage({ params, searchParams }: ClubDetailPageProps) {
   const selected = await getRecruitDetail(recruitmentId);
 
   return (
-    <div className="mt-5 w-full px-5 lg:mt-[50px] lg:w-[60%] lg:max-w-[60%] lg:min-w-[60%]">
+    <div className="mt-5 w-full px-5 lg:mt-[35px] lg:w-[60%] lg:max-w-[60%] lg:min-w-[60%]">
       <RecruitDetailHeader
         title={recent.data.clubName}
         category={recent.data.category}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #479 

## 📝작업 내용

> 최신 모집공고 바로가기 링크 색상 수정
> 동아리 지원하기 버튼 disabled 시 색상 수정
> 동아리 헤더 gap 수정

### 스크린샷 (선택)
기존
<img width="1454" height="801" alt="image" src="https://github.com/user-attachments/assets/79440a52-e50f-41fb-84cb-b30cf3a7e4b5" />
수정 후
<img width="1454" height="801" alt="image" src="https://github.com/user-attachments/assets/a77eac11-85a0-446f-a760-8e47e788d09f" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
