### PR TITLE
[no-issue] refactor: boolean 변수 has 접두사를 is로 통일

### DIFF
--- a/.cursor/rules/naming-convention.mdc
+++ b/.cursor/rules/naming-convention.mdc
@@ -7,3 +7,4 @@ alwaysApply: true
 - 변수, 함수, 컴포넌트, 파일 이름은 항상 이 프로젝트 도메인에 맞는 직관적인 이름으로 짓는다.
 - 약어나 한 글자 변수를 지양하고, 역할과 의도가 이름만으로 파악되도록 한다.
 - 도메인 용어(동아리, 모집 공고, 즐겨찾기 등)에 대응하는 영문 네이밍을 일관되게 사용한다 (예: club, recruitment, favorite).
+- Boolean 변수/prop은 반드시 `is` 접두사를 사용한다 (`has`, `should`, `can` 등 사용 금지). 예: `isVisible`, `isFavorite`, `isDecorated`, `isHalfStar`.

--- a/src/entities/club-detail/ui/club-detail-header.tsx
+++ b/src/entities/club-detail/ui/club-detail-header.tsx
@@ -46,7 +46,7 @@ function ClubDetailHeader({
         <PeriodSection
           startDate={startDate}
           endDate={endDate}
-          hasDecoration={false}
+          isDecorated={false}
           className="lg:text-lg"
           isAlwaysRecruiting={isAlwaysRecruiting}
         />

--- a/src/entities/club-detail/ui/period-section.tsx
+++ b/src/entities/club-detail/ui/period-section.tsx
@@ -4,7 +4,7 @@ import cn from '@/shared/lib/utils';
 interface PeriodSectionProps {
   startDate?: string;
   endDate?: string;
-  hasDecoration?: boolean;
+  isDecorated?: boolean;
   className?: string;
   isAlwaysRecruiting: boolean;
 }
@@ -12,12 +12,12 @@ interface PeriodSectionProps {
 function PeriodSection({
   startDate,
   endDate,
-  hasDecoration = true,
+  isDecorated = true,
   className,
   isAlwaysRecruiting,
 }: PeriodSectionProps) {
-  const hasDate = startDate && endDate;
-  if (!hasDate) {
+  const isDateAvailable = startDate && endDate;
+  if (!isDateAvailable) {
     return <span className="block min-h-[1lh] text-xs" />;
   }
 
@@ -25,7 +25,7 @@ function PeriodSection({
     <span className={cn(`text-xs leading-none ${className}`)}>상시모집</span>
   ) : (
     <span className={cn(`text-xs leading-none ${className}`)}>
-      {hasDecoration ? (
+      {isDecorated ? (
         <span className="text-[#8B95A1]">
           모집기한 · {formatDateDotted(startDate!)}~{formatDateDotted(endDate!)}
         </span>

--- a/src/entities/club-detail/ui/recruit-detail-header.tsx
+++ b/src/entities/club-detail/ui/recruit-detail-header.tsx
@@ -65,7 +65,7 @@ function RecruitDetailHeader({
           <PeriodSection
             startDate={startDate}
             endDate={endDate}
-            hasDecoration={false}
+            isDecorated={false}
             className="mt-1 text-sm whitespace-nowrap lg:text-lg"
             isAlwaysRecruiting={isAlwaysRecruiting}
           />

--- a/src/entities/club-detail/ui/recruit-detail-view.tsx
+++ b/src/entities/club-detail/ui/recruit-detail-view.tsx
@@ -42,13 +42,13 @@ function RecruitDetailView({
     setCurrentIndex((prev) => (prev + 1) % imageUrls.length);
   };
 
-  const hasRecruitContent =
+  const isRecruitContentAvailable =
     Boolean(title?.trim()) ||
     Boolean(content?.trim()) ||
     Boolean(recruitForm?.trim()) ||
     imageUrls.length > 0;
 
-  if (!hasRecruitContent) {
+  if (!isRecruitContentAvailable) {
     return (
       <p className="py-30 text-center text-gray-500">
         동아리 모집 기간이 아닙니다.

--- a/src/entities/club-detail/ui/review-star.tsx
+++ b/src/entities/club-detail/ui/review-star.tsx
@@ -6,8 +6,8 @@ interface StarRatingProps {
 
 function StarRating({ rate }: StarRatingProps) {
   const fullStars = Math.floor(rate);
-  const hasHalfStar = rate - fullStars >= 0.5;
-  const emptyStars = 5 - fullStars - (hasHalfStar ? 1 : 0);
+  const isHalfStar = rate - fullStars >= 0.5;
+  const emptyStars = 5 - fullStars - (isHalfStar ? 1 : 0);
 
   return (
     <div className="flex flex-1 gap-1">
@@ -22,7 +22,7 @@ function StarRating({ rate }: StarRatingProps) {
             height={14}
           />
         ))}
-      {hasHalfStar && (
+      {isHalfStar && (
         <Image
           src="/detail/comment/starHalf.svg"
           alt="반 별"

--- a/src/shared/ui/calendar/calendar-body.tsx
+++ b/src/shared/ui/calendar/calendar-body.tsx
@@ -187,8 +187,8 @@ function CalendarBody({
         endTime={endTime}
         onStartTimeChange={onStartTimeChange}
         onEndTimeChange={onEndTimeChange}
-        hasStartDate={!!startDate}
-        hasEndDate={!!endDate}
+        isStartDateSelected={!!startDate}
+        isEndDateSelected={!!endDate}
         variant={variant}
       />
       <button

--- a/src/shared/ui/calendar/time-picker.tsx
+++ b/src/shared/ui/calendar/time-picker.tsx
@@ -23,8 +23,8 @@ interface TimePickerProps {
     minute: number;
     second: number;
   }) => void;
-  hasStartDate: boolean;
-  hasEndDate: boolean;
+  isStartDateSelected: boolean;
+  isEndDateSelected: boolean;
   variant?: 'dark' | 'light';
 }
 
@@ -35,8 +35,8 @@ function TimePicker({
   endTime,
   onStartTimeChange,
   onEndTimeChange,
-  hasStartDate,
-  hasEndDate,
+  isStartDateSelected,
+  isEndDateSelected,
   variant = 'light',
 }: TimePickerProps) {
   const hours = Array.from({ length: 24 }, (_, i) => i);
@@ -46,14 +46,14 @@ function TimePicker({
   const timeConfigs = [
     {
       label: '시작 시간',
-      show: hasStartDate,
+      show: isStartDateSelected,
       time: startTime,
       onChange: onStartTimeChange,
       defaults: { hour: 0, minute: 0, second: 0 },
     },
     {
       label: '마감 시간',
-      show: hasEndDate,
+      show: isEndDateSelected,
       time: endTime,
       onChange: onEndTimeChange,
       defaults: { hour: 23, minute: 59, second: 59 },


### PR DESCRIPTION
## Summary
- Boolean 변수/prop의 `has` 접두사를 `is`로 통일 (8파일, 21줄)
- `naming-convention.mdc` 규칙에 Boolean은 `is` 접두사만 사용하도록 명시

## 변경 내용
| 변경 전 | 변경 후 | 파일 |
|---------|---------|------|
| `hasDecoration` | `isDecorated` | period-section, club-detail-header, recruit-detail-header |
| `hasHalfStar` | `isHalfStar` | review-star |
| `hasRecruitContent` | `isRecruitContentAvailable` | recruit-detail-view |
| `hasStartDate/hasEndDate` | `isStartDateSelected/isEndDateSelected` | time-picker, calendar-body |
| `hasDate` | `isDateAvailable` | period-section |

## Test plan
- [x] `pnpm build` 성공 확인 (이전 PR #493에서 검증)
- [x] prettier + eslint pre-commit hook 통과


Made with [Cursor](https://cursor.com)