### PR TITLE
refactor: 마이페이지 디자인 수정 및 동아리 생성 신청 카드 구현

### DIFF
--- a/public/chatIcon.svg
+++ b/public/chatIcon.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path
+    fillRule="evenodd"
+    clipRule="evenodd"
+    d="M11 2C6.029 2 2 5.358 2 9.5c0 2.613 1.613 4.913 4.063 6.263L5.25 19.25l4.013-2.65c.572.083 1.158.125 1.737.125 4.971 0 9-3.358 9-7.5S15.971 2 11 2z"
+    fill="#1A1A1A"
+  />
+</svg>

--- a/src/entities/my/api/getClubApplicationStatus.tsx
+++ b/src/entities/my/api/getClubApplicationStatus.tsx
@@ -1,0 +1,24 @@
+import api from '@/shared/api/auth-api';
+import { ApiResponse } from '@/shared/model/type';
+import createErrorResponse from '@/shared/lib/error-message';
+import { ClubApplicationListType } from '../model/type';
+
+async function getClubApplicationStatus() {
+  try {
+    const response: ApiResponse<ClubApplicationListType> = await api
+      .get('club-applications/me', {
+        cache: 'no-store',
+        next: { tags: ['club-applications-me'] },
+      })
+      .json();
+    return {
+      ok: true,
+      data: response.data,
+      status: 200,
+    };
+  } catch (error) {
+    return createErrorResponse(error as Error);
+  }
+}
+
+export default getClubApplicationStatus;

--- a/src/entities/my/model/type.ts
+++ b/src/entities/my/model/type.ts
@@ -7,4 +7,19 @@ interface UserInfoType {
   universityCode: string | null;
 }
 
+export type ClubApplicationStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
+
+export interface ClubApplicationType {
+  clubApplicationId: number;
+  universityName: string;
+  clubName: string;
+  status: ClubApplicationStatus;
+  rejectReason: string | null;
+  createdAt: string;
+}
+
+export interface ClubApplicationListType {
+  clubApplications: ClubApplicationType[];
+}
+
 export default UserInfoType;

