### PR TITLE
[no-issue] refactor: 로그인 모달을 전역 Context + Portal로 전환

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,8 @@ import ClarityProvider from '@/_providers/clarity-provider';
 import Script from 'next/script';
 import { ToDoPinProvider } from 'to-do-pin';
 import { AppSessionProvider } from '@/shared/lib/session-context';
+import { LoginModalProvider } from '@/shared/lib/login-modal-context';
+import GlobalLoginModal from '@/widgets/login/ui/global-login-modal';
 import { ToastContainer } from 'react-toastify';
 
 const pretendard = localFont({
@@ -78,18 +80,21 @@ export default function RootLayout({
       </head>
       <body className={`${pretendard.className} scrollbar-hide`}>
         <AppSessionProvider>
-          <ToDoPinProvider>
-            <WebVitalProvider />
-            <ToastContainer
-              autoClose={2000}
-              hideProgressBar
-              closeOnClick
-              pauseOnHover={false}
-              newestOnTop
-              limit={1}
-            />
-            {children}
-          </ToDoPinProvider>
+          <LoginModalProvider>
+            <ToDoPinProvider>
+              <WebVitalProvider />
+              <ToastContainer
+                autoClose={2000}
+                hideProgressBar
+                closeOnClick
+                pauseOnHover={false}
+                newestOnTop
+                limit={1}
+              />
+              {children}
+            </ToDoPinProvider>
+            <GlobalLoginModal />
+          </LoginModalProvider>
         </AppSessionProvider>
       </body>
     </html>

--- a/src/features/club-detail/ui/club-detail-comment-input.tsx
+++ b/src/features/club-detail/ui/club-detail-comment-input.tsx
@@ -5,7 +5,7 @@ import { toast } from 'react-toastify';
 import { useSession } from '@/shared/lib/session-context';
 import { Button } from '@/shared/ui/button';
 import Textarea from '@/shared/ui/textarea';
-import LoginModal from '@/widgets/login/ui/login-modal';
+import { useLoginModal } from '@/shared/lib/login-modal-context';
 import { postComment } from '../api/postComment';
 import StarRating from './rating-component';
 
@@ -22,7 +22,7 @@ function ClubDetailCommentInput({
   const [rating, setRating] = useState(0);
   const { data: session } = useSession();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { openLoginModal } = useLoginModal();
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value);
@@ -57,15 +57,11 @@ function ClubDetailCommentInput({
           <p className="text-sm font-bold">로그인이 필요한 서비스에요!</p>
           <button
             type="button"
-            onClick={() => setIsModalOpen(true)}
+            onClick={openLoginModal}
             className="cursor-pointer font-semibold text-[#00E457] underline"
           >
             로그인하기
           </button>
-          <LoginModal
-            open={isModalOpen}
-            onClose={() => setIsModalOpen(false)}
-          />
         </div>
       </div>
     );

--- a/src/features/header/ui/header-login.tsx
+++ b/src/features/header/ui/header-login.tsx
@@ -4,8 +4,8 @@ import Link from 'next/link';
 import { useState, useRef } from 'react';
 import { Button } from '@/shared/ui/button';
 import Image from 'next/image';
-import LoginModal from '@/widgets/login/ui/login-modal';
 import useClickOutside from '@/shared/model/useClickOutside';
+import { useLoginModal } from '@/shared/lib/login-modal-context';
 import {
   ChevronIcon,
   UserIcon,
@@ -18,7 +18,7 @@ interface HeaderLoginProps {
 
 function HeaderLogin({ userName }: HeaderLoginProps) {
   const [showDropdown, setShowDropdown] = useState(false);
-  const [isLoginOpen, setIsLoginOpen] = useState(false);
+  const { openLoginModal } = useLoginModal();
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   useClickOutside(dropdownRef, () => setShowDropdown(false));
@@ -72,15 +72,11 @@ function HeaderLogin({ userName }: HeaderLoginProps) {
       ) : (
         <div className="flex gap-2 whitespace-nowrap">
           <button
-            onClick={() => setIsLoginOpen(true)}
+            onClick={openLoginModal}
             className="cursor-pointer whitespace-nowrap"
           >
             로그인
           </button>
-          <LoginModal
-            open={isLoginOpen}
-            onClose={() => setIsLoginOpen(false)}
-          />
         </div>
       )}
     </span>

--- a/src/features/login/ui/login-form.tsx
+++ b/src/features/login/ui/login-form.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 import Input from '@/shared/ui/input';
 import { Eye, EyeOff } from 'lucide-react';
 import DotsPulseLoader from '@/shared/ui/DotsPulseLoader';
+import { useLoginModal } from '@/shared/lib/login-modal-context';
 
 interface LoginFormProps {
   confirmed: boolean;
@@ -15,6 +16,7 @@ interface LoginFormProps {
 
 function LoginForm({ confirmed, setOpen }: LoginFormProps) {
   const router = useRouter();
+  const { closeLoginModal } = useLoginModal();
   const [studentId, setStudentId] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
@@ -59,7 +61,8 @@ function LoginForm({ confirmed, setOpen }: LoginFormProps) {
         toast.error('학번 또는 비밀번호를 확인해주세요.');
         return;
       }
-      window.location.reload();
+      closeLoginModal();
+      router.refresh();
     } catch {
       toast.error('로그인 중 오류가 발생했습니다.');
     } finally {

--- a/src/shared/lib/login-modal-context.tsx
+++ b/src/shared/lib/login-modal-context.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+interface LoginModalContextValue {
+  isOpen: boolean;
+  openLoginModal: () => void;
+  closeLoginModal: () => void;
+}
+
+const LoginModalContext = createContext<LoginModalContextValue>({
+  isOpen: false,
+  openLoginModal: () => {},
+  closeLoginModal: () => {},
+});
+
+export function LoginModalProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openLoginModal = useCallback(() => setIsOpen(true), []);
+  const closeLoginModal = useCallback(() => setIsOpen(false), []);
+
+  const value = useMemo(
+    () => ({ isOpen, openLoginModal, closeLoginModal }),
+    [isOpen, openLoginModal, closeLoginModal],
+  );
+
+  return (
+    <LoginModalContext.Provider value={value}>
+      {children}
+    </LoginModalContext.Provider>
+  );
+}
+
+export function useLoginModal() {
+  return useContext(LoginModalContext);
+}

--- a/src/widgets/login/ui/global-login-modal.tsx
+++ b/src/widgets/login/ui/global-login-modal.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { createPortal } from 'react-dom';
+import { useLoginModal } from '@/shared/lib/login-modal-context';
+import LoginModal from './login-modal';
+
+function GlobalLoginModal() {
+  const { isOpen, closeLoginModal } = useLoginModal();
+
+  if (typeof window === 'undefined') return null;
+
+  return createPortal(
+    <LoginModal open={isOpen} onClose={closeLoginModal} />,
+    document.body,
+  );
+}
+
+export default GlobalLoginModal;

--- a/src/widgets/login/ui/login-required.tsx
+++ b/src/widgets/login/ui/login-required.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useState } from 'react';
-import LoginModal from '@/widgets/login/ui/login-modal';
+import { useLoginModal } from '@/shared/lib/login-modal-context';
 
 function LoginRequired() {
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { openLoginModal } = useLoginModal();
 
   return (
     <div className="flex h-full min-h-[50vh] flex-col items-center justify-center gap-[10px]">
@@ -13,12 +12,11 @@ function LoginRequired() {
       </h1>
       <button
         type="button"
-        onClick={() => setIsModalOpen(true)}
+        onClick={openLoginModal}
         className="font-semibold text-[#00E457] underline"
       >
         로그인하기
       </button>
-      <LoginModal open={isModalOpen} onClose={() => setIsModalOpen(false)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 로그인 모달을 각 사용처의 로컬 useState에서 전역 Context + Portal 방식으로 전환
- `useLoginModal()` 훅으로 어디서든 모달 열기/닫기 가능
- 로그인 성공 시 `closeLoginModal()` + `router.refresh()`로 모달 닫기 및 서버 컴포넌트 갱신

## 변경 파일
- `shared/lib/login-modal-context.tsx` — LoginModalProvider, useLoginModal 훅 (신규)
- `widgets/login/ui/global-login-modal.tsx` — Portal로 body에 모달 렌더링 (신규)
- `app/layout.tsx` — Provider + GlobalLoginModal 추가
- `features/login/ui/login-form.tsx` — 로그인 성공 시 closeLoginModal 호출
- `features/header/ui/header-login.tsx` — 로컬 상태 제거, openLoginModal 사용
- `features/club-detail/ui/club-detail-comment-input.tsx` — 로컬 상태 제거, openLoginModal 사용
- `widgets/login/ui/login-required.tsx` — 로컬 상태 제거, openLoginModal 사용

## Test plan
- [ ] 헤더 로그인 버튼 → 모달 열림 확인
- [ ] 댓글 영역 로그인하기 → 모달 열림 확인
- [ ] 로그인 성공 → 모달 닫힘 + 페이지 갱신 확인
- [ ] 로그인 실패 → 모달 유지 + 에러 토스트 확인
- [ ] 모달 외부 클릭 → 모달 닫힘 확인


Made with [Cursor](https://cursor.com)