### PR TITLE
hotfix: 댓글 탭에서 발생하는 로그인모달 클로즈 이슈 수정

### DIFF
--- a/src/features/header/ui/header-login.tsx
+++ b/src/features/header/ui/header-login.tsx
@@ -28,7 +28,7 @@ function HeaderLogin({ userName }: HeaderLoginProps) {
   const handleSignOut = async () => {
     await fetch('/api/auth/logout', { method: 'POST' });
     router.push('/');
-    router.refresh();
+    window.location.reload();
   };
 
   return (

--- a/src/features/login/ui/login-form.tsx
+++ b/src/features/login/ui/login-form.tsx
@@ -59,7 +59,7 @@ function LoginForm({ confirmed, setOpen }: LoginFormProps) {
         toast.error('학번 또는 비밀번호를 확인해주세요.');
         return;
       }
-      router.refresh();
+      window.location.reload();
     } catch {
       toast.error('로그인 중 오류가 발생했습니다.');
     } finally {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #488 

## 📝작업 내용

### 문제

헤더에 있는 로그인 버튼을 통해 로그인을 진행한 후에는 로그인 모달이 닫히는 반면 상세페이지의 댓글 탭에서 '로그인하기'버튼을 통해 로그인을 진행한 경우에는 로그인 모달이 닫히지 않는 문제가 있었습니다.

혜빈님께서 `handle`함수 어딘가에 `setOpen(false)`가 빠져있는 것 같다고 말했었지만 확인을 해보니 해당 코드의 부재는 아니었음을 확인했고 또한 페이지를 새로고침을 하면 모달이 닫히는 것을 확인했습니다. 그로인해 로그인여부의 업로드에서 문제가 있다는 생각을 하게 되었습니다.

### 원인
두가지의 코드를 보니 로그인모달 코드를 완전히 같은 파일을 사용하는데 다른 점은
헤더는 서버 컴포넌트로써 여기서 `getSession()`을 통해 쿠키 세션을 다시 읽는다면
댓글 탭은 클라이언트 컴포넌트로써 `const { data: session } = useSession();`을 통해서 클라이언트 상태로 로그인 여부를 받아오고 있었습니다.

이때 로그인, 로그아웃 코드에서 `reoute.refresh()`를 호출하고 있었는데 이 경우 서버 컴포넌트는 다시 렌더링되지만 클라이언트 상태(`useSession()`)는 즉시 갱신되지 않습니다.

따라서 로그인 상태가 변경되더라도 댓글 탭에서는 로그인 여부가 반영되지 않아
로그인 모달이 닫히지 않는 문제가 발생했습니다.

### 해결


결론적으로는 서버 세션도 다시 읽고 useSession()도 처음부터 다시 읽도록 `window.location.reload()`으로 수정하여 해결하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
