### PR TITLE
refactor: 동아리 생성 폼 학교 URL params 기반 자동 선택

### DIFF
--- a/src/features/club-create/ui/club-crete-form.tsx
+++ b/src/features/club-create/ui/club-crete-form.tsx
@@ -18,9 +18,10 @@ type Step = 'basic' | 'description';
 function ClubCreateForm() {
   const router = useRouter();
   const { session } = useSession();
+  const universityCode = useUniversityCode();
   const [formData, setFormData] = useState<ClubCreateFormData>({
     clubName: '',
-    universityCode: '',
+    universityCode: universityCode.toUpperCase(),
     clubCategory: '',
     clubAffiliation: '',
     logo: '',
@@ -32,7 +33,6 @@ function ClubCreateForm() {
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [step, setStep] = useState<Step>('basic');
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const universityCode = useUniversityCode();
 
   const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];


### PR DESCRIPTION
## #️⃣연관된 이슈

> #547 

## 📝작업 내용

> 현재는 폼에 있는 대학명 input의 placeholder가 모꼬지 대학교라는 워딩으로 되어있으나 사용자의 실제 대학교를 바로 가져올 수 있도록 URL에서 serachParams를 통해 가지고 와서 바로 해당 input의 placeholder에 보여주도록 수정

- `useUniversityCode()` 사용해서 수정했습니다.

### 스크린샷 (선택)
<img width="493" height="676" alt="image" src="https://github.com/user-attachments/assets/1f5ef090-5d6d-4b3f-b856-3c6ff4b0ac38" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
