### PR TITLE
[no-issue] fix: seo 및 성능 개선

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,4 +3,4 @@ Disallow: /search
 Disallow: /club-register
 Disallow: /post-recruitment
 
-Sitemap: https://www.mokkoji.site/sitemap.xml
+Sitemap: https://mokkoji.site/sitemap.xml

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,6 +26,23 @@ export const metadata: Metadata = {
   openGraph: {
     title: '모꼬지 | 세종대 동아리',
     description: '세종대 동아리 통합 플랫폼',
+    siteName: '모꼬지',
+    locale: 'ko_KR',
+    type: 'website',
+    images: [
+      {
+        url: '/mokkojiBanner.png',
+        width: 1200,
+        height: 630,
+        alt: '모꼬지 - 세종대 동아리 통합 플랫폼',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: '모꼬지 | 세종대 동아리',
+    description: '세종대 동아리 통합 플랫폼',
+    images: ['/mokkojiBanner.png'],
   },
   other: {
     'naver-site-verification': '150a4435ae2108c4b46284bb245f020da60c9069',
@@ -42,7 +59,7 @@ export default function RootLayout({
       <head>
         <Script
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2782954397492984"
-          strategy="beforeInteractive"
+          strategy="lazyOnload"
           crossOrigin="anonymous"
         />
         <Script

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,7 +3,7 @@ import { ApiResponse } from '@/shared/model/type';
 import { ClubsResponse } from '@/widgets/club/model/type';
 import serverApi from '@/shared/api/server-api';
 
-const BASE_URL = 'https://www.mokkoji.site';
+const BASE_URL = 'https://mokkoji.site';
 
 async function getAllClubIds(): Promise<number[]> {
   try {

--- a/src/shared/api/server-api.ts
+++ b/src/shared/api/server-api.ts
@@ -2,11 +2,6 @@ import ky from 'ky';
 
 const serverApi = ky.create({
   prefixUrl: process.env.NEXT_PUBLIC_API_URL,
-  fetch: (input, init) =>
-    fetch(input, {
-      ...init,
-      cache: 'no-store',
-    }),
 });
 
 export default serverApi;


### PR DESCRIPTION
## Summary
- sitemap/robots URL을 metadataBase와 통일하여 검색엔진 혼동 방지
- serverApi 전역 cache: 'no-store' 제거로 Next.js 캐시 활용
- AdSense beforeInteractive → lazyOnload로 LCP 개선
- Twitter 카드 및 OG 메타데이터 보강

## Test plan
- [ ] /sitemap.xml 접근 확인
- [ ] OG 미리보기 확인 (카카오톡/트위터 공유)
- [ ] 페이지 로딩 속도 확인
- [ ] API 캐싱 정상 동작 확인


Made with [Cursor](https://cursor.com)