--- a/src/entities/my/ui/info-row.tsx
+++ b/src/entities/my/ui/info-row.tsx
@@ -8,7 +8,7 @@ type InfoRowProps = {
 
 export default function InfoRow({ label, value, children }: InfoRowProps) {
   return (
-    <div className="grid grid-cols-[80px_1fr] items-center py-3">
+    <div className="grid grid-cols-[80px_1fr] items-center py-2">
       <span className="text-text-secondary flex text-sm font-bold">
         {label}
       </span>

--- a/src/entities/my/ui/info-row.tsx
+++ b/src/entities/my/ui/info-row.tsx
@@ -8,8 +8,10 @@ type InfoRowProps = {
 
 export default function InfoRow({ label, value, children }: InfoRowProps) {
   return (
-    <div className="grid grid-cols-[80px_1fr] items-center gap-4 py-3">
-      <span className="flex font-bold text-gray-600">{label}</span>
+    <div className="grid grid-cols-[80px_1fr] items-center py-3">
+      <span className="text-text-secondary flex text-sm font-bold">
+        {label}
+      </span>
       <div className="flex flex-col items-start justify-start lg:flex lg:gap-2">
         {value}
         {children}

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -5,14 +5,14 @@ import HeaderAdminLink from '@/features/header/ui/header-admin-link';
 import Image from 'next/image';
 import LoginRequired from '@/shared/ui/login-required';
 import ScrollProgressBar from '@/shared/ui/scroll-progress-bar';
-import getMyInfo from '../api/getMyInfo';
-import getClubApplicationStatus from '../api/getClubApplicationStatus';
-import InfoRow from './info-row';
-import EmailChangeDialog from '../../../features/my/ui/email-change-dialog';
-import EmailDeleteButton from '../../../features/my/ui/email-delete-button';
-import MailNotificationToggle from '../../../features/my/ui/mail-notification-toggle';
-import LogoutLink from '../../../features/my/ui/logout-link';
-import ClubApplicationStatus from '../../../features/my/ui/club-application-status';
+import getMyInfo from '@/entities/my/api/getMyInfo';
+import getClubApplicationStatus from '@/entities/my/api/getClubApplicationStatus';
+import InfoRow from '@/entities/my/ui/info-row';
+import EmailChangeDialog from '@/features/my/ui/email-change-dialog';
+import EmailDeleteButton from '@/features/my/ui/email-delete-button';
+import MailNotificationToggle from '@/features/my/ui/mail-notification-toggle';
+import LogoutLink from '@/features/my/ui/logout-link';
+import ClubApplicationStatus from '@/features/my/ui/club-application-status';
 
 async function MyPage() {
   const session = await getSession();

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -87,7 +87,7 @@ async function MyPage() {
             </div>
           )}
 
-          <div className="py-4 lg:hidden">
+          <div className="mb-15 py-4 lg:hidden">
             <LogoutLink />
           </div>
         </div>

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -36,9 +36,9 @@ async function MyPage() {
   const isAdmin = userRole !== UserRole.NORMAL;
 
   return (
-    <div className="flex flex-col items-center px-4">
+    <>
       <ScrollProgressBar />
-      <div className="w-full">
+      <div className="mx-auto w-full px-4 sm:w-lg">
         <div className="mb-6 flex flex-col gap-2">
           <div className="text-text-secondary">{user.name}</div>
           <div className="flex w-[130px] items-center gap-2 rounded-full bg-[#FEE500] px-3 py-2.5">
@@ -92,7 +92,7 @@ async function MyPage() {
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -6,11 +6,13 @@ import Image from 'next/image';
 import LoginRequired from '@/shared/ui/login-required';
 import ScrollProgressBar from '@/shared/ui/scroll-progress-bar';
 import getMyInfo from '../api/getMyInfo';
+import getClubApplicationStatus from '../api/getClubApplicationStatus';
 import InfoRow from './info-row';
 import EmailChangeDialog from '../../../features/my/ui/email-change-dialog';
 import EmailDeleteButton from '../../../features/my/ui/email-delete-button';
 import MailNotificationToggle from '../../../features/my/ui/mail-notification-toggle';
 import LogoutLink from '../../../features/my/ui/logout-link';
+import ClubApplicationStatus from '../../../features/my/ui/club-application-status';
 
 async function MyPage() {
   const session = await getSession();
@@ -19,13 +21,17 @@ async function MyPage() {
     return <LoginRequired />;
   }
 
-  const myInfo = await getMyInfo();
+  const [myInfo, clubApplicationStatus] = await Promise.all([
+    getMyInfo(),
+    getClubApplicationStatus(),
+  ]);
 
   if (!myInfo.ok || !myInfo.data) {
     return <ErrorBoundaryUi />;
   }
 
   const user = myInfo.data;
+  const clubApplications = clubApplicationStatus.data?.clubApplications ?? [];
   const userRole = session?.role || UserRole.NORMAL;
   const isAdmin = userRole !== UserRole.NORMAL;
 
@@ -51,6 +57,11 @@ async function MyPage() {
             <span className="text-sm text-neutral-900">카카오 로그인</span>
           </div>
         </div>
+
+        {clubApplications.length > 0 && (
+          <ClubApplicationStatus applications={clubApplications} />
+        )}
+
         <div className="flex flex-col">
           <span className="mb-4 font-semibold">내 정보</span>
           <InfoRow label="이메일" value={user.email}>

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -42,18 +42,7 @@ async function MyPage() {
         <div className="mb-8 flex flex-col gap-2">
           <div className="text-text-secondary">{user.name}</div>
           <div className="flex w-[130px] items-center gap-2 rounded-full bg-[#FEE500] px-3 py-2.5">
-            <svg
-              className="left-4 h-4 w-4 shrink-0"
-              viewBox="0 0 22 22"
-              fill="none"
-            >
-              <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M11 2C6.029 2 2 5.358 2 9.5c0 2.613 1.613 4.913 4.063 6.263L5.25 19.25l4.013-2.65c.572.083 1.158.125 1.737.125 4.971 0 9-3.358 9-7.5S15.971 2 11 2z"
-                fill="#1A1A1A"
-              />
-            </svg>
+            <Image src="/chatIcon.svg" alt="챗아이콘" width={16} height={16} />
             <span className="text-sm text-neutral-900">카카오 로그인</span>
           </div>
         </div>

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -33,8 +33,26 @@ async function MyPage() {
     <div className="flex flex-col items-center px-4">
       <ScrollProgressBar />
       <div className="w-full">
-        <div>
-          <InfoRow label="이름" value={user.name} />
+        <div className="mb-6 flex flex-col gap-2">
+          <div className="text-text-secondary">{user.name}</div>
+          <div className="flex w-[130px] items-center gap-2 rounded-full bg-[#FEE500] px-3 py-2.5">
+            <svg
+              className="left-4 h-4 w-4 shrink-0"
+              viewBox="0 0 22 22"
+              fill="none"
+            >
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M11 2C6.029 2 2 5.358 2 9.5c0 2.613 1.613 4.913 4.063 6.263L5.25 19.25l4.013-2.65c.572.083 1.158.125 1.737.125 4.971 0 9-3.358 9-7.5S15.971 2 11 2z"
+                fill="#1A1A1A"
+              />
+            </svg>
+            <span className="text-sm text-neutral-900">카카오 로그인</span>
+          </div>
+        </div>
+        <div className="flex flex-col">
+          <span className="mb-4 font-semibold">내 정보</span>
           <InfoRow label="이메일" value={user.email}>
             <div className="flex items-center gap-3">
               <EmailChangeDialog

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -39,7 +39,7 @@ async function MyPage() {
     <>
       <ScrollProgressBar />
       <div className="mx-auto w-full px-4 sm:w-lg">
-        <div className="mb-6 flex flex-col gap-2">
+        <div className="mb-8 flex flex-col gap-2">
           <div className="text-text-secondary">{user.name}</div>
           <div className="flex w-[130px] items-center gap-2 rounded-full bg-[#FEE500] px-3 py-2.5">
             <svg

--- a/src/features/my/ui/club-application-card.tsx
+++ b/src/features/my/ui/club-application-card.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useState } from 'react';
+import dayjs from 'dayjs';
+import { ClubApplicationType } from '@/entities/my/model/type';
+
+type ClubApplicationCardProps = {
+  application: ClubApplicationType;
+};
+
+function ClubApplicationCard({ application }: ClubApplicationCardProps) {
+  const [showRejectReason, setShowRejectReason] = useState(false);
+  const { clubName, universityName, status, createdAt, rejectReason } =
+    application;
+
+  return (
+    <li className="flex flex-col gap-3 rounded-2xl border-2 border-[#22CF64] p-4">
+      <div className="flex flex-col gap-1">
+        <span className="text-xl font-semibold">
+          {clubName}{' '}
+          <span className="text-text-tertiary text-lg">{universityName}</span>
+        </span>
+        <span className="text-text-tertiary text-sm">
+          신청일시 | {dayjs(createdAt).format('YYYY.MM.DD')}
+        </span>
+      </div>
+
+      <div className="h-0.5 w-full rounded-full bg-[#f8f8f8]">
+        <div
+          className={`bg-gradient-primary h-1 rounded-full ${
+            status === 'PENDING' ? 'w-1/2' : 'w-full'
+          }`}
+        />
+      </div>
+
+      <div className="mx-2 flex items-center justify-between">
+        <span
+          className={`text-sm ${
+            status === 'PENDING' ? 'text-[#22CF64]' : 'text-text-tertiary'
+          }`}
+        >
+          승인 대기
+        </span>
+
+        {status === 'PENDING' && (
+          <span className="text-text-tertiary text-sm">승인/반려</span>
+        )}
+
+        {status === 'APPROVED' && (
+          <span className="rounded-full border border-[#22CF64] px-3 py-1 text-xs text-[#22CF64]">
+            승인
+          </span>
+        )}
+
+        {status === 'REJECTED' && (
+          <div className="flex items-center gap-2">
+            <span className="text-alert-500 border-alert-500 rounded-full border px-3 py-1 text-xs">
+              반려
+            </span>
+            <button
+              type="button"
+              onClick={() => setShowRejectReason((prev) => !prev)}
+              className="text-text-tertiary text-xs underline"
+            >
+              반려 사유 확인
+            </button>
+          </div>
+        )}
+      </div>
+
+      {status === 'REJECTED' && showRejectReason && rejectReason && (
+        <span className="text-alert-500 text-xs">{rejectReason}</span>
+      )}
+    </li>
+  );
+}
+
+export default ClubApplicationCard;

--- a/src/features/my/ui/club-application-card.tsx
+++ b/src/features/my/ui/club-application-card.tsx
@@ -1,22 +1,40 @@
 'use client';
 
-import { useState } from 'react';
 import dayjs from 'dayjs';
-import { ClubApplicationType } from '@/entities/my/model/type';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/shared/ui/dialog';
+import { Button } from '@/shared/ui/button';
+import {
+  ClubApplicationStatus as ClubApplicationStatusType,
+  ClubApplicationType,
+} from '@/entities/my/model/type';
+
+const ClubApplicationStatusLabel: Record<ClubApplicationStatusType, string> = {
+  PENDING: '승인 대기',
+  APPROVED: '승인 완료',
+  REJECTED: '반려 완료',
+};
 
 type ClubApplicationCardProps = {
   application: ClubApplicationType;
 };
 
 function ClubApplicationCard({ application }: ClubApplicationCardProps) {
-  const [showRejectReason, setShowRejectReason] = useState(false);
   const { clubName, universityName, status, createdAt, rejectReason } =
     application;
 
   return (
-    <li className="flex flex-col gap-3 rounded-2xl border-2 border-[#22CF64] p-4">
+    <li className="flex flex-col gap-3 rounded-2xl border border-[#22CF64] p-4">
       <div className="flex flex-col gap-1">
-        <span className="text-xl font-semibold">
+        <span className="font-semibold">
           {clubName}{' '}
           <span className="text-text-tertiary text-lg">{universityName}</span>
         </span>
@@ -57,20 +75,46 @@ function ClubApplicationCard({ application }: ClubApplicationCardProps) {
             <span className="text-alert-500 border-alert-500 rounded-full border px-3 py-1 text-xs">
               반려
             </span>
-            <button
-              type="button"
-              onClick={() => setShowRejectReason((prev) => !prev)}
-              className="text-text-tertiary text-xs underline"
-            >
-              반려 사유 확인
-            </button>
+            <Dialog>
+              <DialogTrigger asChild>
+                <button
+                  type="button"
+                  className="text-text-tertiary text-xs underline"
+                >
+                  반려 사유 확인
+                </button>
+              </DialogTrigger>
+              <DialogContent
+                aria-describedby="reject-reason-description"
+                className="w-[400px] rounded-2xl"
+              >
+                <DialogHeader>
+                  <DialogTitle className="flex items-start font-semibold">
+                    반려 사유
+                  </DialogTitle>
+                </DialogHeader>
+                <DialogDescription
+                  id="reject-reason-description"
+                  className="text-text-secondary text-sm"
+                >
+                  {rejectReason}
+                </DialogDescription>
+                <DialogFooter>
+                  <DialogClose asChild>
+                    <Button
+                      type="button"
+                      variant="submit-default"
+                      className="mt-2 rounded-xl bg-[#4AF38A] py-6 font-normal text-[#474747] disabled:text-white"
+                    >
+                      확인
+                    </Button>
+                  </DialogClose>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
           </div>
         )}
       </div>
-
-      {status === 'REJECTED' && showRejectReason && rejectReason && (
-        <span className="text-alert-500 text-xs">{rejectReason}</span>
-      )}
     </li>
   );
 }

--- a/src/features/my/ui/club-application-card.tsx
+++ b/src/features/my/ui/club-application-card.tsx
@@ -12,16 +12,7 @@ import {
   DialogTrigger,
 } from '@/shared/ui/dialog';
 import { Button } from '@/shared/ui/button';
-import {
-  ClubApplicationStatus as ClubApplicationStatusType,
-  ClubApplicationType,
-} from '@/entities/my/model/type';
-
-const ClubApplicationStatusLabel: Record<ClubApplicationStatusType, string> = {
-  PENDING: '승인 대기',
-  APPROVED: '승인 완료',
-  REJECTED: '반려 완료',
-};
+import { ClubApplicationType } from '@/entities/my/model/type';
 
 type ClubApplicationCardProps = {
   application: ClubApplicationType;

--- a/src/features/my/ui/club-application-status.tsx
+++ b/src/features/my/ui/club-application-status.tsx
@@ -1,0 +1,24 @@
+import { ClubApplicationType } from '@/entities/my/model/type';
+import ClubApplicationCard from './club-application-card';
+
+type ClubApplicationStatusProps = {
+  applications: ClubApplicationType[];
+};
+
+function ClubApplicationStatus({ applications }: ClubApplicationStatusProps) {
+  return (
+    <div className="mb-10 flex flex-col gap-3">
+      <div className="font-semibold">신청 현황</div>
+      <ul className="flex flex-col gap-3">
+        {applications.map((application) => (
+          <ClubApplicationCard
+            key={application.clubApplicationId}
+            application={application}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default ClubApplicationStatus;

--- a/src/features/my/ui/mail-notification-toggle.tsx
+++ b/src/features/my/ui/mail-notification-toggle.tsx
@@ -47,7 +47,7 @@ export default function MailNotificationToggle({
         aria-label="메일 알림 설정"
         onClick={handleToggle}
         className={`relative h-7 w-14 rounded-full p-1 transition-colors ${
-          enabled ? 'bg-[#00E457]' : 'bg-gray-300'
+          enabled ? 'bg-[#4AF38A]' : 'bg-gray-300'
         }`}
       >
         <span

--- a/src/views/login/kakao-login-page.tsx
+++ b/src/views/login/kakao-login-page.tsx
@@ -42,18 +42,7 @@ export default function KakaoLoginPage() {
           onClick={handleKakaoLogin}
           className="relative flex w-full items-center justify-center rounded-2xl bg-[#FEE500] py-4 transition-all active:scale-[0.985] active:bg-[#F0D900]"
         >
-          <svg
-            className="absolute left-4 h-5 w-5 shrink-0"
-            viewBox="0 0 22 22"
-            fill="none"
-          >
-            <path
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M11 2C6.029 2 2 5.358 2 9.5c0 2.613 1.613 4.913 4.063 6.263L5.25 19.25l4.013-2.65c.572.083 1.158.125 1.737.125 4.971 0 9-3.358 9-7.5S15.971 2 11 2z"
-              fill="#1A1A1A"
-            />
-          </svg>
+          <Image src="/chatIcon.svg" alt="챗아이콘" width={16} height={16} />
           <span className="text-base font-semibold tracking-tight text-neutral-900">
             카카오톡으로 시작하기
           </span>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #529 

## 📝작업 내용

- 동아리 생성신청을 한 경우 동아리 신청 카드가 뜨도록 구현했습니다.
-> 신청 이력을 가져와야 상태를 보여줄 수 있어 비지니스 로직이라 판단하여 features 폴더에 추가로 생성하였습니다. 
- 그 외에도 변경된 레이아웃과 디자인에 맞춰 수정했습니다. 

### 스크린샷 (선택)
<img width="310" height="676" alt="image" src="https://github.com/user-attachments/assets/8e2eaa30-51dd-4dd4-a7a0-f86cce7c3416" />


## 💬리뷰 요구사항(선택)

- 디자이너님이 만들어주신 디자인에는 해당 동아리의 로고와 분류가 있었는데 백엔드에서 내려주는 정보에는 로고와 분류가 없어서 로고는 제거하고 분류 대신 학교명을 띄우도록 수정했습니다. (동아리명은 제가 신청시에 아무거나 적는다고 아하라고 쳤어요...!)
- 이름이 dd로 뜨는데 이건 창우님이 진행해주신 작업 코드리뷰 시 동아리장 신청자명에 dd라고 막 쳤다가 변경이 되어버렸습니다...

