### PR TITLE
feat: 피드백 플로팅 버튼 구현

### DIFF
--- a/src/app/theme.css
+++ b/src/app/theme.css
@@ -9,6 +9,7 @@
   --color-text-tertiary: #9f9f9f; /* 텍스트 placeholder */
   --color-alert-500: #ff383c;
   --color-disabled: #cccccc;
+  --color-gray2: #d6d6d6;
 
   --color-darkmode-line: #43E780; /* 다크모드 시 LINE */
   --color-darkmode-tag: #1AE166; /* 다크모드 시 TAG */

--- a/src/widgets/club/ui/club-item-list.tsx
+++ b/src/widgets/club/ui/club-item-list.tsx
@@ -2,6 +2,7 @@ import { ClubAffiliation, ClubCategory } from '@/shared/model/type';
 import ErrorBoundaryUi from '@/shared/ui/error-boundary-ui';
 import { searchParamsCache } from '@/shared/lib/club-search-params';
 import NumberPagination from '@/shared/ui/numberPagination';
+import FeedbackModal from '@/widgets/feedback/feedback-modal';
 import getClubList from '../api/getClubList';
 import ClubItemClientList from './club-item-client-list';
 
@@ -34,6 +35,7 @@ async function ClubItemList() {
   return (
     <div className="mb-8">
       <ClubItemClientList clubs={clubListResponse.data.clubs} />
+      <FeedbackModal />
       <NumberPagination
         page={page}
         totalPages={clubListResponse.data.page.totalPages}

--- a/src/widgets/club/ui/club-item-list.tsx
+++ b/src/widgets/club/ui/club-item-list.tsx
@@ -2,7 +2,7 @@ import { ClubAffiliation, ClubCategory } from '@/shared/model/type';
 import ErrorBoundaryUi from '@/shared/ui/error-boundary-ui';
 import { searchParamsCache } from '@/shared/lib/club-search-params';
 import NumberPagination from '@/shared/ui/numberPagination';
-import FeedbackModal from '@/widgets/feedback/feedback-modal';
+import FeedbackModal from '@/widgets/feedback/ui/feedback-modal';
 import getClubList from '../api/getClubList';
 import ClubItemClientList from './club-item-client-list';
 

--- a/src/widgets/feedback/api/postDiscordWebhook.ts
+++ b/src/widgets/feedback/api/postDiscordWebhook.ts
@@ -1,0 +1,46 @@
+interface PostDiscordWebhookRequest {
+  rating: number;
+  comment: string;
+}
+
+async function postDiscordWebhook({
+  rating,
+  comment,
+}: PostDiscordWebhookRequest): Promise<void> {
+  const response = await fetch(
+    process.env.NEXT_PUBLIC_DISCORD_FEEDBACK_WEBHOOK_URL!,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        embeds: [
+          {
+            title: '📋 모꼬지 사용자 피드백',
+            color: 0x4ade80,
+            fields: [
+              {
+                name: '⭐ 별점',
+                value: '★'.repeat(rating) + '☆'.repeat(5 - rating),
+                inline: true,
+              },
+              {
+                name: '💬 의견',
+                value: comment || '(내용 없음)',
+                inline: false,
+              },
+            ],
+            footer: {
+              text: `모꼬지 피드백 • ${new Date().toLocaleString('ko-KR')}`,
+            },
+          },
+        ],
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error('디스코드 웹훅 전송에 실패했습니다.');
+  }
+}
+
+export default postDiscordWebhook;

--- a/src/widgets/feedback/api/postReport.ts
+++ b/src/widgets/feedback/api/postReport.ts
@@ -1,3 +1,5 @@
+import ky from 'ky';
+
 interface PostReportRequest {
   rating: number;
   content: string;
@@ -7,15 +9,9 @@ async function postReport({
   rating,
   content,
 }: PostReportRequest): Promise<void> {
-  const response = await fetch('/api/local/reports', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ rating, content }),
+  await ky.post('/api/local/reports', {
+    json: { rating, content },
   });
-
-  if (!response.ok) {
-    throw new Error('피드백 전송에 실패했습니다.');
-  }
 }
 
 export default postReport;

--- a/src/widgets/feedback/api/postReport.ts
+++ b/src/widgets/feedback/api/postReport.ts
@@ -1,0 +1,21 @@
+interface PostReportRequest {
+  rating: number;
+  content: string;
+}
+
+async function postReport({
+  rating,
+  content,
+}: PostReportRequest): Promise<void> {
+  const response = await fetch('/api/local/reports', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ rating, content }),
+  });
+
+  if (!response.ok) {
+    throw new Error('피드백 전송에 실패했습니다.');
+  }
+}
+
+export default postReport;

