### PR TITLE
[no-issue] fix: 즐겨찾기 상태가 새로고침 후 유지되지 않는 버그 수정

### DIFF
--- a/.cursor/rules/naming-convention.mdc
+++ b/.cursor/rules/naming-convention.mdc
@@ -7,3 +7,4 @@ alwaysApply: true
 - 변수, 함수, 컴포넌트, 파일 이름은 항상 이 프로젝트 도메인에 맞는 직관적인 이름으로 짓는다.
 - 약어나 한 글자 변수를 지양하고, 역할과 의도가 이름만으로 파악되도록 한다.
 - 도메인 용어(동아리, 모집 공고, 즐겨찾기 등)에 대응하는 영문 네이밍을 일관되게 사용한다 (예: club, recruitment, favorite).
+- Boolean 변수/prop은 반드시 `is` 접두사를 사용한다 (`has`, `should`, `can` 등 사용 금지). 예: `isVisible`, `isFavorite`, `isDecorated`, `isHalfStar`.

--- a/src/entities/club-detail/api/getClubDetail.ts
+++ b/src/entities/club-detail/api/getClubDetail.ts
@@ -1,14 +1,22 @@
 import createErrorResponse from '@/shared/lib/error-message';
 import { ApiResponse } from '@/shared/model/type';
