### PR TITLE
feat: 회원 탈퇴 기능 구현

### DIFF
--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -15,6 +15,7 @@ import EmailChangeDialog from '@/features/my/ui/email-change-dialog';
 import EmailDeleteButton from '@/features/my/ui/email-delete-button';
 import MailNotificationToggle from '@/features/my/ui/mail-notification-toggle';
 import LogoutLink from '@/features/my/ui/logout-link';
+import WithdrawButton from '@/features/my/ui/withdraw-button';
 import ClubApplicationStatus from '@/features/my/ui/club-application-status';
 
 async function MyPage({ isNewUser = false }: { isNewUser?: boolean }) {
@@ -95,8 +96,11 @@ async function MyPage({ isNewUser = false }: { isNewUser?: boolean }) {
               universities={universities}
             />
           </div>
-          <div className="mb-15 lg:hidden">
+          <div className="lg:hidden">
             <LogoutLink />
+          </div>
+          <div className="mt-2 mb-15">
+            <WithdrawButton />
           </div>
         </div>
       </div>

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -96,7 +96,7 @@ async function MyPage({ isNewUser = false }: { isNewUser?: boolean }) {
               universities={universities}
             />
           </div>
-          <div className="lg:hidden">
+          <div>
             <LogoutLink />
           </div>
           <div className="mt-2 mb-15">

--- a/src/features/my/api/deleteUser.tsx
+++ b/src/features/my/api/deleteUser.tsx
@@ -1,0 +1,20 @@
+'use server';
+
+import api from '@/shared/api/auth-api';
+import ErrorHandler from '@/shared/lib/error-message';
+
+async function deleteUser() {
+  try {
+    await api.delete('users');
+
+    return {
+      ok: true,
+      message: '회원 탈퇴가 완료되었습니다.',
+      status: 200,
+    };
+  } catch (e) {
+    return ErrorHandler(e as Error);
+  }
+}
+
+export default deleteUser;

--- a/src/features/my/ui/logout-link.tsx
+++ b/src/features/my/ui/logout-link.tsx
@@ -1,16 +1,19 @@
 'use client';
 
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
+import { useSession } from '@/shared/lib/session-context';
 
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
 export default function LogoutLink() {
   const router = useRouter();
+  const { refresh } = useSession();
   const universityCode = useUniversityCode();
 
   const handleLogout = async () => {
     await fetch('/api/auth/logout', { method: 'POST' });
+    refresh();
     router.push(`/${universityCode}`);
     router.refresh();
   };

--- a/src/features/my/ui/withdraw-button.tsx
+++ b/src/features/my/ui/withdraw-button.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'react-toastify';
+import Image from 'next/image';
+import useUniversityCode from '@/shared/hooks/useUniversityCode';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/shared/ui/dialog';
+import { Button } from '@/shared/ui/button';
+import deleteUser from '../api/deleteUser';
+
+export default function WithdrawButton() {
+  const router = useRouter();
+  const universityCode = useUniversityCode();
+  const [open, setOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleWithdraw = async () => {
+    setSubmitting(true);
+    const response = await deleteUser();
+    if (!response.ok) {
+      toast.error(response.message);
+      setSubmitting(false);
+      return;
+    }
+    await fetch('/api/auth/logout', { method: 'POST' });
+    toast.success('회원 탈퇴가 완료되었습니다.');
+    setOpen(false);
+    router.push(`/${universityCode}`);
+    router.refresh();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="text-text-secondary mt-2 flex items-center gap-2 text-sm hover:underline"
+        >
+          회원 탈퇴
+          <Image src="/nextBlack.svg" alt="arrow" width={8} height={12} />
+        </button>
+      </DialogTrigger>
+
+      <DialogContent
+        aria-describedby="withdraw-desc"
+        className="w-[400px] rounded-2xl"
+      >
+        <DialogHeader>
+          <DialogTitle className="font-semibold">회원 탈퇴</DialogTitle>
+          <DialogDescription id="withdraw-desc" className="text-sm">
+            탈퇴 시 계정과 관련된 모든 데이터가 삭제되며 복구할 수 없습니다.
+            <br />
+            <br />
+            정말 탈퇴하시겠습니까?
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={submitting}
+          >
+            취소
+          </Button>
+          <Button
+            className="bg-red-500 text-white hover:bg-red-600"
+            onClick={handleWithdraw}
+            disabled={submitting}
+          >
+            {submitting ? '탈퇴 중…' : '탈퇴'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/my/ui/withdraw-button.tsx
+++ b/src/features/my/ui/withdraw-button.tsx
@@ -43,7 +43,7 @@ export default function WithdrawButton() {
       <DialogTrigger asChild>
         <button
           type="button"
-          className="text-text-secondary mt-2 flex items-center gap-2 text-sm hover:underline"
+          className="mt-2 flex items-center gap-2 text-[#FF383C] hover:underline"
         >
           회원 탈퇴
           <Image src="/nextBlack.svg" alt="arrow" width={8} height={12} />
@@ -57,7 +57,10 @@ export default function WithdrawButton() {
         <DialogHeader>
           <DialogTitle className="font-semibold">회원 탈퇴</DialogTitle>
           <DialogDescription id="withdraw-desc" className="text-sm">
-            탈퇴 시 계정과 관련된 모든 데이터가 삭제되며 복구할 수 없습니다.
+            탈퇴 시 계정과 관련된{' '}
+            <span className="font-semibold underline">
+              모든 데이터가 삭제되며 복구할 수 없습니다.
+            </span>
             <br />
             <br />
             정말 탈퇴하시겠습니까?

--- a/src/features/my/ui/withdraw-button.tsx
+++ b/src/features/my/ui/withdraw-button.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import Image from 'next/image';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
+import { useSession } from '@/shared/lib/session-context';
 import {
   Dialog,
   DialogTrigger,
@@ -19,6 +20,7 @@ import deleteUser from '../api/deleteUser';
 
 export default function WithdrawButton() {
   const router = useRouter();
+  const { refresh } = useSession();
   const universityCode = useUniversityCode();
   const [open, setOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -32,6 +34,7 @@ export default function WithdrawButton() {
       return;
     }
     await fetch('/api/auth/logout', { method: 'POST' });
+    refresh();
     toast.success('회원 탈퇴가 완료되었습니다.');
     setOpen(false);
     router.push(`/${universityCode}`);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #552

## 📝작업 내용

회원 탈퇴 기능을 구현했습니다.

- `DELETE /users` 회원 탈퇴 API(Server Action) 구현
- 마이페이지에 회원 탈퇴 버튼 및 확인 다이얼로그 추가 (안내 문구 강조 처리)
- 탈퇴 완료 시 세션 쿠키 삭제 → 홈으로 이동
- 탈퇴·로그아웃 후 헤더가 로그인 상태로 남던 버그 수정
  - 헤더 로그인 표시는 클라이언트 세션 컨텍스트(`useSession`)가 결정하는데, `router.refresh()`만으로는 갱신되지 않아 `refresh()`를 호출하도록 수정
  - 동일 패턴이던 마이페이지 로그아웃 버튼(`logout-link`)도 함께 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 탈퇴 후 헤더 상태 갱신을 `refresh()` 호출 방식으로 처리했는데, 전체 새로고침 방식과 비교해 이 방향이 적절한지 봐주시면 좋겠습니다.
