### PR TITLE
refactor: 어드민 퍼널 step 관리를 searchParams 기반으로 전환 및 뒤로가기 버튼 제거

### DIFF
--- a/src/features/admin-club-description/ui/create/create-flow-container.tsx
+++ b/src/features/admin-club-description/ui/create/create-flow-container.tsx
@@ -1,18 +1,18 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { Suspense } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import { Button } from '@/shared/ui/button';
-import { PrevButton } from '@/shared/ui/navigation-button';
 import DotsPulseLoader from '@/shared/ui/DotsPulseLoader';
+import SharedLoading from '@/shared/ui/loading';
 import useClubRegisterForm from '@/features/admin-club-description/util/useClubRegisterForm';
 import { postClubRegister } from '@/features/admin-club-description/api/postClubRegister';
 import AdminPageHeader from '@/features/admin/ui/components/admin-page-header';
 import useCreateFlow from './use-create-flow';
 import StepClubRegisterInfo from '../steps/step-club-register-info';
 
-function CreateFlowContainer() {
+function CreateFlowContent() {
   const router = useRouter();
   const flow = useCreateFlow();
   const {
@@ -23,22 +23,6 @@ function CreateFlowContainer() {
     isRegisterInfoValid,
     validateAll,
   } = useClubRegisterForm();
-
-  const [isTransitioning, setIsTransitioning] = useState(false);
-  const [displayStep, setDisplayStep] = useState(flow.currentStep);
-
-  useEffect(() => {
-    if (flow.currentStep !== displayStep) {
-      setIsTransitioning(true);
-      const timer = setTimeout(() => {
-        setDisplayStep(flow.currentStep);
-        setIsTransitioning(false);
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-      }, 300);
-      return () => clearTimeout(timer);
-    }
-    return undefined;
-  }, [flow.currentStep, displayStep]);
 
   const handleSubmit = async () => {
     validateAll();
@@ -70,7 +54,7 @@ function CreateFlowContainer() {
     toast.success('동아리가 등록되었습니다!');
   };
 
-  if (displayStep === 'complete') {
+  if (flow.currentStep === 'complete') {
     return (
       <div className="flex flex-col items-center gap-6 py-20">
         <h2 className="text-2xl font-semibold">등록 완료!</h2>
@@ -81,12 +65,8 @@ function CreateFlowContainer() {
   }
 
   return (
-    <div
-      className={`px-[8%] transition-opacity duration-300 lg:px-[35%] ${
-        isTransitioning ? 'opacity-0' : 'opacity-100'
-      }`}
-    >
-      {displayStep === 'basicInfo' && (
+    <div className="px-[8%] lg:px-[35%]">
+      {flow.currentStep === 'basicInfo' && (
         <div className="flex flex-col gap-2 py-8">
           <AdminPageHeader
             title="동아리 기본 정보"
@@ -115,6 +95,14 @@ function CreateFlowContainer() {
         </div>
       )}
     </div>
+  );
+}
+
+function CreateFlowContainer() {
+  return (
+    <Suspense fallback={<SharedLoading />}>
+      <CreateFlowContent />
+    </Suspense>
   );
 }
 

--- a/src/features/admin-club-description/ui/create/create-flow-container.tsx
+++ b/src/features/admin-club-description/ui/create/create-flow-container.tsx
@@ -68,10 +68,7 @@ function CreateFlowContent() {
     <div className="px-[8%] lg:px-[35%]">
       {flow.currentStep === 'basicInfo' && (
         <div className="flex flex-col gap-2 py-8">
-          <AdminPageHeader
-            title="동아리 기본 정보"
-            onBack={() => router.back()}
-          />
+          <AdminPageHeader title="동아리 기본 정보" />
           <StepClubRegisterInfo
             formData={formData}
             errors={errors}

--- a/src/features/admin-club-description/ui/create/create-flow-container.tsx
+++ b/src/features/admin-club-description/ui/create/create-flow-container.tsx
@@ -54,7 +54,7 @@ function CreateFlowContent() {
     toast.success('동아리가 등록되었습니다!');
   };
 
-  if (flow.currentStep === 'complete') {
+  if (flow.currentStep === 'completeCreateStep') {
     return (
       <div className="flex flex-col items-center gap-6 py-20">
         <h2 className="text-2xl font-semibold">등록 완료!</h2>
@@ -66,7 +66,7 @@ function CreateFlowContent() {
 
   return (
     <div className="px-[8%] lg:px-[35%]">
-      {flow.currentStep === 'basicInfo' && (
+      {flow.currentStep === 'basicInfoCreateStep' && (
         <div className="flex flex-col gap-2 py-8">
           <AdminPageHeader title="동아리 기본 정보" />
           <StepClubRegisterInfo

--- a/src/features/admin-club-description/ui/create/types.ts
+++ b/src/features/admin-club-description/ui/create/types.ts
@@ -1,6 +1,1 @@
 export type CreateStep = 'basicInfo' | 'complete';
-
-export interface CreateFlowState {
-  currentStep: CreateStep;
-  isSubmitting: boolean;
-}

--- a/src/features/admin-club-description/ui/create/types.ts
+++ b/src/features/admin-club-description/ui/create/types.ts
@@ -1,1 +1,1 @@
-export type CreateStep = 'basicInfo' | 'complete';
+export type CreateStep = 'basicInfoCreateStep' | 'completeCreateStep';

--- a/src/features/admin-club-description/ui/create/use-create-flow.ts
+++ b/src/features/admin-club-description/ui/create/use-create-flow.ts
@@ -1,29 +1,31 @@
+'use client';
+
 import { useState } from 'react';
-import { CreateFlowState } from './types';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { CreateStep } from './types';
 
 function useCreateFlow() {
-  const [state, setState] = useState<CreateFlowState>({
-    currentStep: 'basicInfo',
-    isSubmitting: false,
-  });
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isSubmitting, setSubmitting] = useState(false);
 
-  const setSubmitting = (isSubmitting: boolean) => {
-    setState((prev) => ({ ...prev, isSubmitting }));
-  };
+  const currentStep = (searchParams.get('step') as CreateStep) ?? 'basicInfo';
 
   const complete = () => {
-    setState((prev) => ({ ...prev, currentStep: 'complete' }));
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('step', 'complete');
+    router.replace(`?${params.toString()}`);
   };
 
   const reset = () => {
-    setState({
-      currentStep: 'basicInfo',
-      isSubmitting: false,
-    });
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('step', 'basicInfo');
+    router.replace(`?${params.toString()}`);
   };
 
   return {
-    ...state,
+    currentStep,
+    isSubmitting,
     setSubmitting,
     complete,
     reset,

--- a/src/features/admin-club-description/ui/create/use-create-flow.ts
+++ b/src/features/admin-club-description/ui/create/use-create-flow.ts
@@ -9,17 +9,18 @@ function useCreateFlow() {
   const searchParams = useSearchParams();
   const [isSubmitting, setSubmitting] = useState(false);
 
-  const currentStep = (searchParams.get('step') as CreateStep) ?? 'basicInfo';
+  const currentStep =
+    (searchParams.get('step') as CreateStep) ?? 'basicInfoCreateStep';
 
   const complete = () => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set('step', 'complete');
+    params.set('step', 'completeCreateStep');
     router.replace(`?${params.toString()}`);
   };
 
   const reset = () => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set('step', 'basicInfo');
+    params.set('step', 'basicInfoCreateStep');
     router.replace(`?${params.toString()}`);
   };
 

--- a/src/features/admin-club-description/ui/edit/edit-flow-container.tsx
+++ b/src/features/admin-club-description/ui/edit/edit-flow-container.tsx
@@ -137,10 +137,7 @@ function EditFlowContent({ clubInfo, clubId }: ClubEditFlowContainerProps) {
     <div>
       {flow.currentStep === 'basicInfo' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[35%]">
-          <AdminPageHeader
-            title="동아리 기본 정보"
-            onBack={() => router.back()}
-          />
+          <AdminPageHeader title="동아리 기본 정보" />
           <StepClubBasicInfo
             formData={formData}
             errors={errors}
@@ -166,7 +163,7 @@ function EditFlowContent({ clubInfo, clubId }: ClubEditFlowContainerProps) {
 
       {flow.currentStep === 'description' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[21%]">
-          <AdminPageHeader title="동아리 소개" onBack={flow.prevStep} />
+          <AdminPageHeader title="동아리 소개" />
           {flow.isSubmitting ? (
             <DotsPulseLoader wrapperClassName="flex justify-center flex-col items-center mt-4" />
           ) : (

--- a/src/features/admin-club-description/ui/edit/edit-flow-container.tsx
+++ b/src/features/admin-club-description/ui/edit/edit-flow-container.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { Suspense, useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import ky from 'ky';
 import { ClubInfoType } from '@/shared/model/type';
 import { Button } from '@/shared/ui/button';
 import DotsPulseLoader from '@/shared/ui/DotsPulseLoader';
+import SharedLoading from '@/shared/ui/loading';
 import useClubForm from '@/features/admin-club-description/util/useClubForm';
 import { patchClubInfo } from '@/features/admin-club-description/api/postClubRegister';
 import AdminPageHeader from '@/features/admin/ui/components/admin-page-header';
@@ -19,7 +20,7 @@ interface ClubEditFlowContainerProps {
   clubId: number;
 }
 
-function EditFlowContainer({ clubInfo, clubId }: ClubEditFlowContainerProps) {
+function EditFlowContent({ clubInfo, clubId }: ClubEditFlowContainerProps) {
   const router = useRouter();
   const flow = useEditFlow();
   const initialFormData = {
@@ -45,21 +46,6 @@ function EditFlowContainer({ clubInfo, clubId }: ClubEditFlowContainerProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [preview, setPreview] = useState<string | null>(clubInfo.logo ?? null);
   const [logoFile, setLogoFile] = useState<File | null>(null);
-  const [isTransitioning, setIsTransitioning] = useState(false);
-  const [displayStep, setDisplayStep] = useState(flow.currentStep);
-
-  useEffect(() => {
-    if (flow.currentStep !== displayStep) {
-      setIsTransitioning(true);
-      const timer = setTimeout(() => {
-        setDisplayStep(flow.currentStep);
-        setIsTransitioning(false);
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-      }, 300);
-      return () => clearTimeout(timer);
-    }
-    return undefined;
-  }, [flow.currentStep, displayStep]);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -135,7 +121,7 @@ function EditFlowContainer({ clubInfo, clubId }: ClubEditFlowContainerProps) {
     toast.success('동아리 정보가 수정되었습니다!');
   };
 
-  if (displayStep === 'complete') {
+  if (flow.currentStep === 'complete') {
     return (
       <div className="flex flex-col items-center gap-6 py-20">
         <h2 className="text-2xl font-semibold">수정 완료!</h2>
@@ -148,12 +134,8 @@ function EditFlowContainer({ clubInfo, clubId }: ClubEditFlowContainerProps) {
   }
 
   return (
-    <div
-      className={`transition-opacity duration-300 ${
-        isTransitioning ? 'opacity-0' : 'opacity-100'
-      }`}
-    >
-      {displayStep === 'basicInfo' && (
+    <div>
+      {flow.currentStep === 'basicInfo' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[35%]">
           <AdminPageHeader
             title="동아리 기본 정보"
@@ -182,9 +164,9 @@ function EditFlowContainer({ clubInfo, clubId }: ClubEditFlowContainerProps) {
         </div>
       )}
 
-      {displayStep === 'description' && (
+      {flow.currentStep === 'description' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[21%]">
-          <AdminPageHeader title="동아리 소개" onBack={() => flow.prevStep()} />
+          <AdminPageHeader title="동아리 소개" onBack={flow.prevStep} />
           {flow.isSubmitting ? (
             <DotsPulseLoader wrapperClassName="flex justify-center flex-col items-center mt-4" />
           ) : (
@@ -208,6 +190,14 @@ function EditFlowContainer({ clubInfo, clubId }: ClubEditFlowContainerProps) {
         </div>
       )}
     </div>
+  );
+}
+
+function EditFlowContainer(props: ClubEditFlowContainerProps) {
+  return (
+    <Suspense fallback={<SharedLoading />}>
+      <EditFlowContent {...props} />
+    </Suspense>
   );
 }
 

--- a/src/features/admin-club-description/ui/edit/edit-flow-container.tsx
+++ b/src/features/admin-club-description/ui/edit/edit-flow-container.tsx
@@ -134,7 +134,7 @@ function EditFlowContent({ clubInfo, clubId }: ClubEditFlowContainerProps) {
   }
 
   return (
-    <div>
+    <>
       {flow.currentStep === 'basicInfo' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[35%]">
           <AdminPageHeader title="동아리 기본 정보" />
@@ -186,7 +186,7 @@ function EditFlowContent({ clubInfo, clubId }: ClubEditFlowContainerProps) {
           />
         </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/src/features/admin-club-description/ui/edit/edit-flow-container.tsx
+++ b/src/features/admin-club-description/ui/edit/edit-flow-container.tsx
@@ -121,7 +121,7 @@ function EditFlowContent({ clubInfo, clubId }: ClubEditFlowContainerProps) {
     toast.success('동아리 정보가 수정되었습니다!');
   };
 
-  if (flow.currentStep === 'complete') {
+  if (flow.currentStep === 'completeEditStep') {
     return (
       <div className="flex flex-col items-center gap-6 py-20">
         <h2 className="text-2xl font-semibold">수정 완료!</h2>
@@ -135,7 +135,7 @@ function EditFlowContent({ clubInfo, clubId }: ClubEditFlowContainerProps) {
 
   return (
     <>
-      {flow.currentStep === 'basicInfo' && (
+      {flow.currentStep === 'basicInfoEditStep' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[35%]">
           <AdminPageHeader title="동아리 기본 정보" />
           <StepClubBasicInfo
@@ -161,7 +161,7 @@ function EditFlowContent({ clubInfo, clubId }: ClubEditFlowContainerProps) {
         </div>
       )}
 
-      {flow.currentStep === 'description' && (
+      {flow.currentStep === 'descriptionEditStep' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[21%]">
           <AdminPageHeader title="동아리 소개" />
           {flow.isSubmitting ? (

--- a/src/features/admin-club-description/ui/edit/types.ts
+++ b/src/features/admin-club-description/ui/edit/types.ts
@@ -1,6 +1,1 @@
 export type EditStep = 'basicInfo' | 'description' | 'complete';
-
-export interface EditFlowState {
-  currentStep: EditStep;
-  isSubmitting: boolean;
-}

--- a/src/features/admin-club-description/ui/edit/types.ts
+++ b/src/features/admin-club-description/ui/edit/types.ts
@@ -1,1 +1,4 @@
-export type EditStep = 'basicInfo' | 'description' | 'complete';
+export type EditStep =
+  | 'basicInfoEditStep'
+  | 'descriptionEditStep'
+  | 'completeEditStep';

--- a/src/features/admin-club-description/ui/edit/use-edit-flow.ts
+++ b/src/features/admin-club-description/ui/edit/use-edit-flow.ts
@@ -1,48 +1,57 @@
+'use client';
+
 import { useState } from 'react';
-import { EditStep, EditFlowState } from './types';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { EditStep } from './types';
 
 const EDIT_STEPS: EditStep[] = ['basicInfo', 'description', 'complete'];
+const DEFAULT_STEP: EditStep = 'basicInfo';
 
 function useEditFlow() {
-  const [state, setState] = useState<EditFlowState>({
-    currentStep: 'basicInfo',
-    isSubmitting: false,
-  });
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isSubmitting, setSubmitting] = useState(false);
+
+  const currentStep = (searchParams.get('step') as EditStep) ?? DEFAULT_STEP;
 
   const nextStep = () => {
-    const idx = EDIT_STEPS.indexOf(state.currentStep);
+    const idx = EDIT_STEPS.indexOf(currentStep);
     if (idx < EDIT_STEPS.length - 1) {
-      setState((prev) => ({ ...prev, currentStep: EDIT_STEPS[idx + 1] }));
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('step', EDIT_STEPS[idx + 1]);
+      router.push(`?${params.toString()}`);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
 
   const prevStep = () => {
-    const idx = EDIT_STEPS.indexOf(state.currentStep);
+    const idx = EDIT_STEPS.indexOf(currentStep);
     if (idx > 0) {
-      setState((prev) => ({ ...prev, currentStep: EDIT_STEPS[idx - 1] }));
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('step', EDIT_STEPS[idx - 1]);
+      router.push(`?${params.toString()}`);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
 
-  const setSubmitting = (isSubmitting: boolean) => {
-    setState((prev) => ({ ...prev, isSubmitting }));
-  };
-
   const complete = () => {
-    setState((prev) => ({ ...prev, currentStep: 'complete' }));
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('step', 'complete');
+    router.replace(`?${params.toString()}`);
   };
 
   const reset = () => {
-    setState({
-      currentStep: 'basicInfo',
-      isSubmitting: false,
-    });
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('step', DEFAULT_STEP);
+    router.replace(`?${params.toString()}`);
   };
 
   return {
-    ...state,
+    currentStep,
+    isSubmitting,
+    setSubmitting,
     nextStep,
     prevStep,
-    setSubmitting,
     complete,
     reset,
   };

--- a/src/features/admin-club-description/ui/edit/use-edit-flow.ts
+++ b/src/features/admin-club-description/ui/edit/use-edit-flow.ts
@@ -4,8 +4,12 @@ import { useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { EditStep } from './types';
 
-const EDIT_STEPS: EditStep[] = ['basicInfo', 'description', 'complete'];
-const DEFAULT_STEP: EditStep = 'basicInfo';
+const EDIT_STEPS: EditStep[] = [
+  'basicInfoEditStep',
+  'descriptionEditStep',
+  'completeEditStep',
+];
+const DEFAULT_STEP: EditStep = 'basicInfoEditStep';
 
 function useEditFlow() {
   const router = useRouter();
@@ -36,7 +40,7 @@ function useEditFlow() {
 
   const complete = () => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set('step', 'complete');
+    params.set('step', 'completeEditStep');
     router.replace(`?${params.toString()}`);
   };
 

--- a/src/features/admin-recruitment/ui/create/create-flow-container.tsx
+++ b/src/features/admin-recruitment/ui/create/create-flow-container.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { Suspense, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import ky from 'ky';
@@ -8,6 +8,7 @@ import { ClubInfoType } from '@/shared/model/type';
 import useImageUpload from '@/shared/model/useImageUpload';
 import { Button } from '@/shared/ui/button';
 import DotsPulseLoader from '@/shared/ui/DotsPulseLoader';
+import SharedLoading from '@/shared/ui/loading';
 import useRecruitmentForm from '@/features/admin-recruitment/util/useRecruitmentForm';
 import postRecruitmentForm from '@/features/admin-recruitment/api/postRecruitmentForm';
 import StepRecruitmentBasicInfo from '@/features/admin-recruitment/ui/steps/step-recruitment-basic-info';
@@ -21,7 +22,7 @@ interface CreateFlowContainerProps {
   clubInfo: ClubInfoType;
 }
 
-function CreateFlowContainer({ clubId, clubInfo }: CreateFlowContainerProps) {
+function CreateFlowContent({ clubId, clubInfo }: CreateFlowContainerProps) {
   const router = useRouter();
   const flow = useCreateFlow();
   const {
@@ -34,24 +35,9 @@ function CreateFlowContainer({ clubId, clubInfo }: CreateFlowContainerProps) {
     handleNextStep,
   } = useRecruitmentForm({ onNextStep: flow.nextStep });
 
-  const [isTransitioning, setIsTransitioning] = useState(false);
-  const [displayStep, setDisplayStep] = useState(flow.currentStep);
   const [createRecruitmentId, setCreateRecruitmentId] = useState<number>();
 
   const imageUpload = useImageUpload([]);
-
-  useEffect(() => {
-    if (flow.currentStep !== displayStep) {
-      setIsTransitioning(true);
-      const timer = setTimeout(() => {
-        setDisplayStep(flow.currentStep);
-        setIsTransitioning(false);
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-      }, 300);
-      return () => clearTimeout(timer);
-    }
-    return undefined;
-  }, [flow.currentStep, displayStep]);
 
   const handleSubmit = async () => {
     flow.setIsSubmitting(true);
@@ -94,7 +80,7 @@ function CreateFlowContainer({ clubId, clubInfo }: CreateFlowContainerProps) {
     toast.success('모집 공고가 등록되었습니다!');
   };
 
-  if (displayStep === 'complete') {
+  if (flow.currentStep === 'complete') {
     return (
       <div className="flex flex-col items-center gap-6 py-20">
         <h2 className="text-2xl font-semibold">등록 완료!</h2>
@@ -111,12 +97,8 @@ function CreateFlowContainer({ clubId, clubInfo }: CreateFlowContainerProps) {
   }
 
   return (
-    <div
-      className={`transition-opacity duration-300 ${
-        isTransitioning ? 'opacity-0' : 'opacity-100'
-      }`}
-    >
-      {displayStep === 'basicInfo' && (
+    <div>
+      {flow.currentStep === 'basicInfo' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[35%]">
           <AdminPageHeader
             title="모집글 기본 정보"
@@ -152,7 +134,7 @@ function CreateFlowContainer({ clubId, clubInfo }: CreateFlowContainerProps) {
         </div>
       )}
 
-      {displayStep === 'postInfo' && (
+      {flow.currentStep === 'postInfo' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[21%]">
           <AdminPageHeader title="모집공고" onBack={flow.prevStep} />
           {flow.isSubmitting ? (
@@ -178,6 +160,14 @@ function CreateFlowContainer({ clubId, clubInfo }: CreateFlowContainerProps) {
         </div>
       )}
     </div>
+  );
+}
+
+function CreateFlowContainer(props: CreateFlowContainerProps) {
+  return (
+    <Suspense fallback={<SharedLoading />}>
+      <CreateFlowContent {...props} />
+    </Suspense>
   );
 }
 

--- a/src/features/admin-recruitment/ui/create/create-flow-container.tsx
+++ b/src/features/admin-recruitment/ui/create/create-flow-container.tsx
@@ -100,10 +100,7 @@ function CreateFlowContent({ clubId, clubInfo }: CreateFlowContainerProps) {
     <div>
       {flow.currentStep === 'basicInfo' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[35%]">
-          <AdminPageHeader
-            title="모집글 기본 정보"
-            onBack={() => router.back()}
-          />
+          <AdminPageHeader title="모집글 기본 정보" />
           <StepRecruitmentBasicInfo
             formData={formData}
             errors={errors}
@@ -136,7 +133,7 @@ function CreateFlowContent({ clubId, clubInfo }: CreateFlowContainerProps) {
 
       {flow.currentStep === 'postInfo' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[21%]">
-          <AdminPageHeader title="모집공고" onBack={flow.prevStep} />
+          <AdminPageHeader title="모집공고" />
           {flow.isSubmitting ? (
             <DotsPulseLoader wrapperClassName="flex justify-center flex-col items-center mt-4" />
           ) : (

--- a/src/features/admin-recruitment/ui/create/create-flow-container.tsx
+++ b/src/features/admin-recruitment/ui/create/create-flow-container.tsx
@@ -80,7 +80,7 @@ function CreateFlowContent({ clubId, clubInfo }: CreateFlowContainerProps) {
     toast.success('모집 공고가 등록되었습니다!');
   };
 
-  if (flow.currentStep === 'complete') {
+  if (flow.currentStep === 'completeCreateStep') {
     return (
       <div className="flex flex-col items-center gap-6 py-20">
         <h2 className="text-2xl font-semibold">등록 완료!</h2>
@@ -98,7 +98,7 @@ function CreateFlowContent({ clubId, clubInfo }: CreateFlowContainerProps) {
 
   return (
     <>
-      {flow.currentStep === 'basicInfo' && (
+      {flow.currentStep === 'basicInfoCreateStep' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[35%]">
           <AdminPageHeader title="모집글 기본 정보" />
           <StepRecruitmentBasicInfo
@@ -131,7 +131,7 @@ function CreateFlowContent({ clubId, clubInfo }: CreateFlowContainerProps) {
         </div>
       )}
 
-      {flow.currentStep === 'postInfo' && (
+      {flow.currentStep === 'postInfoCreateStep' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[21%]">
           <AdminPageHeader title="모집공고" />
           {flow.isSubmitting ? (

--- a/src/features/admin-recruitment/ui/create/create-flow-container.tsx
+++ b/src/features/admin-recruitment/ui/create/create-flow-container.tsx
@@ -97,7 +97,7 @@ function CreateFlowContent({ clubId, clubInfo }: CreateFlowContainerProps) {
   }
 
   return (
-    <div>
+    <>
       {flow.currentStep === 'basicInfo' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[35%]">
           <AdminPageHeader title="모집글 기본 정보" />
@@ -156,7 +156,7 @@ function CreateFlowContent({ clubId, clubInfo }: CreateFlowContainerProps) {
           />
         </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/src/features/admin-recruitment/ui/create/types.ts
+++ b/src/features/admin-recruitment/ui/create/types.ts
@@ -1,6 +1,1 @@
 export type CreateStep = 'basicInfo' | 'postInfo' | 'complete';
-
-export interface CreateFlowState {
-  currentStep: CreateStep;
-  isSubmitting: boolean;
-}

--- a/src/features/admin-recruitment/ui/create/types.ts
+++ b/src/features/admin-recruitment/ui/create/types.ts
@@ -1,1 +1,4 @@
-export type CreateStep = 'basicInfo' | 'postInfo' | 'complete';
+export type CreateStep =
+  | 'basicInfoCreateStep'
+  | 'postInfoCreateStep'
+  | 'completeCreateStep';

--- a/src/features/admin-recruitment/ui/create/use-create-flow.ts
+++ b/src/features/admin-recruitment/ui/create/use-create-flow.ts
@@ -1,45 +1,57 @@
+'use client';
+
 import { useState } from 'react';
-import { CreateStep, CreateFlowState } from './types';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { CreateStep } from './types';
 
 const STEPS: CreateStep[] = ['basicInfo', 'postInfo', 'complete'];
+const DEFAULT_STEP: CreateStep = 'basicInfo';
 
 function useCreateFlow() {
-  const [state, setState] = useState<CreateFlowState>({
-    currentStep: 'basicInfo',
-    isSubmitting: false,
-  });
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const currentStep = (searchParams.get('step') as CreateStep) ?? DEFAULT_STEP;
 
   const nextStep = () => {
-    const idx = STEPS.indexOf(state.currentStep);
+    const idx = STEPS.indexOf(currentStep);
     if (idx < STEPS.length - 1) {
-      setState((prev) => ({ ...prev, currentStep: STEPS[idx + 1] }));
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('step', STEPS[idx + 1]);
+      router.push(`?${params.toString()}`);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
 
   const prevStep = () => {
-    const idx = STEPS.indexOf(state.currentStep);
+    const idx = STEPS.indexOf(currentStep);
     if (idx > 0) {
-      setState((prev) => ({ ...prev, currentStep: STEPS[idx - 1] }));
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('step', STEPS[idx - 1]);
+      router.push(`?${params.toString()}`);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
 
-  const setIsSubmitting = (isSubmitting: boolean) => {
-    setState((prev) => ({ ...prev, isSubmitting }));
-  };
-
   const complete = () => {
-    setState((prev) => ({ ...prev, currentStep: 'complete' }));
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('step', 'complete');
+    router.replace(`?${params.toString()}`);
   };
 
   const reset = () => {
-    setState({ currentStep: 'basicInfo', isSubmitting: false });
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('step', DEFAULT_STEP);
+    router.replace(`?${params.toString()}`);
   };
 
   return {
-    ...state,
+    currentStep,
+    isSubmitting,
+    setIsSubmitting,
     nextStep,
     prevStep,
-    setIsSubmitting,
     complete,
     reset,
   };

--- a/src/features/admin-recruitment/ui/create/use-create-flow.ts
+++ b/src/features/admin-recruitment/ui/create/use-create-flow.ts
@@ -4,8 +4,12 @@ import { useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { CreateStep } from './types';
 
-const STEPS: CreateStep[] = ['basicInfo', 'postInfo', 'complete'];
-const DEFAULT_STEP: CreateStep = 'basicInfo';
+const STEPS: CreateStep[] = [
+  'basicInfoCreateStep',
+  'postInfoCreateStep',
+  'completeCreateStep',
+];
+const DEFAULT_STEP: CreateStep = 'basicInfoCreateStep';
 
 function useCreateFlow() {
   const router = useRouter();
@@ -36,7 +40,7 @@ function useCreateFlow() {
 
   const complete = () => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set('step', 'complete');
+    params.set('step', 'completeCreateStep');
     router.replace(`?${params.toString()}`);
   };
 

--- a/src/features/admin-recruitment/ui/edit/edit-flow-container.tsx
+++ b/src/features/admin-recruitment/ui/edit/edit-flow-container.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { Suspense, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import ky from 'ky';
@@ -9,6 +9,7 @@ import useImageUpload from '@/shared/model/useImageUpload';
 import { Button } from '@/shared/ui/button';
 import AdminPageHeader from '@/features/admin/ui/components/admin-page-header';
 import DotsPulseLoader from '@/shared/ui/DotsPulseLoader';
+import SharedLoading from '@/shared/ui/loading';
 import useRecruitmentForm from '@/features/admin-recruitment/util/useRecruitmentForm';
 import patchRecruitmentForm from '@/features/admin-recruitment/api/patchRecruitmentForm';
 import deleteRecruitmentForm from '@/features/admin-recruitment/api/deleteRecruitmentForm';
@@ -27,7 +28,7 @@ interface EditFlowContainerProps {
   recruitments: ClubRecruitments[];
 }
 
-function EditFlowContainer({ clubInfo, recruitments }: EditFlowContainerProps) {
+function EditFlowContent({ clubInfo, recruitments }: EditFlowContainerProps) {
   const router = useRouter();
   const flow = useEditFlow();
   const {
@@ -45,26 +46,11 @@ function EditFlowContainer({ clubInfo, recruitments }: EditFlowContainerProps) {
     useState<RecruitmentDetail | null>(null);
   const [isLoadingRecruitmentDetail, setIsLoadingRecruitmentDetail] =
     useState(false);
-  const [isTransitioning, setIsTransitioning] = useState(false);
-  const [displayStep, setDisplayStep] = useState(flow.currentStep);
   const imageUpload = useImageUpload(recruitmentDetail?.imageUrls ?? []);
   const [isDeleting, setIsDeleting] = useState(false);
   const [localRecruitments, setLocalRecruitments] =
     useState<ClubRecruitments[]>(recruitments);
   const [editRecruitmentId, setEditRecruitmentId] = useState<number>();
-
-  useEffect(() => {
-    if (flow.currentStep !== displayStep) {
-      setIsTransitioning(true);
-      const timer = setTimeout(() => {
-        setDisplayStep(flow.currentStep);
-        setIsTransitioning(false);
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-      }, 300);
-      return () => clearTimeout(timer);
-    }
-    return undefined;
-  }, [flow.currentStep, displayStep]);
 
   const handleEdit = async (post: ClubRecruitments) => {
     setIsLoadingRecruitmentDetail(true);
@@ -163,7 +149,7 @@ function EditFlowContainer({ clubInfo, recruitments }: EditFlowContainerProps) {
     );
   }
 
-  if (displayStep === 'selectPost') {
+  if (flow.currentStep === 'selectPost') {
     return (
       <StepSelectPost
         recruitments={localRecruitments}
@@ -174,7 +160,7 @@ function EditFlowContainer({ clubInfo, recruitments }: EditFlowContainerProps) {
     );
   }
 
-  if (displayStep === 'complete') {
+  if (flow.currentStep === 'complete') {
     return (
       <div className="flex flex-col items-center gap-6 py-20">
         <h2 className="text-2xl font-semibold">수정 완료!</h2>
@@ -191,12 +177,8 @@ function EditFlowContainer({ clubInfo, recruitments }: EditFlowContainerProps) {
   }
 
   return (
-    <div
-      className={`transition-opacity duration-300 ${
-        isTransitioning ? 'opacity-0' : 'opacity-100'
-      }`}
-    >
-      {displayStep === 'basicInfo' && (
+    <div>
+      {flow.currentStep === 'basicInfo' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[35%]">
           <AdminPageHeader
             title="모집글 기본 정보"
@@ -232,9 +214,9 @@ function EditFlowContainer({ clubInfo, recruitments }: EditFlowContainerProps) {
         </div>
       )}
 
-      {displayStep === 'postInfo' && (
+      {flow.currentStep === 'postInfo' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[21%]">
-          <AdminPageHeader title="모집글" onBack={flow.goToSelectPost} />
+          <AdminPageHeader title="모집글" onBack={flow.prevStep} />
           {flow.isSubmitting ? (
             <DotsPulseLoader wrapperClassName="flex justify-center flex-col items-center mt-4" />
           ) : (
@@ -259,6 +241,14 @@ function EditFlowContainer({ clubInfo, recruitments }: EditFlowContainerProps) {
         </div>
       )}
     </div>
+  );
+}
+
+function EditFlowContainer(props: EditFlowContainerProps) {
+  return (
+    <Suspense fallback={<SharedLoading />}>
+      <EditFlowContent {...props} />
+    </Suspense>
   );
 }
 

--- a/src/features/admin-recruitment/ui/edit/edit-flow-container.tsx
+++ b/src/features/admin-recruitment/ui/edit/edit-flow-container.tsx
@@ -180,10 +180,7 @@ function EditFlowContent({ clubInfo, recruitments }: EditFlowContainerProps) {
     <div>
       {flow.currentStep === 'basicInfo' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[35%]">
-          <AdminPageHeader
-            title="모집글 기본 정보"
-            onBack={flow.goToSelectPost}
-          />
+          <AdminPageHeader title="모집글 기본 정보" />
           <StepRecruitmentBasicInfo
             formData={formData}
             errors={errors}
@@ -216,7 +213,7 @@ function EditFlowContent({ clubInfo, recruitments }: EditFlowContainerProps) {
 
       {flow.currentStep === 'postInfo' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[21%]">
-          <AdminPageHeader title="모집글" onBack={flow.prevStep} />
+          <AdminPageHeader title="모집글" />
           {flow.isSubmitting ? (
             <DotsPulseLoader wrapperClassName="flex justify-center flex-col items-center mt-4" />
           ) : (

--- a/src/features/admin-recruitment/ui/edit/edit-flow-container.tsx
+++ b/src/features/admin-recruitment/ui/edit/edit-flow-container.tsx
@@ -177,7 +177,7 @@ function EditFlowContent({ clubInfo, recruitments }: EditFlowContainerProps) {
   }
 
   return (
-    <div>
+    <>
       {flow.currentStep === 'basicInfo' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[35%]">
           <AdminPageHeader title="모집글 기본 정보" />
@@ -237,7 +237,7 @@ function EditFlowContent({ clubInfo, recruitments }: EditFlowContainerProps) {
           />
         </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/src/features/admin-recruitment/ui/edit/edit-flow-container.tsx
+++ b/src/features/admin-recruitment/ui/edit/edit-flow-container.tsx
@@ -149,7 +149,7 @@ function EditFlowContent({ clubInfo, recruitments }: EditFlowContainerProps) {
     );
   }
 
-  if (flow.currentStep === 'selectPost') {
+  if (flow.currentStep === 'selectPostEditStep') {
     return (
       <StepSelectPost
         recruitments={localRecruitments}
@@ -160,7 +160,7 @@ function EditFlowContent({ clubInfo, recruitments }: EditFlowContainerProps) {
     );
   }
 
-  if (flow.currentStep === 'complete') {
+  if (flow.currentStep === 'completeEditStep') {
     return (
       <div className="flex flex-col items-center gap-6 py-20">
         <h2 className="text-2xl font-semibold">수정 완료!</h2>
@@ -178,7 +178,7 @@ function EditFlowContent({ clubInfo, recruitments }: EditFlowContainerProps) {
 
   return (
     <>
-      {flow.currentStep === 'basicInfo' && (
+      {flow.currentStep === 'basicInfoEditStep' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[35%]">
           <AdminPageHeader title="모집글 기본 정보" />
           <StepRecruitmentBasicInfo
@@ -211,7 +211,7 @@ function EditFlowContent({ clubInfo, recruitments }: EditFlowContainerProps) {
         </div>
       )}
 
-      {flow.currentStep === 'postInfo' && (
+      {flow.currentStep === 'postInfoEditStep' && (
         <div className="flex flex-col gap-2 px-[8%] py-8 lg:px-[21%]">
           <AdminPageHeader title="모집글" />
           {flow.isSubmitting ? (

--- a/src/features/admin-recruitment/ui/edit/types.ts
+++ b/src/features/admin-recruitment/ui/edit/types.ts
@@ -1,9 +1,1 @@
-import { ClubRecruitments } from '@/entities/club-detail/model/type';
-
 export type EditStep = 'selectPost' | 'basicInfo' | 'postInfo' | 'complete';
-
-export interface EditFlowState {
-  currentStep: EditStep;
-  selectedPost?: ClubRecruitments;
-  isSubmitting: boolean;
-}

--- a/src/features/admin-recruitment/ui/edit/types.ts
+++ b/src/features/admin-recruitment/ui/edit/types.ts
@@ -1,1 +1,5 @@
-export type EditStep = 'selectPost' | 'basicInfo' | 'postInfo' | 'complete';
+export type EditStep =
+  | 'selectPostEditStep'
+  | 'basicInfoEditStep'
+  | 'postInfoEditStep'
+  | 'completeEditStep';

--- a/src/features/admin-recruitment/ui/edit/use-edit-flow.ts
+++ b/src/features/admin-recruitment/ui/edit/use-edit-flow.ts
@@ -1,6 +1,9 @@
+'use client';
+
 import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { ClubRecruitments } from '@/entities/club-detail/model/type';
-import { EditStep, EditFlowState } from './types';
+import { EditStep } from './types';
 
 const EDIT_STEPS: EditStep[] = [
   'selectPost',
@@ -8,61 +11,69 @@ const EDIT_STEPS: EditStep[] = [
   'postInfo',
   'complete',
 ];
+const DEFAULT_STEP: EditStep = 'selectPost';
 
 function useEditFlow() {
-  const [state, setState] = useState<EditFlowState>({
-    currentStep: 'selectPost',
-    selectedPost: undefined,
-    isSubmitting: false,
-  });
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [selectedPost, setSelectedPost] = useState<
+    ClubRecruitments | undefined
+  >(undefined);
+  const [isSubmitting, setSubmitting] = useState(false);
+
+  const currentStep = (searchParams.get('step') as EditStep) ?? DEFAULT_STEP;
 
   const startEdit = (post: ClubRecruitments) => {
-    setState((prev) => ({
-      ...prev,
-      currentStep: 'basicInfo',
-      selectedPost: post,
-    }));
+    setSelectedPost(post);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('step', 'basicInfo');
+    router.push(`?${params.toString()}`);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   const nextStep = () => {
-    const idx = EDIT_STEPS.indexOf(state.currentStep);
+    const idx = EDIT_STEPS.indexOf(currentStep);
     if (idx < EDIT_STEPS.length - 1) {
-      setState((prev) => ({ ...prev, currentStep: EDIT_STEPS[idx + 1] }));
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('step', EDIT_STEPS[idx + 1]);
+      router.push(`?${params.toString()}`);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
 
   const prevStep = () => {
-    const idx = EDIT_STEPS.indexOf(state.currentStep);
+    const idx = EDIT_STEPS.indexOf(currentStep);
     if (idx > 0) {
-      setState((prev) => ({ ...prev, currentStep: EDIT_STEPS[idx - 1] }));
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('step', EDIT_STEPS[idx - 1]);
+      router.push(`?${params.toString()}`);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
 
   const goToSelectPost = () => {
-    setState((prev) => ({
-      ...prev,
-      currentStep: 'selectPost',
-    }));
-  };
-
-  const setSubmitting = (isSubmitting: boolean) => {
-    setState((prev) => ({ ...prev, isSubmitting }));
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('step', 'selectPost');
+    router.push(`?${params.toString()}`);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   const complete = () => {
-    setState((prev) => ({ ...prev, currentStep: 'complete' }));
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('step', 'complete');
+    router.replace(`?${params.toString()}`);
   };
 
   const reset = () => {
-    setState({
-      currentStep: 'selectPost',
-      selectedPost: undefined,
-      isSubmitting: false,
-    });
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('step', DEFAULT_STEP);
+    router.replace(`?${params.toString()}`);
   };
 
   return {
-    ...state,
+    currentStep,
+    selectedPost,
+    isSubmitting,
     startEdit,
     nextStep,
     prevStep,

--- a/src/features/admin-recruitment/ui/edit/use-edit-flow.ts
+++ b/src/features/admin-recruitment/ui/edit/use-edit-flow.ts
@@ -6,12 +6,12 @@ import { ClubRecruitments } from '@/entities/club-detail/model/type';
 import { EditStep } from './types';
 
 const EDIT_STEPS: EditStep[] = [
-  'selectPost',
-  'basicInfo',
-  'postInfo',
-  'complete',
+  'selectPostEditStep',
+  'basicInfoEditStep',
+  'postInfoEditStep',
+  'completeEditStep',
 ];
-const DEFAULT_STEP: EditStep = 'selectPost';
+const DEFAULT_STEP: EditStep = 'selectPostEditStep';
 
 function useEditFlow() {
   const router = useRouter();
@@ -26,7 +26,7 @@ function useEditFlow() {
   const startEdit = (post: ClubRecruitments) => {
     setSelectedPost(post);
     const params = new URLSearchParams(searchParams.toString());
-    params.set('step', 'basicInfo');
+    params.set('step', 'basicInfoEditStep');
     router.push(`?${params.toString()}`);
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
@@ -53,14 +53,14 @@ function useEditFlow() {
 
   const goToSelectPost = () => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set('step', 'selectPost');
+    params.set('step', 'selectPostEditStep');
     router.push(`?${params.toString()}`);
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   const complete = () => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set('step', 'complete');
+    params.set('step', 'completeEditStep');
     router.replace(`?${params.toString()}`);
   };
 

--- a/src/features/admin-recruitment/ui/steps/step-select-post.tsx
+++ b/src/features/admin-recruitment/ui/steps/step-select-post.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import { ClubRecruitments } from '@/entities/club-detail/model/type';
-import { useRouter } from 'next/navigation';
 import { Button } from '@/shared/ui/button';
 import AdminPageHeader from '@/features/admin/ui/components/admin-page-header';
 
@@ -21,7 +20,6 @@ function StepSelectPost({
   isDeleting = false,
   title = '전체 모집 공고',
 }: StepSelectPostProps) {
-  const router = useRouter();
   const [selectedPost, setSelectedPost] = useState<ClubRecruitments>();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
@@ -48,7 +46,7 @@ function StepSelectPost({
   return (
     <div className="flex min-h-[calc(100vh-100px)] flex-col justify-between px-[11%] py-2 lg:min-h-[calc(100vh-200px)] lg:py-8">
       <div>
-        <AdminPageHeader title={title} onBack={() => router.back()} />
+        <AdminPageHeader title={title} />
 
         {recruitments.length === 0 ? (
           <p className="mt-4 text-gray-400">등록된 모집글이 없습니다.</p>

--- a/src/features/admin/model/use-admin-flow.ts
+++ b/src/features/admin/model/use-admin-flow.ts
@@ -51,8 +51,6 @@ function useAdminFlow(allowedClubs: AdminClubInfo[]) {
     }
   };
 
-  const goBack = () => router.back();
-
   const reset = () => router.push('/admin');
 
   return {
@@ -61,7 +59,6 @@ function useAdminFlow(allowedClubs: AdminClubInfo[]) {
     selectedClubName,
     selectClub,
     selectAction,
-    goBack,
     reset,
     validateClubAccess,
   };

--- a/src/features/admin/ui/admin-flow-container.tsx
+++ b/src/features/admin/ui/admin-flow-container.tsx
@@ -30,7 +30,6 @@ function AdminFlowContent({ allowedClubs, role }: AdminFlowContainerProps) {
         <StepSelectActionMode
           clubName={flow.selectedClubName}
           onNext={flow.selectAction}
-          onBack={flow.goBack}
         />
       )}
     </div>

--- a/src/features/admin/ui/components/admin-page-header.tsx
+++ b/src/features/admin/ui/components/admin-page-header.tsx
@@ -1,16 +1,12 @@
 'use client';
 
-import { PrevButton } from '@/shared/ui/navigation-button';
-
 interface AdminPageHeaderProps {
   title: string;
-  onBack: () => void;
 }
 
-function AdminPageHeader({ title, onBack }: AdminPageHeaderProps) {
+function AdminPageHeader({ title }: AdminPageHeaderProps) {
   return (
     <div className="mb-4 flex items-center gap-2 lg:gap-4">
-      <PrevButton onClick={onBack} />
       <h1 className="text-base font-bold lg:text-[28px]">{title}</h1>
     </div>
   );

--- a/src/features/admin/ui/components/admin-step-layout.tsx
+++ b/src/features/admin/ui/components/admin-step-layout.tsx
@@ -1,21 +1,13 @@
 'use client';
 
 import Image from 'next/image';
-import { PrevButton } from '@/shared/ui/navigation-button';
 
 interface AdminStepLayoutProps {
   clubName?: string;
   children: React.ReactNode;
-  backButtonLabel: string;
-  onBack: () => void;
 }
 
-function AdminStepLayout({
-  clubName,
-  children,
-  backButtonLabel,
-  onBack,
-}: AdminStepLayoutProps) {
+function AdminStepLayout({ clubName, children }: AdminStepLayoutProps) {
   return (
     <div className="flex min-h-[calc(100vh-134px)] w-full flex-col items-center justify-between">
       <div className="flex flex-col items-center gap-2 pt-10">
@@ -35,9 +27,7 @@ function AdminStepLayout({
         {children}
       </div>
 
-      <PrevButton onClick={onBack} className="mt-4">
-        {backButtonLabel}
-      </PrevButton>
+      <div className="mt-4" />
     </div>
   );
 }

--- a/src/features/admin/ui/steps/step-select-action-mode.tsx
+++ b/src/features/admin/ui/steps/step-select-action-mode.tsx
@@ -7,20 +7,11 @@ import type { ContentType, ActionType } from '../../model/types';
 interface StepSelectActionModeProps {
   clubName?: string;
   onNext: (contentType: ContentType, actionType: ActionType) => void;
-  onBack: () => void;
 }
 
-function StepSelectActionMode({
-  clubName,
-  onNext,
-  onBack,
-}: StepSelectActionModeProps) {
+function StepSelectActionMode({ clubName, onNext }: StepSelectActionModeProps) {
   return (
-    <AdminStepLayout
-      clubName={clubName}
-      backButtonLabel="동아리 다시 선택하기"
-      onBack={onBack}
-    >
+    <AdminStepLayout clubName={clubName}>
       <MenuButton
         label="모집글 수정 및 삭제"
         onClick={() => onNext('recruitment', 'edit')}

--- a/src/views/admin-club-description/admin-club-description-page.tsx
+++ b/src/views/admin-club-description/admin-club-description-page.tsx
@@ -5,11 +5,9 @@ import AdminClubDescriptionWidget from '@/widgets/admin-club-description/admin-c
 
 function AdminClubDescriptionPage({ params }: RecruitmentActionParams) {
   return (
-    <div className="w-full">
-      <Suspense fallback={<SharedLoading />}>
-        <AdminClubDescriptionWidget params={params} />
-      </Suspense>
-    </div>
+    <Suspense fallback={<SharedLoading />}>
+      <AdminClubDescriptionWidget params={params} />
+    </Suspense>
   );
 }
 

--- a/src/views/admin-recruitment/admin-recruitment-page.tsx
+++ b/src/views/admin-recruitment/admin-recruitment-page.tsx
@@ -5,11 +5,9 @@ import AdminRecruitmentWidget from '@/widgets/admin-recruitment/admin-recruitmen
 
 function AdminRecruitmentPage({ params }: RecruitmentActionParams) {
   return (
-    <div className="w-full">
-      <Suspense fallback={<SharedLoading />}>
-        <AdminRecruitmentWidget params={params} />
-      </Suspense>
-    </div>
+    <Suspense fallback={<SharedLoading />}>
+      <AdminRecruitmentWidget params={params} />
+    </Suspense>
   );
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

[#505 ] 어드민 퍼널 구조 개선

## 📝작업 내용

기존 퍼널은 step을 컴포넌트 내부 상태(`useState`)로 관리했기 때문에, 브라우저 뒤로가기를 눌러도 이전 step으로 이동하지 않고 퍼널 자체를 이탈하는 문제가 있었습니다. step을 URL의 `searchParams`(`?step=basicInfo` 등)로 관리하도록 전환하면 브라우저 히스토리와 퍼널 step이 자동으로 동기화되어, 뒤로가기 버튼 없이도 브라우저 네이티브 뒤로가기만으로 이전 step으로 복귀할 수 있게 됩니다.

어드민 모집글 생성·수정 및 동아리 정보 수정 퍼널에서 step 상태를 `useState` 기반 내부 상태로 관리하던 방식을 `useSearchParams` + `router.push` 기반으로 전환했습니다. 아울러 각 step 화면에 존재하던 뒤로가기 버튼을 제거했습니다.

### 주요 변경 사항
- **step 상태 관리 방식 변경**: `useCreateFlow` / `useEditFlow` 내부에서 `useState`로 관리하던 `currentStep`을 `useSearchParams().get('step')`으로 읽도록 변경하고, step 전환 시 `router.push`·`router.replace`로 URL을 업데이트하도록 수정
- **`types.ts` 정리**: 기존 `CreateFlowState` / `EditFlowState` 등 step 상태를 담던 인터페이스를 제거하고 Step 타입만 남김
- **뒤로가기 버튼 제거**: `AdminPageHeader`, `AdminStepLayout`, `StepSelectPost`, 각 flow container 등에서 렌더링하던 커스텀 뒤로가기 버튼과 관련 props·핸들러를 제거
- **step 전환 시 스크롤 초기화**: step 이동(`nextStep`, `prevStep`, `startEdit`) 시 `window.scrollTo({ top: 0, behavior: 'smooth' })`를 호출해 항상 페이지 상단에서 다음 step을 시작하도록 개선
- **적용 범위**: `admin-recruitment`(생성/수정)와 `admin-club-description`(수정) 두 퍼널 모두 동일하게 적용

### 참고 자료(설계 문서화 자료)
[**어드민 퍼널 개선 설계**](https://mokkoji.notion.site/3247455c17d0805caea8ed883d4eeefc?source=copy_link)

## 💬리뷰 요구사항(선택)

기존 퍼널 방식의 구조적 한계를 개선하기 위해 위와 같은 방식을 사용했습니다. 제가 생각하기엔 라우트 히스토리에 쌓는 구조로 가는 것이 효과적이라고 생각하여서 그렇게 판단하였는데, 더 좋은 구조가 있다면 의견주시면 감사하겠습니다!!
또, 이 과정에서 페이드 효과를 제거하게 되었는데, 성능상 이슈가 없음에도 넣을 이유가 없다고 생각되어 제거하였습니다. (지난 회의 스켈레톤 ui와 같은 이슈)
마지막으로 뒤로가기 버튼 제거에 대해 UX적으로 괜찮은지 한번 검토 부탁드리겠습니다 감사합니다!

+ 혹시 제가 구현이 잘못되어있는 부분이 있다면 말씀해주세요~!!