### PR TITLE
refactor: 건국대 학교코드 추가 관련 구현

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,7 +1,8 @@
 import HomePage from '@/views/home/ui/home-page';
+import { getUniversityName } from '@/shared/lib/universityMeta';
 
 function Page() {
-  return <HomePage />;
+  return <HomePage universityName={getUniversityName('SEJONG')} />;
 }
 
 export default Page;

--- a/src/app/[universityCode]/(home)/page.tsx
+++ b/src/app/[universityCode]/(home)/page.tsx
@@ -1,7 +1,18 @@
 import HomePage from '@/views/home/ui/home-page';
+import {
+  getUniversityName,
+  urlCodeToApiCode,
+} from '@/shared/lib/universityMeta';
 
-function Page() {
-  return <HomePage />;
+async function Page({
+  params,
+}: {
+  params: Promise<{ universityCode: string }>;
+}) {
+  const { universityCode } = await params;
+  const universityName = getUniversityName(urlCodeToApiCode(universityCode));
+
+  return <HomePage universityName={universityName} />;
 }
 
 export default Page;

--- a/src/app/[universityCode]/(main)/club/page.tsx
+++ b/src/app/[universityCode]/(main)/club/page.tsx
@@ -1,6 +1,5 @@
 import ClubPage from '@/views/club/ui/club-page';
 import { type SearchParams } from 'nuqs/server';
-import { getSession } from '@/shared/lib/cookie-session';
 import { urlCodeToApiCode } from '@/shared/lib/universityMeta';
 import { searchParamsCache } from './search-params';
 
@@ -12,10 +11,7 @@ type PageProps = {
 async function Page({ params, searchParams }: PageProps) {
   const { universityCode } = await params;
   await searchParamsCache.parse(searchParams);
-  const session = await getSession();
-  const effectiveUniversityCode =
-    session?.universityCode ?? urlCodeToApiCode(universityCode);
-  return <ClubPage universityCode={effectiveUniversityCode} />;
+  return <ClubPage universityCode={urlCodeToApiCode(universityCode)} />;
 }
 
 export default Page;

--- a/src/app/[universityCode]/(main)/search/page.tsx
+++ b/src/app/[universityCode]/(main)/search/page.tsx
@@ -1,6 +1,5 @@
 import SearchPage from '@/views/search/ui/search-page';
 import { type SearchParams } from 'nuqs/server';
-import { getSession } from '@/shared/lib/cookie-session';
 import { urlCodeToApiCode } from '@/shared/lib/universityMeta';
 import { searchParamsCache } from './search-params';
 
@@ -12,10 +11,7 @@ type PageProps = {
 async function Page({ params, searchParams }: PageProps) {
   const { universityCode } = await params;
   await searchParamsCache.parse(searchParams);
-  const session = await getSession();
-  const effectiveUniversityCode =
-    session?.universityCode ?? urlCodeToApiCode(universityCode);
-  return <SearchPage universityCode={effectiveUniversityCode} />;
+  return <SearchPage universityCode={urlCodeToApiCode(universityCode)} />;
 }
 
 export default Page;

--- a/src/app/[universityCode]/layout.tsx
+++ b/src/app/[universityCode]/layout.tsx
@@ -1,0 +1,25 @@
+import ErrorPage from '@/entities/error/ui/error-page';
+import { isValidUniversityCode } from '@/shared/lib/universityMeta';
+
+export default async function UniversityCodeLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ universityCode: string }>;
+}) {
+  const { universityCode } = await params;
+
+  if (!isValidUniversityCode(universityCode)) {
+    return (
+      <ErrorPage
+        statusCode={404}
+        title="지원하지 않는 학교예요"
+        message="입력하신 학교 주소를 찾을 수 없어요. 주소를 다시 확인해주세요."
+        showHomeButton={false}
+      />
+    );
+  }
+
+  return children;
+}

