### PR TITLE
fix: 운영 모집글 이미지 안 뜨는 이슈 수정 (prod S3 호스트 remotePatterns 추가)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,7 +12,6 @@ let nextConfig: NextConfig = {
     ? ['tsx', 'ts', 'jsx', 'js']
     : ['tsx', 'ts', 'jsx', 'js', 'dev.tsx'],
   images: {
-    domains: [process.env.NEXT_PUBLIC_S3_DOMAIN || ''],
     remotePatterns: [
       {
         protocol: 'https',
@@ -27,6 +26,11 @@ let nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'dev-mokkoji-app-data.s3.ap-northeast-2.amazonaws.com',
+        pathname: '**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'prod-mokkoji-app-data.s3.ap-northeast-2.amazonaws.com',
         pathname: '**',
       },
     ],


### PR DESCRIPTION
## #️⃣연관된 이슈

> #550

## 📝작업 내용

운영 서버에서 모집글 이미지가 표시되지 않는 이슈를 수정했습니다.

- **원인**: 모집글 이미지는 `next/image` 최적화를 거치는데, 운영 이미지 호스트 `prod-mokkoji-app-data.s3.ap-northeast-2.amazonaws.com` 가 `next.config.ts` 의 `images.remotePatterns` 에 등록되어 있지 않아 `INVALID_IMAGE_OPTIMIZE_REQUEST`(400) 가 발생했습니다. 로고 이미지는 Radix `AvatarImage`(일반 `<img>`)로 렌더링되어 최적화를 거치지 않으므로 정상 표시되었고, 그래서 문제가 모집글 이미지에서만 드러났습니다.
- `images.remotePatterns` 에 `prod-mokkoji-app-data.s3.ap-northeast-2.amazonaws.com` 추가
- deprecated 된 빈 `images.domains: [process.env.NEXT_PUBLIC_S3_DOMAIN || '']` 제거 (해당 env 미설정으로 `['']` 무효 상태였음)

### 스크린샷 (선택)

로컬 dev 서버 이미지 최적화 엔드포인트(`/_next/image`) 검증:
- 미등록 호스트 → `400 ("url" parameter is not allowed)`
- 수정 후 prod 호스트 → 400 사라짐(허용 목록 통과, 업스트림 fetch 단계 진입)