--- a/src/widgets/feedback/feedback-modal.tsx
+++ b/src/widgets/feedback/feedback-modal.tsx
@@ -8,12 +8,14 @@ function FeedbackModal() {
   const [hovered, setHovered] = useState(0);
   const [comment, setComment] = useState('');
   const { isVisible } = useScrollUp();
+  const [isOpen, setIsOpen] = useState(true);
 
   const content = (
     <div className="border-gray2 relative w-full rounded-xl border bg-white p-6">
       <button
         className="absolute top-5 right-5 text-sm text-[#474747]"
         aria-label="닫기"
+        onClick={() => setIsOpen(false)}
       >
         ✕
       </button>
@@ -64,10 +66,12 @@ function FeedbackModal() {
 
   return (
     <>
-      <div className="mt-5 flex w-full flex-col items-center justify-center sm:hidden">
-        {content}
-      </div>
-      {isVisible && (
+      {isOpen && (
+        <div className="mt-5 flex w-full flex-col items-center justify-center sm:hidden">
+          {content}
+        </div>
+      )}
+      {isOpen && isVisible && (
         <div className="fixed right-23 bottom-25 z-50 hidden w-85 sm:block">
           {content}
         </div>

--- a/src/widgets/feedback/feedback-modal.tsx
+++ b/src/widgets/feedback/feedback-modal.tsx
@@ -38,7 +38,9 @@ function FeedbackModal() {
         ],
       }),
     });
-    toast.success('의견 감사합니다!');
+    toast.success('의견 감사합니다!', {
+      autoClose: 2000,
+    });
     setRating(0);
     setComment('');
   };

--- a/src/widgets/feedback/feedback-modal.tsx
+++ b/src/widgets/feedback/feedback-modal.tsx
@@ -1,67 +1,78 @@
 'use client';
 
 import { useState } from 'react';
+import useScrollUp from '@/shared/model/useScrollUp';
 
 function FeedbackModal() {
   const [rating, setRating] = useState(0);
   const [hovered, setHovered] = useState(0);
   const [comment, setComment] = useState('');
+  const { isVisible } = useScrollUp();
+
+  const content = (
+    <div className="border-gray2 relative w-full rounded-xl border bg-white p-6">
+      <button
+        className="absolute top-5 right-5 text-sm text-[#474747]"
+        aria-label="닫기"
+      >
+        ✕
+      </button>
+
+      <h2 className="mb-1 pr-6 text-lg font-semibold text-[#474747]">
+        모꼬지 사용 경험이 궁금해요!
+      </h2>
+      <p className="mb-4 text-sm text-[#474747]">자유롭게 의견을 남겨주세요.</p>
+
+      <div className="mb-4 flex gap-2">
+        {[1, 2, 3, 4, 5].map((star) => (
+          <button
+            key={star}
+            onMouseEnter={() => setHovered(star)}
+            onMouseLeave={() => setHovered(0)}
+            onClick={() => setRating(star)}
+            className="text-3xl transition-transform hover:scale-110 active:scale-95"
+            aria-label={`${star}점`}
+          >
+            <span
+              className={
+                star <= (hovered || rating)
+                  ? 'text-lightmode-tag'
+                  : 'text-gray-300'
+              }
+            >
+              ★
+            </span>
+          </button>
+        ))}
+      </div>
+
+      <textarea
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        placeholder="입력해주세요."
+        className="mb-2 h-14 w-full resize-none rounded-lg bg-[#F4F4F4] px-2.5 py-1.5 text-sm text-[#474747] placeholder-gray-400 focus:outline-none"
+      />
+
+      <button
+        disabled={rating === 0 && comment.length <= 0}
+        className="bg-lightmode-tag w-full cursor-pointer rounded-lg py-3 text-sm transition-colors disabled:bg-gray-200 disabled:text-gray-400"
+      >
+        확인
+      </button>
+    </div>
+  );
 
   return (
-    <div className="mt-5 flex w-full flex-col items-center justify-center">
-      <div className="border-gray2 relative w-full rounded-xl border bg-white p-6">
-        <button
-          className="absolute top-5 right-5 text-sm text-[#474747]"
-          aria-label="닫기"
-        >
-          ✕
-        </button>
-
-        <h2 className="mb-1 pr-6 text-lg font-semibold text-[#474747]">
-          모꼬지 사용 경험이 궁금해요!
-        </h2>
-        <p className="mb-4 text-sm text-[#474747]">
-          자유롭게 의견을 남겨주세요.
-        </p>
-
-        <div className="mb-4 flex gap-2">
-          {[1, 2, 3, 4, 5].map((star) => (
-            <button
-              key={star}
-              onMouseEnter={() => setHovered(star)}
-              onMouseLeave={() => setHovered(0)}
-              onClick={() => setRating(star)}
-              className="text-3xl transition-transform hover:scale-110 active:scale-95"
-              aria-label={`${star}점`}
-            >
-              <span
-                className={
-                  star <= (hovered || rating)
-                    ? 'text-lightmode-tag'
-                    : 'text-gray-300'
-                }
-              >
-                ★
-              </span>
-            </button>
-          ))}
-        </div>
-
-        <textarea
-          value={comment}
-          onChange={(e) => setComment(e.target.value)}
-          placeholder="입력해주세요."
-          className="mb-2 h-14 w-full resize-none rounded-lg bg-[#F4F4F4] px-2.5 py-1.5 text-sm text-[#474747] placeholder-gray-400 focus:outline-none sm:px-4 sm:py-3 sm:text-base"
-        />
-
-        <button
-          disabled={rating === 0 && comment.length <= 0}
-          className="bg-lightmode-tag w-full cursor-pointer rounded-lg py-3 text-sm transition-colors disabled:bg-gray-200 disabled:text-gray-400 sm:py-3.5 sm:text-base"
-        >
-          확인
-        </button>
+    <>
+      <div className="mt-5 flex w-full flex-col items-center justify-center sm:hidden">
+        {content}
       </div>
-    </div>
+      {isVisible && (
+        <div className="fixed right-23 bottom-25 z-50 hidden w-85 sm:block">
+          {content}
+        </div>
+      )}
+    </>
   );
 }
 

--- a/src/widgets/feedback/feedback-modal.tsx
+++ b/src/widgets/feedback/feedback-modal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import useScrollUp from '@/shared/model/useScrollUp';
+import { toast } from 'react-toastify';
 
 function FeedbackModal() {
   const [rating, setRating] = useState(0);
@@ -9,6 +10,38 @@ function FeedbackModal() {
   const [comment, setComment] = useState('');
   const { isVisible } = useScrollUp();
   const [isOpen, setIsOpen] = useState(true);
+  const handleSubmit = async () => {
+    await fetch(process.env.NEXT_PUBLIC_DISCORD_FEEDBACK_WEBHOOK_URL!, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        embeds: [
+          {
+            title: '📋 모꼬지 사용자 피드백',
+            color: 0x4ade80,
+            fields: [
+              {
+                name: '⭐ 별점',
+                value: '★'.repeat(rating) + '☆'.repeat(5 - rating),
+                inline: true,
+              },
+              {
+                name: '💬 의견',
+                value: comment || '(내용 없음)',
+                inline: false,
+              },
+            ],
+            footer: {
+              text: `모꼬지 피드백 • ${new Date().toLocaleString('ko-KR')}`,
+            },
+          },
+        ],
+      }),
+    });
+    toast.success('의견 감사합니다!');
+    setRating(0);
+    setComment('');
+  };
 
   const content = (
     <div className="border-gray2 relative w-full rounded-xl border bg-white p-6">
@@ -57,6 +90,7 @@ function FeedbackModal() {
 
       <button
         disabled={rating === 0 && comment.length <= 0}
+        onClick={handleSubmit}
         className="bg-lightmode-tag w-full cursor-pointer rounded-lg py-3 text-sm transition-colors disabled:bg-gray-200 disabled:text-gray-400"
       >
         확인

--- a/src/widgets/feedback/feedback-modal.tsx
+++ b/src/widgets/feedback/feedback-modal.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState } from 'react';
+
+function FeedbackModal() {
+  const [rating, setRating] = useState(0);
+  const [hovered, setHovered] = useState(0);
+  const [comment, setComment] = useState('');
+
+  return (
+    <div className="mt-5 flex w-full flex-col items-center justify-center">
+      <div className="border-gray2 relative w-full rounded-xl border bg-white p-6">
+        <button
+          className="absolute top-5 right-5 text-sm text-[#474747]"
+          aria-label="닫기"
+        >
+          ✕
+        </button>
+
+        <h2 className="mb-1 pr-6 text-lg font-semibold text-[#474747]">
+          모꼬지 사용 경험이 궁금해요!
+        </h2>
+        <p className="mb-4 text-sm text-[#474747]">
+          자유롭게 의견을 남겨주세요.
+        </p>
+
+        <div className="mb-4 flex gap-2">
+          {[1, 2, 3, 4, 5].map((star) => (
+            <button
+              key={star}
+              onMouseEnter={() => setHovered(star)}
+              onMouseLeave={() => setHovered(0)}
+              onClick={() => setRating(star)}
+              className="text-3xl transition-transform hover:scale-110 active:scale-95"
+              aria-label={`${star}점`}
+            >
+              <span
+                className={
+                  star <= (hovered || rating)
+                    ? 'text-lightmode-tag'
+                    : 'text-gray-300'
+                }
+              >
+                ★
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <textarea
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          placeholder="입력해주세요."
+          className="mb-2 h-14 w-full resize-none rounded-lg bg-[#F4F4F4] px-2.5 py-1.5 text-sm text-[#474747] placeholder-gray-400 focus:outline-none sm:px-4 sm:py-3 sm:text-base"
+        />
+
+        <button
+          disabled={rating === 0 && comment.length <= 0}
+          className="bg-lightmode-tag w-full cursor-pointer rounded-lg py-3 text-sm transition-colors disabled:bg-gray-200 disabled:text-gray-400 sm:py-3.5 sm:text-base"
+        >
+          확인
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default FeedbackModal;

--- a/src/widgets/feedback/ui/feedback-modal.tsx
+++ b/src/widgets/feedback/ui/feedback-modal.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import useScrollUp from '@/shared/model/useScrollUp';
 import { toast } from 'react-toastify';
+import postReport from '../api/postReport';
+import postDiscordWebhook from '../api/postDiscordWebhook';
 
 function FeedbackModal() {
   const [rating, setRating] = useState(0);
@@ -10,39 +12,17 @@ function FeedbackModal() {
   const [comment, setComment] = useState('');
   const { isVisible } = useScrollUp();
   const [isOpen, setIsOpen] = useState(true);
+
   const handleSubmit = async () => {
-    await fetch(process.env.NEXT_PUBLIC_DISCORD_FEEDBACK_WEBHOOK_URL!, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        embeds: [
-          {
-            title: '📋 모꼬지 사용자 피드백',
-            color: 0x4ade80,
-            fields: [
-              {
-                name: '⭐ 별점',
-                value: '★'.repeat(rating) + '☆'.repeat(5 - rating),
-                inline: true,
-              },
-              {
-                name: '💬 의견',
-                value: comment || '(내용 없음)',
-                inline: false,
-              },
-            ],
-            footer: {
-              text: `모꼬지 피드백 • ${new Date().toLocaleString('ko-KR')}`,
-            },
-          },
-        ],
-      }),
-    });
-    toast.success('의견 감사합니다!', {
-      autoClose: 2000,
-    });
-    setRating(0);
-    setComment('');
+    try {
+      await postDiscordWebhook({ rating, comment });
+      await postReport({ rating, content: comment });
+      toast.success('의견 감사합니다!', { autoClose: 2000 });
+      setRating(0);
+      setComment('');
+    } catch {
+      toast.error('전송에 실패했습니다. 다시 시도해주세요.');
+    }
   };
 
   const content = (

--- a/src/widgets/feedback/ui/feedback-modal.tsx
+++ b/src/widgets/feedback/ui/feedback-modal.tsx
@@ -35,9 +35,9 @@ function FeedbackModal() {
         ✕
       </button>
 
-      <h2 className="mb-1 pr-6 text-lg font-semibold text-[#474747]">
+      <h1 className="mb-1 pr-6 text-lg font-semibold text-[#474747]">
         모꼬지 사용 경험이 궁금해요!
-      </h2>
+      </h1>
       <p className="mb-4 text-sm text-[#474747]">자유롭게 의견을 남겨주세요.</p>
 
       <div className="mb-4 flex gap-2">


### PR DESCRIPTION
## #️⃣연관된 이슈

> #514 

## 📝작업 내용

- 플로팅 버튼 컴포넌트 구현
- 모바일, 웹 버전에 맞춰 /clubs 페이지에 넣기
- 피드백 들어왔을때 디스코드 웹훅 걸어서 post

### 스크린샷 (선택)
- 데스크탑
<img width="1509" height="847" alt="image" src="https://github.com/user-attachments/assets/4be3fb02-f973-4fe2-9062-83793d7e75e4" />

- 모바일
<img width="326" height="698" alt="image" src="https://github.com/user-attachments/assets/5ad3d58d-535a-47bf-9c3a-40b8fc319be4" />

- 웹훅이미지
<img width="418" height="250" alt="image" src="https://github.com/user-attachments/assets/40108b5b-8902-4225-8f4e-8f05c85640a2" />


## 💬리뷰 요구사항(선택)

> 백엔드측 post api가 아직 머지되면 해당 부분까지 추가하겠습니다. -> 완료