-import { ClubDetail } from '@/entities/club-detail/model/type';
+import {
+  ClubDetailRaw,
+  mapClubDetail,
+} from '@/entities/club-detail/model/type';
 import api from '@/shared/api/auth-api';
 
 async function getClubDetail(id: number) {
   try {
-    const response: ApiResponse<ClubDetail> = await api
+    const response: ApiResponse<ClubDetailRaw> = await api
       .get(`clubs/${id}`)
       .json();
-    return { ok: true, data: response.data, status: 200 };
+    if (!response.data) return { ok: false, message: '데이터 없음' };
+    return {
+      ok: true,
+      data: mapClubDetail(response.data),
+      status: 200,
+    };
   } catch (e) {
     return createErrorResponse(e as Error);
   }

--- a/src/entities/club-detail/model/type.ts
+++ b/src/entities/club-detail/model/type.ts
@@ -15,6 +15,10 @@ export interface ClubDetail {
   status: RecruitStatus;
 }
 
+export interface ClubDetailRaw extends Omit<ClubDetail, 'isFavorite'> {
+  favorite: boolean;
+}
+
 export interface ClubDetailData {
   data: ClubDetail;
 }
@@ -36,6 +40,11 @@ export interface RecruitmentDetail {
   clubName: string;
   logo: string;
   isAlwaysRecruiting: boolean;
+}
+
+export interface RecruitmentDetailRaw
+  extends Omit<RecruitmentDetail, 'isFavorite'> {
+  favorite: boolean;
 }
 
 export interface RecruitmentDetailResponse {
@@ -65,4 +74,18 @@ export interface ClubComment {
   isModified: boolean;
   time: string;
   isWriter: boolean;
+}
+
+export function mapRecruitmentDetail({
+  favorite,
+  ...rest
+}: RecruitmentDetailRaw): RecruitmentDetail {
+  return { ...rest, isFavorite: favorite };
+}
+
+export function mapClubDetail({
+  favorite,
+  ...rest
+}: ClubDetailRaw): ClubDetail {
+  return { ...rest, isFavorite: favorite };
 }

--- a/src/entities/club-detail/ui/club-detail-header.tsx
+++ b/src/entities/club-detail/ui/club-detail-header.tsx
@@ -46,7 +46,7 @@ function ClubDetailHeader({
         <PeriodSection
           startDate={startDate}
           endDate={endDate}
-          hasDecoration={false}
+          isDecorated={false}
           className="lg:text-lg"
           isAlwaysRecruiting={isAlwaysRecruiting}
         />

--- a/src/entities/club-detail/ui/period-section.tsx
+++ b/src/entities/club-detail/ui/period-section.tsx
@@ -4,7 +4,7 @@ import cn from '@/shared/lib/utils';
 interface PeriodSectionProps {
   startDate?: string;
   endDate?: string;
-  hasDecoration?: boolean;
+  isDecorated?: boolean;
   className?: string;
   isAlwaysRecruiting: boolean;
 }
@@ -12,12 +12,12 @@ interface PeriodSectionProps {
 function PeriodSection({
   startDate,
   endDate,
-  hasDecoration = true,
+  isDecorated = true,
   className,
   isAlwaysRecruiting,
 }: PeriodSectionProps) {
-  const hasDate = startDate && endDate;
-  if (!hasDate) {
+  const isDateAvailable = startDate && endDate;
+  if (!isDateAvailable) {
     return <span className="block min-h-[1lh] text-xs" />;
   }
 
@@ -25,7 +25,7 @@ function PeriodSection({
     <span className={cn(`text-xs leading-none ${className}`)}>상시모집</span>
   ) : (
     <span className={cn(`text-xs leading-none ${className}`)}>
-      {hasDecoration ? (
+      {isDecorated ? (
         <span className="text-[#8B95A1]">
           모집기한 · {formatDateDotted(startDate!)}~{formatDateDotted(endDate!)}
         </span>

--- a/src/entities/club-detail/ui/recruit-detail-header.tsx
+++ b/src/entities/club-detail/ui/recruit-detail-header.tsx
@@ -65,7 +65,7 @@ function RecruitDetailHeader({
           <PeriodSection
             startDate={startDate}
             endDate={endDate}
-            hasDecoration={false}
+            isDecorated={false}
             className="mt-1 text-sm whitespace-nowrap lg:text-lg"
             isAlwaysRecruiting={isAlwaysRecruiting}
           />

--- a/src/entities/club-detail/ui/recruit-detail-view.tsx
+++ b/src/entities/club-detail/ui/recruit-detail-view.tsx
@@ -42,13 +42,13 @@ function RecruitDetailView({
     setCurrentIndex((prev) => (prev + 1) % imageUrls.length);
   };
 
-  const hasRecruitContent =
+  const isRecruitContentAvailable =
     Boolean(title?.trim()) ||
     Boolean(content?.trim()) ||
     Boolean(recruitForm?.trim()) ||
     imageUrls.length > 0;
 
-  if (!hasRecruitContent) {
+  if (!isRecruitContentAvailable) {
     return (
       <p className="py-30 text-center text-gray-500">
         동아리 모집 기간이 아닙니다.

--- a/src/entities/club-detail/ui/review-star.tsx
+++ b/src/entities/club-detail/ui/review-star.tsx
@@ -6,8 +6,8 @@ interface StarRatingProps {
 
 function StarRating({ rate }: StarRatingProps) {
   const fullStars = Math.floor(rate);
-  const hasHalfStar = rate - fullStars >= 0.5;
-  const emptyStars = 5 - fullStars - (hasHalfStar ? 1 : 0);
+  const isHalfStar = rate - fullStars >= 0.5;
+  const emptyStars = 5 - fullStars - (isHalfStar ? 1 : 0);
 
   return (
     <div className="flex flex-1 gap-1">
@@ -22,7 +22,7 @@ function StarRating({ rate }: StarRatingProps) {
             height={14}
           />
         ))}
-      {hasHalfStar && (
+      {isHalfStar && (
         <Image
           src="/detail/comment/starHalf.svg"
           alt="반 별"

--- a/src/entities/club/model/type.ts
+++ b/src/entities/club/model/type.ts
@@ -19,6 +19,14 @@ export interface Club {
   recruitmentPreviewResponse: RecruitmentPreviewResponse | null;
 }
 
+export interface ClubRaw extends Omit<Club, 'isFavorite'> {
+  favorite: boolean;
+}
+
+export function mapClub({ favorite, ...rest }: ClubRaw): Club {
+  return { ...rest, isFavorite: favorite };
+}
+
 export interface Recruitment {
   club: Club;
   id: number;
@@ -37,6 +45,11 @@ export interface RecruitmentResponse {
 
 export interface ClubsResponse {
   clubs: Club[];
+  page: Pagination;
+}
+
+export interface ClubsRawResponse {
+  clubs: ClubRaw[];
   page: Pagination;
 }
 

--- a/src/shared/model/type.ts
+++ b/src/shared/model/type.ts
@@ -25,6 +25,10 @@ export interface ClubList {
   clubs: ClubType[];
 }
 
+export interface ClubListRaw {
+  clubs: ClubTypeRaw[];
+}
+
 export interface ClubType {
   id: number;
   name: string;
@@ -39,6 +43,14 @@ export interface ClubType {
   recruitStatus: RecruitStatus;
 }
 
+export interface ClubTypeRaw extends Omit<ClubType, 'isFavorite'> {
+  favorite?: boolean;
+}
+
+export function mapClubType({ favorite, ...rest }: ClubTypeRaw): ClubType {
+  return { ...rest, isFavorite: favorite };
+}
+
 export interface Pagination {
   page: number;
   size: number;
@@ -51,6 +63,11 @@ export interface FavoriteList {
   pagination: Pagination;
 }
 
+export interface FavoriteListRaw {
+  clubs: ClubTypeRaw[];
+  pagination: Pagination;
+}
+
 export interface FavoriteItemListProps {
   clubs: FavoriteList[];
   totalElements: number;
@@ -58,6 +75,10 @@ export interface FavoriteItemListProps {
 
 export interface ClubSearchResponse {
   clubs: ClubType[];
+}
+
+export interface ClubSearchRawResponse {
+  clubs: ClubTypeRaw[];
   pagination: Pagination;
 }
 

--- a/src/shared/ui/calendar/calendar-body.tsx
+++ b/src/shared/ui/calendar/calendar-body.tsx
@@ -187,8 +187,8 @@ function CalendarBody({
         endTime={endTime}
         onStartTimeChange={onStartTimeChange}
         onEndTimeChange={onEndTimeChange}
-        hasStartDate={!!startDate}
-        hasEndDate={!!endDate}
+        isStartDateSelected={!!startDate}
+        isEndDateSelected={!!endDate}
         variant={variant}
       />
       <button

--- a/src/shared/ui/calendar/time-picker.tsx
+++ b/src/shared/ui/calendar/time-picker.tsx
@@ -23,8 +23,8 @@ interface TimePickerProps {
     minute: number;
     second: number;
   }) => void;
-  hasStartDate: boolean;
-  hasEndDate: boolean;
+  isStartDateSelected: boolean;
+  isEndDateSelected: boolean;
   variant?: 'dark' | 'light';
 }
 
@@ -35,8 +35,8 @@ function TimePicker({
   endTime,
   onStartTimeChange,
   onEndTimeChange,
-  hasStartDate,
-  hasEndDate,
+  isStartDateSelected,
+  isEndDateSelected,
   variant = 'light',
 }: TimePickerProps) {
   const hours = Array.from({ length: 24 }, (_, i) => i);
@@ -46,14 +46,14 @@ function TimePicker({
   const timeConfigs = [
     {
       label: '시작 시간',
-      show: hasStartDate,
+      show: isStartDateSelected,
       time: startTime,
       onChange: onStartTimeChange,
       defaults: { hour: 0, minute: 0, second: 0 },
     },
     {
       label: '마감 시간',
-      show: hasEndDate,
+      show: isEndDateSelected,
       time: endTime,
       onChange: onEndTimeChange,
       defaults: { hour: 23, minute: 59, second: 59 },

--- a/src/shared/ui/favorite-button.tsx
+++ b/src/shared/ui/favorite-button.tsx
@@ -32,10 +32,15 @@ function FavoriteButton({
           return;
         }
         try {
+          let result;
           if (!favorite) {
-            await postFavorite(Number(clubId));
+            result = await postFavorite(Number(clubId));
           } else {
-            await deleteFavorite(Number(clubId));
+            result = await deleteFavorite(Number(clubId));
+          }
+          if (!result.ok) {
+            toast.error(result.message);
+            return;
           }
           setFavorite((prev) => !prev);
         } catch (error) {

--- a/src/views/club/api/getRecentRecruitDetail.ts
+++ b/src/views/club/api/getRecentRecruitDetail.ts
@@ -3,12 +3,13 @@ import { ApiResponse } from '@/shared/model/type';
 import api from '@/shared/api/auth-api';
 import { getSession } from '@/shared/lib/cookie-session';
 import serverApi from '@/shared/api/server-api';
-import { RecruitmentDetail } from '../model/type';
+import type { RecruitmentDetailRaw } from '@/entities/club-detail/model/type';
+import { mapRecruitmentDetail } from '../model/type';
 
 async function getRecentRecruitDetail(id: number) {
   const session = await getSession();
   try {
-    let response: ApiResponse<RecruitmentDetail>;
+    let response: ApiResponse<RecruitmentDetailRaw>;
     if (session?.accessToken) {
       response = await api.get(`recruitments/club/recent/${id}`).json();
     } else {
@@ -19,7 +20,12 @@ async function getRecentRecruitDetail(id: number) {
         })
         .json();
     }
-    return { ok: true, data: response.data, status: 200 };
+    if (!response.data) return { ok: false, message: '데이터 없음' };
+    return {
+      ok: true,
+      data: mapRecruitmentDetail(response.data),
+      status: 200,
+    };
   } catch (e) {
     return createErrorResponse(e as Error);
   }

--- a/src/views/club/api/getRecruitDetail.tsx
+++ b/src/views/club/api/getRecruitDetail.tsx
@@ -3,12 +3,13 @@ import { ApiResponse } from '@/shared/model/type';
 import api from '@/shared/api/auth-api';
 import { getSession } from '@/shared/lib/cookie-session';
 import serverApi from '@/shared/api/server-api';
-import { RecruitmentDetail } from '../model/type';
+import type { RecruitmentDetailRaw } from '@/entities/club-detail/model/type';
+import { mapRecruitmentDetail } from '../model/type';
 
 async function getRecruitDetail(recruitmentId: number) {
   const session = await getSession();
   try {
-    let response: ApiResponse<RecruitmentDetail>;
+    let response: ApiResponse<RecruitmentDetailRaw>;
     if (session?.accessToken) {
       response = await api.get(`recruitments/${recruitmentId}`).json();
     } else {
@@ -19,7 +20,12 @@ async function getRecruitDetail(recruitmentId: number) {
         })
         .json();
     }
-    return { ok: true, data: response.data, status: 200 };
+    if (!response.data) return { ok: false, message: '데이터 없음' };
+    return {
+      ok: true,
+      data: mapRecruitmentDetail(response.data),
+      status: 200,
+    };
   } catch (e) {
     return createErrorResponse(e as Error);
   }

--- a/src/views/club/model/type.ts
+++ b/src/views/club/model/type.ts
@@ -1,8 +1,15 @@
 export type {
   ClubDetail,
   ClubDetailData,
+  ClubDetailRaw,
   RecruitmentDetail,
+  RecruitmentDetailRaw,
   RecruitmentDetailResponse,
   ClubRecruitments,
   ClubRecruitmentsResponse,
+} from '@/entities/club-detail/model/type';
+
+export {
+  mapRecruitmentDetail,
+  mapClubDetail,
 } from '@/entities/club-detail/model/type';

--- a/src/widgets/club/api/getClubList.ts
+++ b/src/widgets/club/api/getClubList.ts
@@ -7,7 +7,8 @@ import api from '@/shared/api/auth-api';
 import createErrorResponse from '@/shared/lib/error-message';
 import { getSession } from '@/shared/lib/cookie-session';
 import serverApi from '@/shared/api/server-api';
-import { ClubsResponse } from '../model/type';
+import { mapClub } from '@/entities/club/model/type';
+import { ClubsRawResponse } from '../model/type';
 
 async function getClubList({
   page,
@@ -41,13 +42,25 @@ async function getClubList({
   });
 
   try {
-    const client = session?.accessToken ? api : serverApi;
+    const isAuthenticated = !!session?.accessToken;
+    const client = isAuthenticated ? api : serverApi;
+    const fetchOptions = isAuthenticated
+      ? { searchParams, cache: 'no-store' as const }
+      : { searchParams, next: { tags: ['clubs'] } };
 
     const response = await client
-      .get('clubs', { searchParams, next: { tags: ['clubs'] } })
-      .json<ApiResponse<ClubsResponse>>();
+      .get('clubs', fetchOptions)
+      .json<ApiResponse<ClubsRawResponse>>();
 
-    return { ok: true, message: '성공', data: response.data };
+    const responseData = response.data;
+    if (!responseData) return { ok: false, message: '데이터 없음' };
+
+    const data = {
+      ...responseData,
+      clubs: responseData.clubs.map(mapClub),
+    };
+
+    return { ok: true, message: '성공', data };
   } catch (e) {
     return createErrorResponse(e as Error);
   }

--- a/src/widgets/club/model/type.ts
+++ b/src/widgets/club/model/type.ts
@@ -1,6 +1,7 @@
 export type {
   Club,
   ClubsResponse,
+  ClubsRawResponse,
   Recruitment,
   RecruitmentResponse,
   RecruitmentPreviewResponse,

--- a/src/widgets/recruit/api/getClubList.ts
+++ b/src/widgets/recruit/api/getClubList.ts
@@ -1,4 +1,9 @@
-import { ApiResponse, ClubCategory, ClubList } from '@/shared/model/type';
+import {
+  ApiResponse,
+  ClubCategory,
+  ClubListRaw,
+  mapClubType,
+} from '@/shared/model/type';
 import api from '@/shared/api/auth-api';
 import { getSession } from '@/shared/lib/cookie-session';
 import serverApi from '@/shared/api/server-api';
@@ -30,23 +35,25 @@ async function getClubList(params: GetRecruitListParams) {
     }
   });
   try {
-    let response: ApiResponse<ClubList>;
-    if (session?.accessToken) {
-      response = await api
-        .get('clubs', {
-          searchParams,
-          next: { tags: ['clubs'] },
-        })
-        .json<ApiResponse<ClubList>>();
-    } else {
-      response = await serverApi
-        .get('clubs', {
-          searchParams,
-          next: { tags: ['clubs'] },
-        })
-        .json<ApiResponse<ClubList>>();
-    }
-    return { ok: true, message: '성공', data: response.data, status: 200 };
+    const isAuthenticated = !!session?.accessToken;
+    const client = isAuthenticated ? api : serverApi;
+    const fetchOptions = isAuthenticated
+      ? { searchParams, cache: 'no-store' as const }
+      : { searchParams, next: { tags: ['clubs'] } };
+
+    const response = await client
+      .get('clubs', fetchOptions)
+      .json<ApiResponse<ClubListRaw>>();
+
+    const responseData = response.data;
+    if (!responseData) return { ok: false, message: '데이터 없음' };
+
+    const data = {
+      ...responseData,
+      clubs: responseData.clubs.map(mapClubType),
+    };
+
+    return { ok: true, message: '성공', data, status: 200 };
   } catch (e) {
     return createErrorResponse(e as Error);
   }

--- a/src/widgets/search/api/searchClubs.ts
+++ b/src/widgets/search/api/searchClubs.ts
@@ -1,7 +1,8 @@
 import {
   ClubCategory,
   ClubAffiliation,
-  ClubSearchResponse,
+  ClubSearchRawResponse,
+  mapClubType,
 } from '@/shared/model/type';
 import serverApi from '@/shared/api/server-api';
 import createErrorResponse from '@/shared/lib/error-message';
@@ -31,12 +32,17 @@ async function searchClubs(params: SearchClubsParams) {
         searchParams,
         next: { tags: ['clubs-search'] },
       })
-      .json<{ data: ClubSearchResponse }>();
+      .json<{ data: ClubSearchRawResponse }>();
+
+    const data = {
+      ...response.data,
+      clubs: response.data.clubs.map(mapClubType),
+    };
 
     return {
       ok: true,
       message: '성공',
-      data: response.data,
+      data,
       status: 200,
     };
   } catch (e) {


### PR DESCRIPTION
## Summary

- 백엔드 API 응답 필드명(`favorite`) ↔ 프론트엔드 타입(`isFavorite`) 불일치로 즐겨찾기 상태가 항상 `undefined`로 처리되던 버그 수정
- API 경계에 매퍼 함수(`mapClub`, `mapClubType`, `mapRecruitmentDetail`, `mapClubDetail`)를 추가하여 `favorite` → `isFavorite` 변환
- 인증 유저의 클럽 리스트 요청에 `cache: 'no-store'` 적용하여 유저별 `isFavorite` 데이터가 공유 캐시되는 문제 방지
- `FavoriteButton`에서 서버 액션 반환값(`ok`) 확인 후 실패 시 toast 표시 및 상태 롤백

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `entities/club/model/type.ts` | `mapClub` 매퍼 추가 |
| `shared/model/type.ts` | `mapClubType` 매퍼 추가 |
| `entities/club-detail/model/type.ts` | `mapRecruitmentDetail`, `mapClubDetail` 매퍼 추가 |
| `widgets/club/api/getClubList.ts` | 매퍼 적용 + 인증 시 `cache: 'no-store'` |
| `widgets/recruit/api/getClubList.ts` | 매퍼 적용 + 인증 시 `cache: 'no-store'` |
| `widgets/search/api/searchClubs.ts` | 매퍼 적용 |
| `widgets/favorite/api/getFavoriteList.ts` | 매퍼 적용 |
| `views/club/api/getRecentRecruitDetail.ts` | 매퍼 적용 |
| `views/club/api/getRecruitDetail.tsx` | 매퍼 적용 |
| `entities/club-detail/api/getClubDetail.ts` | 매퍼 적용 |
| `shared/ui/favorite-button.tsx` | 서버 액션 결과 확인 후 실패 시 롤백 |
| `views/club/model/type.ts` | 매퍼 함수 re-export |

## Test plan

- [x] 로그인 후 `/club` 페이지에서 좋아요 버튼 클릭 → 채워진 하트 표시
- [ ] 새로고침 후에도 좋아요 상태 유지 확인
- [ ] 비로그인 상태에서 좋아요 버튼 클릭 시 로그인 안내 toast 표시
- [ ] 이미 즐겨찾기한 동아리에 다시 좋아요 시 409 에러 toast 표시
- [ ] 동아리 상세 페이지에서도 좋아요 상태 정상 표시 확인
- [ ] 검색, 즐겨찾기 페이지에서도 좋아요 상태 정상 표시 확인


Made with [Cursor](https://cursor.com)