### PR TITLE
fix: 카카오 로그인 콜백 요청 시 Origin 헤더 추가

### DIFF
--- a/src/app/api/auth/callback/kakao/route.ts
+++ b/src/app/api/auth/callback/kakao/route.ts
@@ -20,8 +20,11 @@ export async function GET(request: NextRequest) {
   }
 
   try {
+    // eslint-disable-next-line no-console
+    console.log('[callback] Origin header:', process.env.NEXT_PUBLIC_BASE_URL);
     const loginResponse = await serverApi.post('users/auth/kakao', {
       json: { code },
+      headers: { Origin: process.env.NEXT_PUBLIC_BASE_URL },
     });
 
     const loginResponseBody: LoginSuccessResponse = await loginResponse.json();

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -88,14 +88,14 @@ async function MyPage({ isNewUser = false }: { isNewUser?: boolean }) {
                 : undefined
             }
           />
-          <div className="py-6">
+          <div className="pt-6">
             <UniversitySelectModalWrapper
               defaultOpen={isNewUser}
               universityCode={user.universityCode}
               universities={universities}
             />
           </div>
-          <div className="mb-15 py-4 lg:hidden">
+          <div className="mb-15 lg:hidden">
             <LogoutLink />
           </div>
         </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #542 

## 📝작업 내용

로컬(http://localhost:3000)에서 카카오 로그인 시 백엔드 500 에러 발생, 로그인 불가한 이슈를 해결했습니다.

기존에 백엔드가 `redirect_uri`를 하드코딩된 값으로 사용하던 방식에서 Origin 헤더를 기반으로 동적 생성하는 방식으로 변경되었습니다.
그러나 Next.js API Route(서버 사이드) 환경에서는 Origin 헤더가 자동으로 포함되지 않아 로컬 카카오 로그인 시 500 에러가 발생했고 프론트에서 Origin 헤더를 직접 추가하도록 수정하여 이슈를 해결했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

추가로 환경변수가 추가되어 디코로 전달 드리겠습니다 !
