### PR TITLE
feat: 동아리장 등록 신청 기능 구현

### DIFF
--- a/src/app/[universityCode]/club-application/layout.tsx
+++ b/src/app/[universityCode]/club-application/layout.tsx
@@ -24,7 +24,9 @@ export default async function Layout({
   return (
     <div className="flex flex-col">
       <Header universityCode={universityCode} />
-      <main className="flex px-4 py-7">{children}</main>
+      <main className="flex px-4 py-7 pb-[calc(1.75rem+85px)] lg:pb-7">
+        {children}
+      </main>
       <BottomNav />
     </div>
   );

--- a/src/features/club-master-application/api/getClubsByUniversity.ts
+++ b/src/features/club-master-application/api/getClubsByUniversity.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { unstable_cache } from 'next/cache';
-import api from '@/shared/api/auth-api';
+import serverApi from '@/shared/api/server-api';
 import type { ClubOption } from '../model/type';
 
 interface ClubPreviewResponse {
@@ -17,7 +17,7 @@ interface AllClubsApiResponse {
 
 const fetchClubsByUniversity = unstable_cache(
   async (universityCode: string): Promise<ClubOption[]> => {
-    const response = await api
+    const response = await serverApi
       .get('clubs', {
         searchParams: {
           universityCode,

--- a/src/features/club-master-application/api/getClubsByUniversity.ts
+++ b/src/features/club-master-application/api/getClubsByUniversity.ts
@@ -1,0 +1,36 @@
+'use server';
+
+import api from '@/shared/api/auth-api';
+import type { ClubOption } from '../model/type';
+
+interface ClubPreviewResponse {
+  id: number;
+  name: string;
+}
+
+interface AllClubsApiResponse {
+  data: {
+    clubs: ClubPreviewResponse[];
+  };
+}
+
+async function getClubsByUniversity(
+  universityCode: string,
+): Promise<ClubOption[]> {
+  try {
+    const response = await api
+      .get('clubs', {
+        searchParams: {
+          universityCode,
+          page: 1,
+          size: 200,
+        },
+      })
+      .json<AllClubsApiResponse>();
+    return response.data.clubs.map(({ id, name }) => ({ id, name }));
+  } catch {
+    return [];
+  }
+}
+
+export default getClubsByUniversity;

--- a/src/features/club-master-application/api/getClubsByUniversity.ts
+++ b/src/features/club-master-application/api/getClubsByUniversity.ts
@@ -2,21 +2,16 @@
 
 import { unstable_cache } from 'next/cache';
 import serverApi from '@/shared/api/server-api';
-import type { ClubOption } from '../model/type';
-
-interface ClubPreviewResponse {
-  id: number;
-  name: string;
-}
+import type { ClubSummary } from '../model/type';
 
 interface AllClubsApiResponse {
   data: {
-    clubs: ClubPreviewResponse[];
+    clubs: ClubSummary[];
   };
 }
 
 const fetchClubsByUniversity = unstable_cache(
-  async (universityCode: string): Promise<ClubOption[]> => {
+  async (universityCode: string): Promise<ClubSummary[]> => {
     const response = await serverApi
       .get('clubs', {
         searchParams: {
@@ -34,7 +29,7 @@ const fetchClubsByUniversity = unstable_cache(
 
 async function getClubsByUniversity(
   universityCode: string,
-): Promise<ClubOption[]> {
+): Promise<ClubSummary[]> {
   try {
     return await fetchClubsByUniversity(universityCode);
   } catch {

--- a/src/features/club-master-application/api/getClubsByUniversity.ts
+++ b/src/features/club-master-application/api/getClubsByUniversity.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { unstable_cache } from 'next/cache';
 import api from '@/shared/api/auth-api';
 import type { ClubOption } from '../model/type';
 
@@ -14,10 +15,8 @@ interface AllClubsApiResponse {
   };
 }
 
-async function getClubsByUniversity(
-  universityCode: string,
-): Promise<ClubOption[]> {
-  try {
+const fetchClubsByUniversity = unstable_cache(
+  async (universityCode: string): Promise<ClubOption[]> => {
     const response = await api
       .get('clubs', {
         searchParams: {
@@ -28,6 +27,16 @@ async function getClubsByUniversity(
       })
       .json<AllClubsApiResponse>();
     return response.data.clubs.map(({ id, name }) => ({ id, name }));
+  },
+  ['clubs-by-university'],
+  { revalidate: 3600 },
+);
+
+async function getClubsByUniversity(
+  universityCode: string,
+): Promise<ClubOption[]> {
+  try {
+    return await fetchClubsByUniversity(universityCode);
   } catch {
     return [];
   }

--- a/src/features/club-master-application/api/postClubMasterApplication.ts
+++ b/src/features/club-master-application/api/postClubMasterApplication.ts
@@ -9,9 +9,7 @@ async function postClubMasterApplication(data: ClubMasterApplicationFormData) {
     await api.post('club-master-applications', { json: data });
     return { ok: true, message: '동아리장 등록 신청이 완료되었습니다.' };
   } catch (error) {
-    return createErrorResponse(error as Error, [
-      { status: 409, message: '이미 신청된 동아리입니다.' },
-    ]);
+    return createErrorResponse(error as Error, undefined, [403, 404, 409]);
   }
 }
 

--- a/src/features/club-master-application/api/postClubMasterApplication.ts
+++ b/src/features/club-master-application/api/postClubMasterApplication.ts
@@ -1,0 +1,18 @@
+'use server';
+
+import api from '@/shared/api/auth-api';
+import createErrorResponse from '@/shared/lib/error-message';
+import type { ClubMasterApplicationFormData } from '../model/type';
+
+async function postClubMasterApplication(data: ClubMasterApplicationFormData) {
+  try {
+    await api.post('club-master-applications', { json: data });
+    return { ok: true, message: '동아리장 등록 신청이 완료되었습니다.' };
+  } catch (error) {
+    return createErrorResponse(error as Error, [
+      { status: 409, message: '이미 신청된 동아리입니다.' },
+    ]);
+  }
+}
+
+export default postClubMasterApplication;

--- a/src/features/club-master-application/api/postClubMasterApplication.ts
+++ b/src/features/club-master-application/api/postClubMasterApplication.ts
@@ -9,7 +9,7 @@ async function postClubMasterApplication(data: ClubMasterApplicationFormData) {
     await api.post('club-master-applications', { json: data });
     return { ok: true, message: '동아리장 등록 신청이 완료되었습니다.' };
   } catch (error) {
-    return createErrorResponse(error as Error, undefined, [403, 404, 409]);
+    return createErrorResponse(error as Error);
   }
 }
 

--- a/src/features/club-master-application/model/type.ts
+++ b/src/features/club-master-application/model/type.ts
@@ -1,0 +1,10 @@
+export interface ClubMasterApplicationFormData {
+  universityCode: string;
+  clubId: number;
+  userName: string;
+}
+
+export interface ClubOption {
+  id: number;
+  name: string;
+}

--- a/src/features/club-master-application/model/type.ts
+++ b/src/features/club-master-application/model/type.ts
@@ -1,7 +1,7 @@
 export interface ClubMasterApplicationFormData {
   universityCode: string;
   clubId: number;
-  userName: string;
+  userName: string | null;
 }
 
 export interface ClubSummary {

--- a/src/features/club-master-application/model/type.ts
+++ b/src/features/club-master-application/model/type.ts
@@ -4,7 +4,7 @@ export interface ClubMasterApplicationFormData {
   userName: string;
 }
 
-export interface ClubOption {
+export interface ClubSummary {
   id: number;
   name: string;
 }

--- a/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
+++ b/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
-import Input from '@/shared/ui/input';
+import { useSession } from '@/shared/lib/session-context';
 import { Button } from '@/shared/ui/button';
 import {
   Select,
@@ -20,6 +20,7 @@ import type { ClubSummary } from '../model/type';
 function ClubMasterApplicationForm() {
   const router = useRouter();
   const universityCode = useUniversityCode();
+  const { session } = useSession();
   const [isClubsLoading, setIsClubsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -27,7 +28,6 @@ function ClubMasterApplicationForm() {
     universityCode.toUpperCase(),
   );
   const [selectedClubId, setSelectedClubId] = useState('');
-  const [userName, setUserName] = useState('');
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [clubs, setClubs] = useState<ClubSummary[]>([]);
 
@@ -49,17 +49,14 @@ function ClubMasterApplicationForm() {
   };
 
   const isValid =
-    selectedUniversityCode !== '' &&
-    selectedClubId !== '' &&
-    userName.trim() !== '' &&
-    isConfirmed;
+    selectedUniversityCode !== '' && selectedClubId !== '' && isConfirmed;
 
   const handleSubmit = async () => {
     setIsSubmitting(true);
     const result = await postClubMasterApplication({
       universityCode: selectedUniversityCode,
       clubId: Number(selectedClubId),
-      userName: userName.trim(),
+      userName: session?.user?.name ?? null,
     });
     setIsSubmitting(false);
     if (result.ok) {
@@ -125,19 +122,6 @@ function ClubMasterApplicationForm() {
             ))}
           </SelectContent>
         </Select>
-      </div>
-
-      <div className="flex flex-col gap-1.5">
-        <label htmlFor="master-name" className="text-sm">
-          이름
-        </label>
-        <Input
-          id="master-name"
-          placeholder="홍길동"
-          value={userName}
-          onChange={(e) => setUserName(e.target.value)}
-          className="rounded-lg border border-[#D6D6D6] bg-white px-4 py-3 text-sm placeholder:text-[#C0C0C0]"
-        />
       </div>
 
       <div className="flex flex-col gap-3">

--- a/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
+++ b/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'react-toastify';
+import useUniversityCode from '@/shared/hooks/useUniversityCode';
+import Input from '@/shared/ui/input';
+import { Button } from '@/shared/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/ui/select';
+import getClubsByUniversity from '../api/getClubsByUniversity';
+import postClubMasterApplication from '../api/postClubMasterApplication';
+import type { ClubOption } from '../model/type';
+
+function ClubMasterApplicationForm() {
+  const router = useRouter();
+  const universityCode = useUniversityCode();
+  const [isPending, startTransition] = useTransition();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const [selectedUniversityCode, setSelectedUniversityCode] = useState('');
+  const [selectedClubId, setSelectedClubId] = useState('');
+  const [userName, setUserName] = useState('');
+  const [isConfirmed, setIsConfirmed] = useState(false);
+  const [clubs, setClubs] = useState<ClubOption[]>([]);
+
+  const handleUniversityChange = (value: string) => {
+    setSelectedUniversityCode(value);
+    setSelectedClubId('');
+    startTransition(async () => {
+      const result = await getClubsByUniversity(value);
+      setClubs(result);
+    });
+  };
+
+  const isValid =
+    selectedUniversityCode !== '' &&
+    selectedClubId !== '' &&
+    userName.trim() !== '' &&
+    isConfirmed;
+
+  const handleSubmit = async () => {
+    setIsSubmitting(true);
+    const result = await postClubMasterApplication({
+      universityCode: selectedUniversityCode,
+      clubId: Number(selectedClubId),
+      userName: userName.trim(),
+    });
+    setIsSubmitting(false);
+    if (result.ok) {
+      toast.success(
+        <span>
+          제출되었습니다.
+          <br />
+          마이페이지에서 현황을 확인하실 수 있습니다.
+        </span>,
+      );
+      router.push(`/${universityCode}/my`);
+    } else {
+      toast.error(result.message);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6 py-8">
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="master-school" className="text-sm">
+          학교
+        </label>
+        <Select
+          value={selectedUniversityCode}
+          onValueChange={handleUniversityChange}
+        >
+          <SelectTrigger
+            id="master-school"
+            className="h-auto w-full rounded-lg border border-[#D6D6D6] bg-white py-5 indent-1.5 text-sm transition-colors duration-200 focus:border-[#00E457] data-[placeholder]:text-[#9C9C9C]"
+          >
+            <SelectValue placeholder="모꼬지대학교" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="SEJONG">세종대학교</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="master-club" className="text-sm">
+          동아리
+        </label>
+        <Select
+          value={selectedClubId}
+          onValueChange={setSelectedClubId}
+          disabled={!selectedUniversityCode || isPending}
+        >
+          <SelectTrigger
+            id="master-club"
+            className="h-auto w-full rounded-lg border border-[#D6D6D6] bg-white py-5 indent-1.5 text-sm transition-colors duration-200 focus:border-[#00E457] disabled:opacity-50 data-[placeholder]:text-[#9C9C9C]"
+          >
+            <SelectValue
+              placeholder={
+                isPending ? '불러오는 중...' : '동아리를 선택해주세요'
+              }
+            />
+          </SelectTrigger>
+          <SelectContent>
+            {clubs.map((club) => (
+              <SelectItem key={club.id} value={String(club.id)}>
+                {club.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="master-name" className="text-sm">
+          실명
+        </label>
+        <Input
+          id="master-name"
+          placeholder="김세종"
+          value={userName}
+          onChange={(e) => setUserName(e.target.value)}
+          className="rounded-lg border border-[#D6D6D6] bg-white px-4 py-3 text-sm placeholder:text-[#C0C0C0]"
+        />
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <p className="text-sm leading-relaxed text-[#474747]">
+          신청 전, 해당 동아리에 실제로 소속되어 있는지 확인해주세요.
+          <br />
+          허위 신청 시 승인이 제한될 수 있습니다.
+        </p>
+        <label className="flex cursor-pointer items-center gap-2">
+          <input
+            type="checkbox"
+            checked={isConfirmed}
+            onChange={() => setIsConfirmed(!isConfirmed)}
+            className="h-4 w-4 cursor-pointer"
+          />
+          <span className="text-sm text-[#474747]">확인했어요.</span>
+        </label>
+      </div>
+
+      <Button
+        type="button"
+        variant="submit-default"
+        disabled={!isValid || isSubmitting}
+        onClick={handleSubmit}
+        className="mt-2 rounded-xl bg-[#4AF38A] py-6 font-normal text-[#474747] disabled:text-white"
+      >
+        {isSubmitting ? '제출 중...' : '신청하기'}
+      </Button>
+    </div>
+  );
+}
+
+export default ClubMasterApplicationForm;

--- a/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
+++ b/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
@@ -88,7 +88,7 @@ function ClubMasterApplicationForm() {
         >
           <SelectTrigger
             id="master-school"
-            className="h-auto w-full rounded-lg border border-[#D6D6D6] bg-white py-5 indent-1.5 text-sm transition-colors duration-200 focus:border-[#00E457] data-[placeholder]:text-[#9C9C9C]"
+            className="h-auto w-full rounded-lg border border-[#D6D6D6] bg-white py-3 indent-1.5 text-sm transition-colors duration-200 focus:border-[#00E457] data-[placeholder]:text-[#9C9C9C]"
           >
             <SelectValue placeholder="모꼬지대학교" />
           </SelectTrigger>
@@ -109,7 +109,7 @@ function ClubMasterApplicationForm() {
         >
           <SelectTrigger
             id="master-club"
-            className="h-auto w-full rounded-lg border border-[#D6D6D6] bg-white py-5 indent-1.5 text-sm transition-colors duration-200 focus:border-[#00E457] disabled:opacity-50 data-[placeholder]:text-[#9C9C9C]"
+            className="h-auto w-full rounded-lg border border-[#D6D6D6] bg-white py-3 indent-1.5 text-sm transition-colors duration-200 focus:border-[#00E457] disabled:opacity-50 data-[placeholder]:text-[#9C9C9C]"
           >
             <SelectValue
               placeholder={
@@ -117,7 +117,7 @@ function ClubMasterApplicationForm() {
               }
             />
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent viewportClassName="h-auto max-h-48 overflow-y-auto">
             {clubs.map((club) => (
               <SelectItem key={club.id} value={String(club.id)}>
                 {club.name}
@@ -129,11 +129,11 @@ function ClubMasterApplicationForm() {
 
       <div className="flex flex-col gap-1.5">
         <label htmlFor="master-name" className="text-sm">
-          실명
+          이름
         </label>
         <Input
           id="master-name"
-          placeholder="김세종"
+          placeholder="홍길동"
           value={userName}
           onChange={(e) => setUserName(e.target.value)}
           className="rounded-lg border border-[#D6D6D6] bg-white px-4 py-3 text-sm placeholder:text-[#C0C0C0]"

--- a/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
+++ b/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
@@ -69,6 +69,26 @@ function ClubMasterApplicationForm() {
   return (
     <div className="flex flex-col gap-6 py-8">
       <div className="flex flex-col gap-1.5">
+        <label htmlFor="master-school" className="text-sm">
+          학교
+        </label>
+        <Select
+          value={selectedUniversityCode}
+          onValueChange={handleUniversityChange}
+        >
+          <SelectTrigger
+            id="master-school"
+            className="h-auto w-full rounded-lg border border-[#D6D6D6] bg-white py-5 indent-1.5 text-sm transition-colors duration-200 focus:border-[#00E457] data-[placeholder]:text-[#9C9C9C]"
+          >
+            <SelectValue placeholder="모꼬지대학교" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="SEJONG">세종대학교</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
         <label htmlFor="master-club" className="text-sm">
           동아리명
         </label>
@@ -93,26 +113,6 @@ function ClubMasterApplicationForm() {
                 {club.name}
               </SelectItem>
             ))}
-          </SelectContent>
-        </Select>
-      </div>
-
-      <div className="flex flex-col gap-1.5">
-        <label htmlFor="master-school" className="text-sm">
-          학교
-        </label>
-        <Select
-          value={selectedUniversityCode}
-          onValueChange={handleUniversityChange}
-        >
-          <SelectTrigger
-            id="master-school"
-            className="h-auto w-full rounded-lg border border-[#D6D6D6] bg-white py-5 indent-1.5 text-sm transition-colors duration-200 focus:border-[#00E457] data-[placeholder]:text-[#9C9C9C]"
-          >
-            <SelectValue placeholder="모꼬지대학교" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="SEJONG">세종대학교</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
+++ b/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
@@ -69,28 +69,8 @@ function ClubMasterApplicationForm() {
   return (
     <div className="flex flex-col gap-6 py-8">
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="master-school" className="text-sm">
-          학교
-        </label>
-        <Select
-          value={selectedUniversityCode}
-          onValueChange={handleUniversityChange}
-        >
-          <SelectTrigger
-            id="master-school"
-            className="h-auto w-full rounded-lg border border-[#D6D6D6] bg-white py-5 indent-1.5 text-sm transition-colors duration-200 focus:border-[#00E457] data-[placeholder]:text-[#9C9C9C]"
-          >
-            <SelectValue placeholder="모꼬지대학교" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="SEJONG">세종대학교</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-
-      <div className="flex flex-col gap-1.5">
         <label htmlFor="master-club" className="text-sm">
-          동아리
+          동아리명
         </label>
         <Select
           value={selectedClubId}
@@ -113,6 +93,26 @@ function ClubMasterApplicationForm() {
                 {club.name}
               </SelectItem>
             ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="master-school" className="text-sm">
+          학교
+        </label>
+        <Select
+          value={selectedUniversityCode}
+          onValueChange={handleUniversityChange}
+        >
+          <SelectTrigger
+            id="master-school"
+            className="h-auto w-full rounded-lg border border-[#D6D6D6] bg-white py-5 indent-1.5 text-sm transition-colors duration-200 focus:border-[#00E457] data-[placeholder]:text-[#9C9C9C]"
+          >
+            <SelectValue placeholder="모꼬지대학교" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="SEJONG">세종대학교</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
+++ b/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/shared/ui/select';
 import getClubsByUniversity from '../api/getClubsByUniversity';
 import postClubMasterApplication from '../api/postClubMasterApplication';
-import type { ClubOption } from '../model/type';
+import type { ClubSummary } from '../model/type';
 
 function ClubMasterApplicationForm() {
   const router = useRouter();
@@ -29,7 +29,7 @@ function ClubMasterApplicationForm() {
   const [selectedClubId, setSelectedClubId] = useState('');
   const [userName, setUserName] = useState('');
   const [isConfirmed, setIsConfirmed] = useState(false);
-  const [clubs, setClubs] = useState<ClubOption[]>([]);
+  const [clubs, setClubs] = useState<ClubSummary[]>([]);
 
   useEffect(() => {
     getClubsByUniversity(universityCode.toUpperCase()).then((result) => {

--- a/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
+++ b/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
@@ -20,21 +20,31 @@ import type { ClubOption } from '../model/type';
 function ClubMasterApplicationForm() {
   const router = useRouter();
   const universityCode = useUniversityCode();
-  const [isPending, startTransition] = useTransition();
+  const [isClubsLoading, setIsClubsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const [selectedUniversityCode, setSelectedUniversityCode] = useState('');
+  const [selectedUniversityCode, setSelectedUniversityCode] = useState(
+    universityCode.toUpperCase(),
+  );
   const [selectedClubId, setSelectedClubId] = useState('');
   const [userName, setUserName] = useState('');
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [clubs, setClubs] = useState<ClubOption[]>([]);
 
+  useEffect(() => {
+    getClubsByUniversity(universityCode.toUpperCase()).then((result) => {
+      setClubs(result);
+      setIsClubsLoading(false);
+    });
+  }, [universityCode]);
+
   const handleUniversityChange = (value: string) => {
     setSelectedUniversityCode(value);
     setSelectedClubId('');
-    startTransition(async () => {
-      const result = await getClubsByUniversity(value);
+    setIsClubsLoading(true);
+    getClubsByUniversity(value).then((result) => {
       setClubs(result);
+      setIsClubsLoading(false);
     });
   };
 
@@ -95,7 +105,7 @@ function ClubMasterApplicationForm() {
         <Select
           value={selectedClubId}
           onValueChange={setSelectedClubId}
-          disabled={!selectedUniversityCode || isPending}
+          disabled={!selectedUniversityCode || isClubsLoading}
         >
           <SelectTrigger
             id="master-club"
@@ -103,7 +113,7 @@ function ClubMasterApplicationForm() {
           >
             <SelectValue
               placeholder={
-                isPending ? '불러오는 중...' : '동아리를 선택해주세요'
+                isClubsLoading ? '불러오는 중...' : '동아리를 선택해주세요'
               }
             />
           </SelectTrigger>

--- a/src/shared/lib/error-message.ts
+++ b/src/shared/lib/error-message.ts
@@ -21,7 +21,7 @@ function getHttpErrorMessage(status: number) {
 
 async function readServerMessage(error: HTTPError): Promise<string | null> {
   try {
-    const body = (await error.response.clone().json()) as { message?: string };
+    const body = (await error.response.json()) as { message?: string };
     return body.message ?? null;
   } catch {
     return null;
@@ -36,18 +36,13 @@ interface CustomErrorMapping {
 async function createErrorResponse(
   error: Error,
   customErrArray?: CustomErrorMapping[],
-  useServerMessageFor?: number[],
 ) {
   if (error instanceof HTTPError) {
     const { status } = error.response;
-
-    if (useServerMessageFor?.includes(status)) {
-      const serverMessage = await readServerMessage(error);
-      if (serverMessage) {
-        return { ok: false, message: serverMessage, data: undefined, status };
-      }
+    const serverMessage = await readServerMessage(error);
+    if (serverMessage) {
+      return { ok: false, message: serverMessage, data: undefined, status };
     }
-
     const customMessage = customErrArray?.find(
       (item) => item.status === status,
     );

--- a/src/shared/lib/error-message.ts
+++ b/src/shared/lib/error-message.ts
@@ -1,25 +1,31 @@
 import { HTTPError } from 'ky';
 
-function getHttpErrorMessage(error: Error) {
-  if (error instanceof HTTPError) {
-    switch (error.response.status) {
-      case 400:
-        return '잘못된 요청입니다.';
-      case 401:
-        return '로그인이 필요합니다.';
-      case 403:
-        return '권한이 없습니다.';
-      case 404:
-        return '요청한 자원을 찾을 수 없습니다.';
-      case 409:
-        return '이미 등록된 동아리입니다.';
-      case 500:
-        return '서버 오류가 발생했습니다. 다시 시도해주세요.';
-      default:
-        return '알 수 없는 오류가 발생했습니다. 다시 시도해주세요.';
-    }
+function getHttpErrorMessage(status: number) {
+  switch (status) {
+    case 400:
+      return '잘못된 요청입니다.';
+    case 401:
+      return '로그인이 필요합니다.';
+    case 403:
+      return '권한이 없습니다.';
+    case 404:
+      return '요청한 자원을 찾을 수 없습니다.';
+    case 409:
+      return '이미 등록된 동아리입니다.';
+    case 500:
+      return '서버 오류가 발생했습니다. 다시 시도해주세요.';
+    default:
+      return '알 수 없는 오류가 발생했습니다. 다시 시도해주세요.';
   }
-  return '알 수 없는 오류가 발생했습니다. 다시 시도해주세요.';
+}
+
+async function readServerMessage(error: HTTPError): Promise<string | null> {
+  try {
+    const body = (await error.response.clone().json()) as { message?: string };
+    return body.message ?? null;
+  } catch {
+    return null;
+  }
 }
 
 interface CustomErrorMapping {
@@ -27,27 +33,29 @@ interface CustomErrorMapping {
   message: string;
 }
 
-function createErrorResponse(
+async function createErrorResponse(
   error: Error,
   customErrArray?: CustomErrorMapping[],
+  useServerMessageFor?: number[],
 ) {
   if (error instanceof HTTPError) {
-    if (customErrArray) {
-      const customMessage = customErrArray.find(
-        (item) => item.status === error.response.status,
-      );
-      return {
-        ok: false,
-        message: customMessage?.message || getHttpErrorMessage(error),
-        data: undefined,
-        status: error.response.status,
-      };
+    const { status } = error.response;
+
+    if (useServerMessageFor?.includes(status)) {
+      const serverMessage = await readServerMessage(error);
+      if (serverMessage) {
+        return { ok: false, message: serverMessage, data: undefined, status };
+      }
     }
+
+    const customMessage = customErrArray?.find(
+      (item) => item.status === status,
+    );
     return {
       ok: false,
-      message: getHttpErrorMessage(error),
+      message: customMessage?.message ?? getHttpErrorMessage(status),
       data: undefined,
-      status: error.response.status,
+      status,
     };
   }
   return {

--- a/src/shared/ui/select.tsx
+++ b/src/shared/ui/select.tsx
@@ -54,8 +54,18 @@ function SelectContent({
   className,
   children,
   position = 'popper',
+  viewportClassName,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+}: React.ComponentProps<typeof SelectPrimitive.Content> & {
+  viewportClassName?: string;
+}) {
+  const viewportRef = React.useRef<HTMLDivElement>(null);
+
+  const handleScrollUp = () =>
+    viewportRef.current?.scrollBy({ top: -36, behavior: 'smooth' });
+  const handleScrollDown = () =>
+    viewportRef.current?.scrollBy({ top: 36, behavior: 'smooth' });
+
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
@@ -69,17 +79,19 @@ function SelectContent({
         position={position}
         {...props}
       >
-        <SelectScrollUpButton />
+        <SelectScrollUpButton onClick={handleScrollUp} />
         <SelectPrimitive.Viewport
+          ref={viewportRef}
           className={cn(
             'p-1',
             position === 'popper' &&
               'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1',
+            viewportClassName,
           )}
         >
           {children}
         </SelectPrimitive.Viewport>
-        <SelectScrollDownButton />
+        <SelectScrollDownButton onClick={handleScrollDown} />
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
   );

--- a/src/widgets/club-application/ui/club-application-tab.tsx
+++ b/src/widgets/club-application/ui/club-application-tab.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import ClubCreateForm from '@/features/club-create/ui/club-crete-form';
+import ClubMasterApplicationForm from '@/features/club-master-application/ui/ClubMasterApplicationForm';
 import { useState } from 'react';
 
 const TABS = [
@@ -45,7 +46,7 @@ function ClubApplicationTabs() {
       <div className="min-h-[600px] w-full">
         {activeTab === 'club-create' && <ClubCreateForm />}
         {activeTab === 'club-leader-application' && (
-          <div>{/* 동아리장 신청 폼 */}</div>
+          <ClubMasterApplicationForm />
         )}
       </div>
     </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

[#531] 

## 📝작업 내용

- `features/club-master-application` 신규 도메인 추가: API(`getClubsByUniversity`, `postClubMasterApplication`), 타입(`ClubMasterApplicationFormData`, `ClubOption`), 폼 컴포넌트(`ClubMasterApplicationForm`) 구현
- `widgets/club-application` 탭 위젯에 "동아리장 등록" 탭 추가 및 `ClubMasterApplicationForm` 연결
- `getClubsByUniversity` API에 `unstable_cache`(1시간 revalidate)를 적용해 동아리 목록 서버 캐시 처리, 컴포넌트 마운트 시 선제 로딩으로 드롭다운 초기화 지연 개선
- `shared/ui/select.tsx` — `SelectContent`에 `viewportClassName` prop 추가 및 스크롤 버튼(`onClick`) 지원으로 동아리 목록 스크롤 조작 가능하도록 수정
- 폼 필드 순서를 학교 → 동아리명 → 이름 순으로 정렬하고 동아리명 레이블 표기 수정
- `club-application` 레이아웃의 `main` 하단 패딩을 `pb-[calc(1.75rem+85px)]`로 조정해 CTA 버튼이 하단 내비게이션 바에 가려지는 버그 수정


### 스크린샷 (선택)

<img width="268" height="581" alt="image" src="https://github.com/user-attachments/assets/27505056-de05-452c-951f-3455912e80d4" />
<img width="255" height="236" alt="image" src="https://github.com/user-attachments/assets/2e9104c4-7ab6-4eb7-b69a-3530817f8a3e" />


## 💬리뷰 요구사항(선택)

동아리 입력은 드롭다운의 형식으로 선택할 수 있도록 제공하였습니다.
추후 관련 변경사항이 있다면 재반영하겠습니다.