--- a/src/app/api/auth/callback/kakao/route.ts
+++ b/src/app/api/auth/callback/kakao/route.ts
@@ -8,6 +8,7 @@ import {
 import UserInfoType from '@/entities/my/model/type';
 import getTokenExpiration from '@/shared/lib/getTokenExpiration';
 import { buildSessionCookie, CookieSession } from '@/shared/lib/cookie-session';
+import { urlCodeToApiCode } from '@/shared/lib/universityMeta';
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -58,9 +59,9 @@ export async function GET(request: NextRequest) {
       // role 조회 실패해도 로그인은 성공 처리
     }
 
-    const apiUniversityCode = (
-      userResponseBody.data.universityCode ?? 'SEJONG'
-    ).toUpperCase();
+    const apiUniversityCode = urlCodeToApiCode(
+      userResponseBody.data.universityCode ?? 'SEJONG',
+    );
 
     const session: CookieSession = {
       accessToken,

--- a/src/entities/home/ui/club-text-card.tsx
+++ b/src/entities/home/ui/club-text-card.tsx
@@ -1,6 +1,10 @@
 import AnimateOnView from '@/shared/ui/animate-on-view';
 
-function ClubTextCard() {
+interface ClubTextCardProps {
+  universityName: string;
+}
+
+function ClubTextCard({ universityName }: ClubTextCardProps) {
   return (
     <div className="flex h-[50%] w-full flex-col justify-center gap-2 lg:h-full lg:w-[50%]">
       <AnimateOnView animation="animate-fade-left">
@@ -10,7 +14,7 @@ function ClubTextCard() {
       </AnimateOnView>
       <AnimateOnView animation="reveal">
         <p className="my-1 w-full text-2xl leading-[1.5] font-semibold lg:my-3 lg:w-[90%] lg:text-3xl lg:font-bold">
-          세종대 동아리들을 <br className="lg:hidden" />
+          {universityName} 동아리들을 <br className="lg:hidden" />
           한눈에 확인해요.
         </p>
       </AnimateOnView>

--- a/src/entities/home/ui/home-header.tsx
+++ b/src/entities/home/ui/home-header.tsx
@@ -1,11 +1,15 @@
-function HomeHeader() {
+interface HomeHeaderProps {
+  universityName: string;
+}
+
+function HomeHeader({ universityName }: HomeHeaderProps) {
   return (
     <header className="flex flex-col items-center py-8 text-[#2E2E2E]">
       <h1 className="bg-gradient-primary mb-4 w-fit bg-clip-text p-4 text-[120px] font-bold text-transparent">
         Club, set, go!
       </h1>
       <p className="text-[32px]">
-        세종대의 모든{' '}
+        {universityName}의 모든{' '}
         <span className="bg-gradient-primary bg-clip-text font-bold text-transparent">
           동아리
         </span>

--- a/src/entities/home/ui/mobile-home-header.tsx
+++ b/src/entities/home/ui/mobile-home-header.tsx
@@ -1,11 +1,15 @@
-function MobileHomeHeader() {
+interface MobileHomeHeaderProps {
+  universityName: string;
+}
+
+function MobileHomeHeader({ universityName }: MobileHomeHeaderProps) {
   return (
     <header className="flex flex-col items-center py-8 text-[#2E2E2E]">
       <h1 className="bg-gradient-primary mb-4 w-fit bg-clip-text text-[clamp(3rem,14vw,3.75rem)] font-bold whitespace-nowrap text-transparent">
         Club, set, go!
       </h1>
       <p className="text-xl">
-        세종대의 모든{' '}
+        {universityName}의 모든{' '}
         <span className="bg-gradient-primary bg-clip-text font-bold text-transparent">
           동아리
         </span>

--- a/src/features/club-create/ui/club-create-basic-step.tsx
+++ b/src/features/club-create/ui/club-create-basic-step.tsx
@@ -16,6 +16,7 @@ import {
   ClubCategoryToStringLabel,
 } from '@/shared/model/type';
 import type { University } from '@/entities/university/model/type';
+import { urlCodeToApiCode } from '@/shared/lib/universityMeta';
 import type { ClubCreateFormData } from './club-crete-form';
 
 interface ClubCreateBasicStepProps {
@@ -72,7 +73,7 @@ function ClubCreateBasicStep({
           onValueChange={(value) =>
             setFormData((prev) => ({
               ...prev,
-              universityCode: value.toUpperCase(),
+              universityCode: urlCodeToApiCode(value),
             }))
           }
         >

--- a/src/features/club-create/ui/club-create-basic-step.tsx
+++ b/src/features/club-create/ui/club-create-basic-step.tsx
@@ -15,6 +15,7 @@ import {
   ClubCategoryIcon,
   ClubCategoryToStringLabel,
 } from '@/shared/model/type';
+import type { University } from '@/entities/university/model/type';
 import type { ClubCreateFormData } from './club-crete-form';
 
 interface ClubCreateBasicStepProps {
@@ -26,6 +27,7 @@ interface ClubCreateBasicStepProps {
   isConfirmed: boolean;
   setIsConfirmed: React.Dispatch<React.SetStateAction<boolean>>;
   onNext: () => void;
+  universities: University[];
 }
 
 function ClubCreateBasicStep({
@@ -37,6 +39,7 @@ function ClubCreateBasicStep({
   isConfirmed,
   setIsConfirmed,
   onNext,
+  universities,
 }: ClubCreateBasicStepProps) {
   const isValid =
     formData.clubName !== '' &&
@@ -83,7 +86,11 @@ function ClubCreateBasicStep({
             />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="SEJONG">세종대학교</SelectItem>
+            {universities.map(({ code, name }) => (
+              <SelectItem key={code} value={code}>
+                {name}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>

--- a/src/features/club-create/ui/club-crete-form.tsx
+++ b/src/features/club-create/ui/club-crete-form.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
 import { useSession } from '@/shared/lib/session-context';
+import type { University } from '@/entities/university/model/type';
 import postCreateClubApplication from '../api/postCreateClubApplication';
 import type { ClubCreateFormData } from '../model/type';
 import ClubCreateDescriptionStep from './club-create-description-step';
@@ -15,7 +16,11 @@ export type { ClubCreateFormData };
 
 type Step = 'basic' | 'description';
 
-function ClubCreateForm() {
+interface ClubCreateFormProps {
+  universities: University[];
+}
+
+function ClubCreateForm({ universities }: ClubCreateFormProps) {
   const router = useRouter();
   const { session } = useSession();
   const universityCode = useUniversityCode();
@@ -80,6 +85,7 @@ function ClubCreateForm() {
           isConfirmed={isConfirmed}
           setIsConfirmed={setIsConfirmed}
           onNext={handleNext}
+          universities={universities}
         />
       )}
       {step === 'description' && (

--- a/src/features/club-create/ui/club-crete-form.tsx
+++ b/src/features/club-create/ui/club-crete-form.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
 import { useSession } from '@/shared/lib/session-context';
+import { urlCodeToApiCode } from '@/shared/lib/universityMeta';
 import type { University } from '@/entities/university/model/type';
 import postCreateClubApplication from '../api/postCreateClubApplication';
 import type { ClubCreateFormData } from '../model/type';
@@ -26,7 +27,7 @@ function ClubCreateForm({ universities }: ClubCreateFormProps) {
   const universityCode = useUniversityCode();
   const [formData, setFormData] = useState<ClubCreateFormData>({
     clubName: '',
-    universityCode: universityCode.toUpperCase(),
+    universityCode: urlCodeToApiCode(universityCode),
     clubCategory: '',
     clubAffiliation: '',
     logo: '',

--- a/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
+++ b/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
 import { useSession } from '@/shared/lib/session-context';
+import { urlCodeToApiCode } from '@/shared/lib/universityMeta';
 import { Button } from '@/shared/ui/button';
 import {
   Select,
@@ -32,14 +33,14 @@ function ClubMasterApplicationForm({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [selectedUniversityCode, setSelectedUniversityCode] = useState(
-    universityCode.toUpperCase(),
+    urlCodeToApiCode(universityCode),
   );
   const [selectedClubId, setSelectedClubId] = useState('');
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [clubs, setClubs] = useState<ClubSummary[]>([]);
 
   useEffect(() => {
-    getClubsByUniversity(universityCode.toUpperCase()).then((result) => {
+    getClubsByUniversity(urlCodeToApiCode(universityCode)).then((result) => {
       setClubs(result);
       setIsClubsLoading(false);
     });

--- a/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
+++ b/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
@@ -13,11 +13,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/shared/ui/select';
+import type { University } from '@/entities/university/model/type';
 import getClubsByUniversity from '../api/getClubsByUniversity';
 import postClubMasterApplication from '../api/postClubMasterApplication';
 import type { ClubSummary } from '../model/type';
 
-function ClubMasterApplicationForm() {
+interface ClubMasterApplicationFormProps {
+  universities: University[];
+}
+
+function ClubMasterApplicationForm({
+  universities,
+}: ClubMasterApplicationFormProps) {
   const router = useRouter();
   const universityCode = useUniversityCode();
   const { session } = useSession();
@@ -90,7 +97,11 @@ function ClubMasterApplicationForm() {
             <SelectValue placeholder="모꼬지대학교" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="SEJONG">세종대학교</SelectItem>
+            {universities.map(({ code, name }) => (
+              <SelectItem key={code} value={code}>
+                {name}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>

--- a/src/shared/lib/universityMeta.ts
+++ b/src/shared/lib/universityMeta.ts
@@ -10,3 +10,7 @@ export function getUniversityName(code: string): string {
 export function urlCodeToApiCode(urlCode: string): string {
   return urlCode.toUpperCase();
 }
+
+export function isValidUniversityCode(code: string): boolean {
+  return code.toUpperCase() in universityDisplayName;
+}

--- a/src/views/club-application/ui/club-application-page.tsx
+++ b/src/views/club-application/ui/club-application-page.tsx
@@ -1,7 +1,11 @@
 import ClubApplicationTabs from '@/widgets/club-application/ui/club-application-tab';
+import getUniversities from '@/entities/university/api/getUniversities';
 
-function ClubApplicationPage() {
-  return <ClubApplicationTabs />;
+async function ClubApplicationPage() {
+  const universitiesRes = await getUniversities();
+  const universities = universitiesRes.data?.universities ?? [];
+
+  return <ClubApplicationTabs universities={universities} />;
 }
 
 export default ClubApplicationPage;

--- a/src/views/home/ui/desktop-home-page.tsx
+++ b/src/views/home/ui/desktop-home-page.tsx
@@ -8,11 +8,15 @@ import HelpCardWidget from '@/widgets/home/ui/help-card-widget';
 import HomeSearchWidget from '@/widgets/home/ui/home-search-widget';
 import { Suspense } from 'react';
 
-function DeskTopHomePage() {
+interface DeskTopHomePageProps {
+  universityName: string;
+}
+
+function DeskTopHomePage({ universityName }: DeskTopHomePageProps) {
   return (
     <>
       <section className="mx-auto mt-4 flex min-h-[calc(100vh-200px)] w-fit flex-col justify-center">
-        <HomeHeader />
+        <HomeHeader universityName={universityName} />
         <HomeSearchWidget />
       </section>
       <div className="mb-10 flex h-[72px] justify-center">
@@ -20,7 +24,7 @@ function DeskTopHomePage() {
       </div>
       <section className="px-[10%]">
         <Suspense fallback={<SharedLoading />}>
-          <ClubCardWidget />
+          <ClubCardWidget universityName={universityName} />
         </Suspense>
       </section>
       <section className="bg-[linear-gradient(to_bottom,_#FFFFFF_0%,_#F8FAFB_5%,_#F8FAFB_95%,_#FFFFFF_100%)] px-[10%]">

--- a/src/views/home/ui/home-page.tsx
+++ b/src/views/home/ui/home-page.tsx
@@ -2,15 +2,19 @@ import { cookies } from 'next/headers';
 import DeskTopHomePage from './desktop-home-page';
 import MobileHomePage from './mobile-home-page';
 
-async function HomePage() {
+interface HomePageProps {
+  universityName: string;
+}
+
+async function HomePage({ universityName }: HomePageProps) {
   const cookieStore = await cookies();
   const deviceType = cookieStore.get('x-device-type')?.value;
 
   if (deviceType === 'mobile') {
-    return <MobileHomePage />;
+    return <MobileHomePage universityName={universityName} />;
   }
 
-  return <DeskTopHomePage />;
+  return <DeskTopHomePage universityName={universityName} />;
 }
 
 export default HomePage;

--- a/src/views/home/ui/mobile-home-page.tsx
+++ b/src/views/home/ui/mobile-home-page.tsx
@@ -6,18 +6,22 @@ import FeatureIntroduceMobileWidget from '@/widgets/home/ui/feature-introduce-mo
 import HelpCardMobileWidget from '@/widgets/home/ui/help-card-mobile-widget';
 import HomeSearchWidget from '@/widgets/home/ui/home-search-widget';
 
-function MobileHomePage() {
+interface MobileHomePageProps {
+  universityName: string;
+}
+
+function MobileHomePage({ universityName }: MobileHomePageProps) {
   return (
     <>
       <div className="mt-20 px-5">
-        <MobileHomeHeader />
+        <MobileHomeHeader universityName={universityName} />
         <HomeSearchWidget />
       </div>
       <div className="mt-4 mb-30 flex h-[72px] justify-center">
         <HomeDownButton />
       </div>
       <section className="px-5">
-        <ClubCardMobileWidget />
+        <ClubCardMobileWidget universityName={universityName} />
       </section>
       <section className="bg-[linear-gradient(to_bottom,_#FFFFFF_0%,_#F8FAFB_5%,_#F8FAFB_95%,_#FFFFFF_100%)] px-5">
         <FeatureIntroduceMobileWidget />

--- a/src/widgets/club-application/ui/club-application-tab.tsx
+++ b/src/widgets/club-application/ui/club-application-tab.tsx
@@ -2,6 +2,7 @@
 
 import ClubCreateForm from '@/features/club-create/ui/club-crete-form';
 import ClubMasterApplicationForm from '@/features/club-master-application/ui/ClubMasterApplicationForm';
+import type { University } from '@/entities/university/model/type';
 import { useState } from 'react';
 
 const TABS = [
@@ -11,7 +12,11 @@ const TABS = [
 
 type TabKey = (typeof TABS)[number]['key'];
 
-function ClubApplicationTabs() {
+interface ClubApplicationTabsProps {
+  universities: University[];
+}
+
+function ClubApplicationTabs({ universities }: ClubApplicationTabsProps) {
   const [activeTab, setActiveTab] = useState<TabKey>('club-create');
 
   return (
@@ -44,9 +49,11 @@ function ClubApplicationTabs() {
       </div>
 
       <div className="min-h-[600px] w-full">
-        {activeTab === 'club-create' && <ClubCreateForm />}
+        {activeTab === 'club-create' && (
+          <ClubCreateForm universities={universities} />
+        )}
         {activeTab === 'club-leader-application' && (
-          <ClubMasterApplicationForm />
+          <ClubMasterApplicationForm universities={universities} />
         )}
       </div>
     </div>

--- a/src/widgets/club/api/getClubList.ts
+++ b/src/widgets/club/api/getClubList.ts
@@ -26,7 +26,6 @@ async function getClubList({
   universityCode?: string;
 }) {
   const session = await getSession();
-  const effectiveUniversityCode = session?.universityCode ?? universityCode;
 
   const rawParams: Record<string, string | undefined> = {
     page: String(page),
@@ -34,7 +33,7 @@ async function getClubList({
     category: category ? String(category) : undefined,
     affiliation: affiliation ? String(affiliation) : undefined,
     keyword: keyword?.trim() ? String(keyword?.trim()) : undefined,
-    universityCode: effectiveUniversityCode,
+    universityCode,
   };
 
   const searchParams = new URLSearchParams();

--- a/src/widgets/home/ui/club-card-mobile-widget.tsx
+++ b/src/widgets/home/ui/club-card-mobile-widget.tsx
@@ -3,14 +3,18 @@ import RecruitTextCard from '@/entities/home/ui/recruit-text-card';
 import AnimateOnView from '@/features/home/util/animate-viewport';
 import Image from 'next/image';
 
-function ClubCardMobileWidget() {
+interface ClubCardMobileWidgetProps {
+  universityName: string;
+}
+
+function ClubCardMobileWidget({ universityName }: ClubCardMobileWidgetProps) {
   return (
     <div className="flex flex-col gap-50">
       <div
         id="scroll-target"
         className="flex h-fit flex-col items-center gap-13 pt-30"
       >
-        <ClubTextCard />
+        <ClubTextCard universityName={universityName} />
         <AnimateOnView animation="reveal">
           <Image
             src="/main/clubcard.png"

--- a/src/widgets/home/ui/club-card-widget.tsx
+++ b/src/widgets/home/ui/club-card-widget.tsx
@@ -5,7 +5,11 @@ import RecruitVerticalCarousel from '@/features/home/ui/recruit-vertical-carouse
 import ErrorBoundaryUi from '@/shared/ui/error-boundary-ui';
 import getClubList from '@/widgets/club/api/getClubList';
 
-async function ClubCardWidget() {
+interface ClubCardWidgetProps {
+  universityName: string;
+}
+
+async function ClubCardWidget({ universityName }: ClubCardWidgetProps) {
   const clubListResponse = await getClubList({
     page: 1,
     size: 10,
@@ -20,7 +24,7 @@ async function ClubCardWidget() {
         id="scroll-target"
         className="mb-10 flex h-fit flex-col items-center pt-30 lg:mb-40 lg:h-[300px] lg:flex-row lg:pt-20"
       >
-        <ClubTextCard />
+        <ClubTextCard universityName={universityName} />
         <CardSlider clubs={clubListResponse.data.clubs} />
       </div>
       <div className="mb-40 flex h-[550px] w-full flex-col-reverse items-center gap-6 pt-10 lg:mb-60 lg:h-[300px] lg:flex-row lg:gap-0 lg:pt-20">

--- a/src/widgets/recruit/api/getClubList.ts
+++ b/src/widgets/recruit/api/getClubList.ts
@@ -26,8 +26,7 @@ async function getClubList(params: GetRecruitListParams) {
     keyword: params.keyword,
     category: params.category,
     recruitStatus: params.recruitStatus,
-    universityCode:
-      session?.universityCode ?? params.universityCode ?? 'SEJONG',
+    universityCode: params.universityCode ?? 'SEJONG',
   };
 
   const searchParams = new URLSearchParams();

--- a/src/widgets/search/api/searchClubs.ts
+++ b/src/widgets/search/api/searchClubs.ts
@@ -6,7 +6,6 @@ import {
 } from '@/shared/model/type';
 import serverApi from '@/shared/api/server-api';
 import createErrorResponse from '@/shared/lib/error-message';
-import { getSession } from '@/shared/lib/cookie-session';
 
 interface SearchClubsParams {
   keyword?: string;
@@ -19,9 +18,7 @@ interface SearchClubsParams {
 }
 
 async function searchClubs(params: SearchClubsParams) {
-  const session = await getSession();
-  const effectiveUniversityCode =
-    session?.universityCode ?? params.universityCode ?? 'SEJONG';
+  const effectiveUniversityCode = params.universityCode ?? 'SEJONG';
 
   const searchParams = new URLSearchParams();
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #557 

## 📝작업 내용

현재 학교코드를 enum처럼 프론트에서 관리중에 있는데 세종대만 있는 줄 알고 해당 사항을 추가하고자 했던 이슈였으나  `universityMeta.ts` 파일의 코드를 확인해보니 세종대, 건국대 두개에 대해서 다루고 있었습니다. 그래서 그 부분 외의 분리가 필요한 부분들에 대해 작업했습니다.

1. 랜딩페이지에서 '세종대학교의 모든 동아리, 모꼬지에서 한눈에.' 라는 문구가 있는데 이가 url이 /konkuk으로 변경되어도 여전히 세종대인 이슈가 있어서 해당 부분을 url의 universityCode를 기반으로 노출하도록 수정했습니다.
<img width="1494" height="841" alt="image" src="https://github.com/user-attachments/assets/30812169-b61c-450b-8f64-3f20f66642ca" />


2. /konkuk/club에서 세종대 동아리가 나오던 이슈
로그인을 하지 않은 상태에서는 /konkuk/club로 들어가면 백으로 konkuk에 대한 동아리를 요청하기 때문에 '건대동아리' 카드가 뜨는 것을 확인할 수 있었습니다. 하지만 로그인을 하고 /konkuk/club으로 들어가니 아무리 새로고침을 해도 세종대의 동아리카드가 뜨는 이슈가 있었습니다. 요청을 보내는 코드를 확인해보니 해당 부분에서 유저정보에 있는 학교를 우선적으로 체킹해서 백엔드로 요청을 보내고 유저 학교 정보가 없으면 url의 universityCode를 기반으로 보내는 플로우임을 확인했습니다. 제가 세종대생으로 되어있어서 건국대 페이지에서도 세종대 동아리가 보이던거였습니다. 세종대생으로 되어있어도 건국대 url이면 건국대 동아리가 보이는 것이 맞다고 생각하여 유저 학교 정보 기반으로 요청하던 플로우들을 url의 universityCode를 가져와서 보내는 흐름으로 수정했습니다.
<img width="1494" height="841" alt="image" src="https://github.com/user-attachments/assets/e16c8036-f78a-4f18-97c1-903eb088c7a2" />


3. 잘못된 url로의 접근
기존에는 url에 잘못된 학교 코드를 입력해도 사이트로 접근이 되는 형태였는데 이를 url의 학교명이 유효한 universityCode인지 체크하고 유효하지 않을때는 404 안내 페이지 노출시키도록 수정했습니다.
<img width="1494" height="841" alt="image" src="https://github.com/user-attachments/assets/37000cde-633b-448d-b692-f5aa0ba85226" />


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
