### PR TITLE
feat: 학교 변경 시 즐겨찾기 삭제 확인 팝업 및 안내 문구 추가

### DIFF
--- a/src/widgets/login/ui/university-select-modal-wrapper.tsx
+++ b/src/widgets/login/ui/university-select-modal-wrapper.tsx
@@ -5,6 +5,15 @@ import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import type { University } from '@/entities/university/model/type';
 import patchUniversityCode from '@/features/my/api/patchUniversityCode';
+import { Button } from '@/shared/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/shared/ui/dialog';
 import UniversitySelectModal from './university-select-modal';
 
 interface UniversitySelectModalWrapperProps {
@@ -21,6 +30,29 @@ function UniversitySelectModalWrapper({
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const [isLoading, setIsLoading] = useState(false);
+  const [pendingCode, setPendingCode] = useState<string | null>(null);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+  const applyUniversityChange = async (code: string | null) => {
+    setIsLoading(true);
+    await patchUniversityCode(code);
+    setIsLoading(false);
+    setIsConfirmOpen(false);
+    setIsOpen(false);
+    router.refresh();
+  };
+
+  const handleConfirm = (code: string) => {
+    const normalizedCode = code === 'NONE' ? null : code;
+
+    if (normalizedCode === universityCode) {
+      setIsOpen(false);
+      return;
+    }
+
+    setPendingCode(normalizedCode);
+    setIsConfirmOpen(true);
+  };
 
   return (
     <>
@@ -38,14 +70,48 @@ function UniversitySelectModalWrapper({
         isLoading={isLoading}
         universities={universities}
         universityCode={universityCode}
-        onConfirm={async (code) => {
-          setIsLoading(true);
-          await patchUniversityCode(code === 'NONE' ? null : code);
-          setIsLoading(false);
-          setIsOpen(false);
-          router.refresh();
-        }}
+        onConfirm={handleConfirm}
       />
+
+      <Dialog open={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
+        <DialogContent
+          aria-describedby="university-change-desc"
+          className="w-[360px] rounded-2xl"
+        >
+          <DialogHeader>
+            <DialogTitle className="font-semibold">
+              학교를 변경할까요?
+            </DialogTitle>
+            <DialogDescription
+              id="university-change-desc"
+              className="text-text-secondary text-sm"
+            >
+              학교를 변경하면 기존 즐겨찾기가 모두 삭제됩니다. 계속하시겠어요?
+            </DialogDescription>
+          </DialogHeader>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              className="flex-1"
+              disabled={isLoading}
+              onClick={() => setIsConfirmOpen(false)}
+            >
+              취소
+            </Button>
+            <Button
+              type="button"
+              variant="submit-default"
+              className="flex-1"
+              disabled={isLoading}
+              onClick={() => applyUniversityChange(pendingCode)}
+            >
+              {isLoading ? '변경 중…' : '변경하기'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/src/widgets/login/ui/university-select-modal.tsx
+++ b/src/widgets/login/ui/university-select-modal.tsx
@@ -39,9 +39,12 @@ function UniversitySelectModal({
           isOpen ? 'translate-y-0' : 'translate-y-full',
         )}
       >
-        <h1 className="text-text-primary mb-6 text-center text-lg font-semibold">
+        <h1 className="text-text-primary mb-2 text-center text-lg font-semibold">
           학교 선택하기
         </h1>
+        <p className="text-text-secondary mb-6 text-center text-xs">
+          학교를 변경하면 기존 즐겨찾기가 모두 삭제돼요.
+        </p>
 
         <div className="mb-30 flex flex-wrap gap-3">
           {universities.map(({ code, name }) => {


### PR DESCRIPTION
## 작업 내용

학교 변경 시 사용자가 실수로 기존 즐겨찾기를 잃지 않도록 확인 팝업과 안내 문구를 추가했습니다.

- 학교 선택 모달에서 학교를 고르면 바로 변경하지 않고 **확인 다이얼로그**를 띄우도록 변경
  - "학교를 변경하면 기존 즐겨찾기가 모두 삭제됩니다. 계속하시겠어요?" 문구 노출
  - 취소 / 변경하기 버튼 제공, 변경 중에는 버튼 비활성화 및 로딩 표시
- 현재 학교와 동일한 학교를 선택한 경우에는 확인 없이 모달만 닫도록 처리
- 학교 선택 모달 상단에 "학교를 변경하면 기존 즐겨찾기가 모두 삭제돼요." 안내 문구 추가

## 변경 파일

- `src/widgets/login/ui/university-select-modal-wrapper.tsx` — 변경 확인 다이얼로그 추가 및 변경 로직 분리
- `src/widgets/login/ui/university-select-modal.tsx` — 안내 문구 추가
