### PR TITLE
501 refactor deatail page mobile ut

### DIFF
--- a/src/entities/club-detail/ui/period-section.tsx
+++ b/src/entities/club-detail/ui/period-section.tsx
@@ -1,4 +1,4 @@
-import { formatDateDotted } from '@/entities/club/util/getDateUtil';
+import { formatDateDotted, formatTime } from '@/entities/club/util/getDateUtil';
 import cn from '@/shared/lib/utils';
 
 interface PeriodSectionProps {
@@ -30,9 +30,15 @@ function PeriodSection({
           모집기한 · {formatDateDotted(startDate!)}~{formatDateDotted(endDate!)}
         </span>
       ) : (
-        <span className="text[#0A0A0A]">
-          모집기한 | {formatDateDotted(startDate!)}~{formatDateDotted(endDate!)}
-        </span>
+        <>
+          <span className="text[#0A0A0A]">
+            모집기한 | {formatDateDotted(startDate!)}~
+            {formatDateDotted(endDate!)}
+          </span>
+          <span className="ml-1 text-[#8B95A1]">
+            (마감 시간 {formatTime(endDate!)})
+          </span>
+        </>
       )}
     </span>
   );

--- a/src/entities/club-detail/ui/recruit-detail-header.tsx
+++ b/src/entities/club-detail/ui/recruit-detail-header.tsx
@@ -56,7 +56,7 @@ function RecruitDetailHeader({
           </p>
         </div>
       </div>
-      <div className="flex flex-col items-start gap-7 lg:flex-row lg:items-center lg:text-xl">
+      <div className="flex flex-col items-start gap-5 lg:flex-row lg:items-center lg:text-xl">
         <RadiusTag
           recruitStatus={status}
           className="shrink-0 px-3 py-2 text-xs whitespace-nowrap lg:px-4 lg:py-2.5 lg:text-[14px]"

--- a/src/entities/club-detail/ui/recruit-detail-header.tsx
+++ b/src/entities/club-detail/ui/recruit-detail-header.tsx
@@ -43,7 +43,7 @@ function RecruitDetailHeader({
 
   return (
     <header className="w-full cursor-default">
-      <div className="flex flex-row items-center gap-3.5 lg:mb-5 lg:gap-4">
+      <div className="mb-5 flex flex-row items-center gap-3.5 lg:gap-4">
         <ClickLogo logo={logo} title={title} />
         <div className="flex min-w-0 items-center gap-2">
           <h1 className="text-2xl font-bold whitespace-nowrap lg:text-4xl">

--- a/src/entities/club/util/getDateUtil.ts
+++ b/src/entities/club/util/getDateUtil.ts
@@ -22,4 +22,11 @@ export function formatDateDotted(dateStr: string | Date): string {
   return `${year}.${month}.${day}`;
 }
 
+export function formatTime(dateStr: string | Date): string {
+  const date = new Date(dateStr);
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  return `${hours}:${minutes}`;
+}
+
 export default isRecruitEndDateEndOfYear;

--- a/src/widgets/club-detail/ui/club-detail-tabs.tsx
+++ b/src/widgets/club-detail/ui/club-detail-tabs.tsx
@@ -95,7 +95,7 @@ function ClubDetailTabs({
 
   return (
     <div className="mt-8 lg:mt-12">
-      <div className="mb-8 flex justify-center border-b border-b-[#D6D6D6] pb-3 lg:mb-12">
+      <div className="sticky top-0 z-30 mb-8 flex justify-center border-b border-b-[#D6D6D6] bg-white py-5 pb-3 lg:mb-12">
         {TABS.map((tab) => {
           const isSelected = tab.key === activeTab;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#501 

## 📝작업 내용

- 상세페이지 모바일 UT관련 수정


- [x]  상세페이지에 모집마감 시간 표시
- [x] 상세페이지 헤더 갭 수정
- [x] 상세페이지 탭 상단에 고정

모집마감 시간 표시 관련 디자인이 나오지 않아 해당 부분은 수정하지 않았습니다.

### 스크린샷 (선택)
상단고정
<img width="318" height="699" alt="image" src="https://github.com/user-attachments/assets/16d30710-59bc-4369-869e-3f321470a70c" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
