### PR TITLE
feat: 대시보드 진입 시 관리자 권한(총동연/개발자) 분기 처리

### DIFF
--- a/src/app/(admin)/dashboard/(main)/error.tsx
+++ b/src/app/(admin)/dashboard/(main)/error.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import ErrorPage from '@/entities/error/ui/error-page';
+
+export default function DashboardError() {
+  return <ErrorPage statusCode={500} showHomeButton={false} />;
+}

--- a/src/app/(admin)/dashboard/(main)/page.tsx
+++ b/src/app/(admin)/dashboard/(main)/page.tsx
@@ -1,14 +1,48 @@
 import { Suspense } from 'react';
+import { redirect } from 'next/navigation';
 import AdminDashboardView from '@/views/admin/ui/AdminDashboardView';
+import getAdminInfo from '@/features/admin/api/getAdminInfo';
 import getClubMasterApplications from '@/features/admin/api/getClubMasterApplications';
 import getClubApplications from '@/features/admin/api/getClubApplications';
 import getAdminClubs from '@/features/admin/api/getAdminClubs';
+import getUniversities from '@/entities/university/api/getUniversities';
 
-async function DashboardPage() {
+interface DashboardPageProps {
+  searchParams: Promise<{ universityCode?: string }>;
+}
+
+async function DashboardPage({ searchParams }: DashboardPageProps) {
+  const adminInfo = await getAdminInfo();
+
+  if (!adminInfo) {
+    redirect('/dashboard/login');
+  }
+
+  const isMokkojiAdmin = adminInfo.role === 'MOKKOJI_ADMIN';
+
+  const universitiesResult = isMokkojiAdmin ? await getUniversities() : null;
+  const universities =
+    universitiesResult?.ok && universitiesResult.data
+      ? universitiesResult.data.universities.map((university) => ({
+          code: university.code,
+          name: university.name,
+        }))
+      : [];
+
+  const { universityCode: selectedFromUrl } = await searchParams;
+  const universityCode = isMokkojiAdmin
+    ? (selectedFromUrl ?? universities[0]?.code)
+    : (adminInfo.universityCode ?? undefined);
+
   const [clubMasterData, clubApplicationData, clubsData] = await Promise.all([
-    getClubMasterApplications({ page: 1, size: 100 }),
-    getClubApplications({ status: 'PENDING', page: 1, size: 100 }),
-    getAdminClubs({ page: 1, size: 100 }),
+    getClubMasterApplications({ page: 1, size: 100, universityCode }),
+    getClubApplications({
+      status: 'PENDING',
+      page: 1,
+      size: 100,
+      universityCode,
+    }),
+    getAdminClubs({ page: 1, size: 100, universityCode }),
   ]);
 
   const clubMasterApplications = clubMasterData?.applications ?? [];
@@ -29,6 +63,9 @@ async function DashboardPage() {
         pendingMasterCount={pendingMasterCount}
         pendingClubCount={pendingClubCount}
         totalMasters={totalMasters}
+        role={adminInfo.role}
+        universities={universities}
+        selectedCode={universityCode ?? ''}
       />
     </Suspense>
   );

--- a/src/app/(admin)/dashboard/(main)/page.tsx
+++ b/src/app/(admin)/dashboard/(main)/page.tsx
@@ -7,17 +7,23 @@ import getClubApplications from '@/features/admin/api/getClubApplications';
 import getAdminClubs from '@/features/admin/api/getAdminClubs';
 import getUniversities from '@/entities/university/api/getUniversities';
 
+export const dynamic = 'force-dynamic';
+
 interface DashboardPageProps {
   searchParams: Promise<{ universityCode?: string }>;
 }
 
 async function DashboardPage({ searchParams }: DashboardPageProps) {
-  const adminInfo = await getAdminInfo();
+  const adminInfoResult = await getAdminInfo();
 
-  if (!adminInfo) {
+  if (!adminInfoResult.ok || !adminInfoResult.data) {
+    if (adminInfoResult.status >= 500) {
+      throw new Error(adminInfoResult.message);
+    }
     redirect('/dashboard/login');
   }
 
+  const adminInfo = adminInfoResult.data;
   const isMokkojiAdmin = adminInfo.role === 'MOKKOJI_ADMIN';
 
   const universitiesResult = await getUniversities();

--- a/src/app/(admin)/dashboard/(main)/page.tsx
+++ b/src/app/(admin)/dashboard/(main)/page.tsx
@@ -20,7 +20,7 @@ async function DashboardPage({ searchParams }: DashboardPageProps) {
 
   const isMokkojiAdmin = adminInfo.role === 'MOKKOJI_ADMIN';
 
-  const universitiesResult = isMokkojiAdmin ? await getUniversities() : null;
+  const universitiesResult = await getUniversities();
   const universities =
     universitiesResult?.ok && universitiesResult.data
       ? universitiesResult.data.universities.map((university) => ({

--- a/src/entities/university/model/type.ts
+++ b/src/entities/university/model/type.ts
@@ -8,3 +8,5 @@ export interface University {
 export interface UniversitiesResponse {
   universities: University[];
 }
+
+export type UniversityOption = Pick<University, 'code' | 'name'>;

--- a/src/features/admin/api/getAdminInfo.ts
+++ b/src/features/admin/api/getAdminInfo.ts
@@ -1,18 +1,25 @@
 import 'server-only';
-import { HTTPError } from 'ky';
 import api from '@/shared/api/dashboard-api';
+import createErrorResponse from '@/shared/lib/error-message';
+import { ApiResponse } from '@/shared/model/type';
 import type { AdminInfo } from '@/features/admin/model/dashboard-types';
 
-async function getAdminInfo(): Promise<AdminInfo | null> {
+async function getAdminInfo() {
   try {
-    const result = await api.get('admin/me').json<{ data: AdminInfo }>();
+    const response = await api.get('admin/me').json<ApiResponse<AdminInfo>>();
 
-    return result.data ?? null;
-  } catch (error) {
-    if (error instanceof HTTPError && error.response.status < 500) {
-      return null;
+    if (!response.data) {
+      return {
+        ok: false,
+        message: '데이터 없음',
+        data: undefined,
+        status: 200,
+      };
     }
-    throw error;
+
+    return { ok: true, message: '성공', data: response.data, status: 200 };
+  } catch (error) {
+    return createErrorResponse(error as Error);
   }
 }
 

--- a/src/features/admin/api/getAdminInfo.ts
+++ b/src/features/admin/api/getAdminInfo.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import { HTTPError } from 'ky';
 import api from '@/shared/api/dashboard-api';
 import type { AdminInfo } from '@/features/admin/model/dashboard-types';
 
@@ -7,8 +8,11 @@ async function getAdminInfo(): Promise<AdminInfo | null> {
     const result = await api.get('admin/me').json<{ data: AdminInfo }>();
 
     return result.data ?? null;
-  } catch {
-    return null;
+  } catch (error) {
+    if (error instanceof HTTPError && error.response.status < 500) {
+      return null;
+    }
+    throw error;
   }
 }
 

--- a/src/features/admin/api/getAdminInfo.ts
+++ b/src/features/admin/api/getAdminInfo.ts
@@ -1,0 +1,15 @@
+import 'server-only';
+import api from '@/shared/api/dashboard-api';
+import type { AdminInfo } from '@/features/admin/model/dashboard-types';
+
+async function getAdminInfo(): Promise<AdminInfo | null> {
+  try {
+    const result = await api.get('admin/me').json<{ data: AdminInfo }>();
+
+    return result.data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export default getAdminInfo;

--- a/src/features/admin/api/getClubMasterApplications.ts
+++ b/src/features/admin/api/getClubMasterApplications.ts
@@ -8,6 +8,7 @@ import type {
 interface Params {
   page: number;
   size: number;
+  universityCode?: string;
 }
 
 interface Response {
@@ -23,6 +24,8 @@ async function getClubMasterApplications(
       page: String(params.page),
       size: String(params.size),
     });
+    if (params.universityCode)
+      query.set('universityCode', params.universityCode);
 
     const result = await api
       .get(`admin/club-master-applications?${query.toString()}`)

--- a/src/features/admin/model/dashboard-types.ts
+++ b/src/features/admin/model/dashboard-types.ts
@@ -1,5 +1,12 @@
 export type ApplicationStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
 
+export type AdminRole = 'UNIVERSITY_ADMIN' | 'MOKKOJI_ADMIN';
+
+export interface AdminInfo {
+  role: AdminRole;
+  universityCode: string | null;
+}
+
 export interface ClubMasterApplication {
   id: number;
   universityName: string;

--- a/src/views/admin/ui/AdminDashboardView.tsx
+++ b/src/views/admin/ui/AdminDashboardView.tsx
@@ -5,7 +5,6 @@ import type {
 } from '@/features/admin/model/dashboard-types';
 import ClubMasterApplicationWidget from '@/widgets/admin/ui/ClubMasterApplicationWidget';
 import AdminUniversitySelectWidget from '@/widgets/admin/ui/AdminUniversitySelectWidget';
-import { getUniversityName } from '@/shared/lib/universityMeta';
 import type { UniversityOption } from '@/entities/university/model/type';
 
 interface AdminDashboardViewProps {
@@ -32,6 +31,9 @@ function AdminDashboardView({
   selectedCode,
 }: AdminDashboardViewProps) {
   const isMokkojiAdmin = role === 'MOKKOJI_ADMIN';
+  const selectedUniversityName =
+    universities.find((university) => university.code === selectedCode)?.name ??
+    selectedCode;
 
   return (
     <div className="flex flex-col gap-8 px-[140px] pt-4 pb-10">
@@ -49,7 +51,7 @@ function AdminDashboardView({
           />
         ) : (
           <span className="text-[16px] leading-[140%] font-medium text-[#474747]">
-            {getUniversityName(selectedCode)}
+            {selectedUniversityName}
           </span>
         )}
       </div>

--- a/src/views/admin/ui/AdminDashboardView.tsx
+++ b/src/views/admin/ui/AdminDashboardView.tsx
@@ -110,6 +110,7 @@ function AdminDashboardView({
             </p>
           </div>
           <ClubMasterApplicationWidget
+            key={selectedCode}
             initialClubApplications={clubApplications}
             initialClubMasterApplications={clubMasterApplications}
           />

--- a/src/views/admin/ui/AdminDashboardView.tsx
+++ b/src/views/admin/ui/AdminDashboardView.tsx
@@ -6,11 +6,7 @@ import type {
 import ClubMasterApplicationWidget from '@/widgets/admin/ui/ClubMasterApplicationWidget';
 import AdminUniversitySelectWidget from '@/widgets/admin/ui/AdminUniversitySelectWidget';
 import { getUniversityName } from '@/shared/lib/universityMeta';
-
-interface UniversityOption {
-  code: string;
-  name: string;
-}
+import type { UniversityOption } from '@/entities/university/model/type';
 
 interface AdminDashboardViewProps {
   clubMasterApplications: ClubMasterApplication[];

--- a/src/views/admin/ui/AdminDashboardView.tsx
+++ b/src/views/admin/ui/AdminDashboardView.tsx
@@ -1,8 +1,16 @@
 import type {
   ClubMasterApplication,
   ClubApplication,
+  AdminRole,
 } from '@/features/admin/model/dashboard-types';
 import ClubMasterApplicationWidget from '@/widgets/admin/ui/ClubMasterApplicationWidget';
+import AdminUniversitySelectWidget from '@/widgets/admin/ui/AdminUniversitySelectWidget';
+import { getUniversityName } from '@/shared/lib/universityMeta';
+
+interface UniversityOption {
+  code: string;
+  name: string;
+}
 
 interface AdminDashboardViewProps {
   clubMasterApplications: ClubMasterApplication[];
@@ -11,6 +19,9 @@ interface AdminDashboardViewProps {
   pendingMasterCount: number;
   pendingClubCount: number;
   totalMasters: number;
+  role: AdminRole;
+  universities: UniversityOption[];
+  selectedCode: string;
 }
 
 function AdminDashboardView({
@@ -20,16 +31,31 @@ function AdminDashboardView({
   pendingMasterCount,
   pendingClubCount,
   totalMasters,
+  role,
+  universities,
+  selectedCode,
 }: AdminDashboardViewProps) {
+  const isMokkojiAdmin = role === 'MOKKOJI_ADMIN';
+
   return (
     <div className="flex flex-col gap-8 px-[140px] pt-4 pb-10">
-      <div>
+      <div className="flex items-center justify-between">
         <button
           type="button"
           className="flex h-[50px] items-center justify-center rounded-[30px] bg-[#4AF38A] px-5 text-[16px] leading-[140%] font-medium text-[#000000]"
         >
           대시보드
         </button>
+        {isMokkojiAdmin ? (
+          <AdminUniversitySelectWidget
+            universities={universities}
+            selectedCode={selectedCode}
+          />
+        ) : (
+          <span className="text-[16px] leading-[140%] font-medium text-[#474747]">
+            {getUniversityName(selectedCode)}
+          </span>
+        )}
       </div>
 
       <div className="flex flex-col gap-8">

--- a/src/widgets/admin/ui/AdminUniversitySelectWidget.tsx
+++ b/src/widgets/admin/ui/AdminUniversitySelectWidget.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/ui/select';
+
+interface UniversityOption {
+  code: string;
+  name: string;
+}
+
+interface AdminUniversitySelectWidgetProps {
+  universities: UniversityOption[];
+  selectedCode: string;
+}
+
+function AdminUniversitySelectWidget({
+  universities,
+  selectedCode,
+}: AdminUniversitySelectWidgetProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const changeUniversity = (code: string) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('universityCode', code);
+    router.push(`?${params.toString()}`);
+  };
+
+  return (
+    <Select value={selectedCode} onValueChange={changeUniversity}>
+      <SelectTrigger className="w-[200px]">
+        <SelectValue placeholder="학교를 선택해주세요" />
+      </SelectTrigger>
+      <SelectContent>
+        {universities.map((university) => (
+          <SelectItem key={university.code} value={university.code}>
+            {university.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+export default AdminUniversitySelectWidget;

--- a/src/widgets/admin/ui/AdminUniversitySelectWidget.tsx
+++ b/src/widgets/admin/ui/AdminUniversitySelectWidget.tsx
@@ -8,11 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/shared/ui/select';
-
-interface UniversityOption {
-  code: string;
-  name: string;
-}
+import type { UniversityOption } from '@/entities/university/model/type';
 
 interface AdminUniversitySelectWidgetProps {
   universities: UniversityOption[];


### PR DESCRIPTION
## #️⃣연관된 이슈

#560

## 📝작업 내용

관리자 정보 조회 API(`GET /admin/me`, BE PR greedy-team/mokkoji-be#447)를 연동해, 대시보드 로그인 후 진입 시 관리자 권한에 따라 데이터 노출을 분기합니다.

- **총동연(UNIVERSITY_ADMIN)**: `/admin/me`의 `universityCode`로 해당 학교만 조회하고 학교명을 고정 표시
- **모꼬지 개발자(MOKKOJI_ADMIN)**: 학교 선택 셀렉터를 노출하고, 선택 시 `?universityCode=`(URL searchParam)로 서버 컴포넌트를 재조회
- 관리자 정보 조회 실패 구분: 4xx(미인증/권한없음/미등록)는 로그인으로 리다이렉트, 5xx·네트워크 오류는 대시보드 에러 바운더리로 처리
- `/admin/me`가 학교명을 주지 않아, 학교명은 동적 목록 API(`GET /universities`)에서 코드로 조회해 통일 (정적 맵 의존 제거, 신규 학교 자동 대응)

## 💬리뷰 요구사항(선택)