### PR TITLE
fix: 관리자 대시보드 현황 수치 오류 수정 및 승인 대기 신청 화면 재설계

### DIFF
--- a/src/app/(admin)/dashboard/(main)/page.tsx
+++ b/src/app/(admin)/dashboard/(main)/page.tsx
@@ -21,7 +21,7 @@ async function DashboardPage({ searchParams }: DashboardPageProps) {
   const adminInfo = await getAdminInfo();
 
   if (!adminInfo) {
-    redirect('/dashboard/login');
+    redirect('/api/auth/dashboard-logout');
   }
 
   const isMokkojiAdmin = adminInfo.role === 'MOKKOJI_ADMIN';

--- a/src/app/(admin)/dashboard/(main)/page.tsx
+++ b/src/app/(admin)/dashboard/(main)/page.tsx
@@ -13,18 +13,12 @@ async function DashboardPage() {
 
   const clubMasterApplications = clubMasterData?.applications ?? [];
   const clubApplications = clubApplicationData?.applications ?? [];
-  const clubs = clubsData?.clubs ?? [];
 
   const totalClubs = clubsData?.page?.totalElements ?? 0;
   const pendingMasterCount = clubMasterApplications.filter(
     (application) => application.status === 'PENDING',
   ).length;
   const pendingClubCount = clubApplicationData?.page?.totalElements ?? 0;
-  const totalMasters = new Set(
-    clubs
-      .filter((club) => club.clubMaster !== null)
-      .map((club) => club.clubMaster!.id),
-  ).size;
 
   return (
     <Suspense>
@@ -34,7 +28,6 @@ async function DashboardPage() {
         totalClubs={totalClubs}
         pendingMasterCount={pendingMasterCount}
         pendingClubCount={pendingClubCount}
-        totalMasters={totalMasters}
       />
     </Suspense>
   );

--- a/src/app/(admin)/dashboard/(main)/page.tsx
+++ b/src/app/(admin)/dashboard/(main)/page.tsx
@@ -2,20 +2,11 @@ import { Suspense } from 'react';
 import { redirect } from 'next/navigation';
 import AdminDashboardView from '@/views/admin/ui/AdminDashboardView';
 import getAdminInfo from '@/features/admin/api/getAdminInfo';
-import getClubMasterApplications from '@/features/admin/api/getClubMasterApplications';
-import getClubApplications from '@/features/admin/api/getClubApplications';
-import getUniversities from '@/entities/university/api/getUniversities';
-import type { ApplicationStatus } from '@/features/admin/model/dashboard-types';
+import getDashboardData from '@/features/admin/api/getDashboardData';
 
 interface DashboardPageProps {
   searchParams: Promise<{ universityCode?: string }>;
 }
-
-const APPLICATION_STATUSES: ApplicationStatus[] = [
-  'PENDING',
-  'APPROVED',
-  'REJECTED',
-];
 
 async function DashboardPage({ searchParams }: DashboardPageProps) {
   const adminInfo = await getAdminInfo();
@@ -24,33 +15,13 @@ async function DashboardPage({ searchParams }: DashboardPageProps) {
     redirect('/api/auth/dashboard-logout');
   }
 
-  const isMokkojiAdmin = adminInfo.role === 'MOKKOJI_ADMIN';
-
-  const universitiesResult = await getUniversities();
-  const universities =
-    universitiesResult?.ok && universitiesResult.data
-      ? universitiesResult.data.universities.map((university) => ({
-          code: university.code,
-          name: university.name,
-        }))
-      : [];
-
   const { universityCode: selectedFromUrl } = await searchParams;
-  const universityCode = isMokkojiAdmin
-    ? (selectedFromUrl ?? universities[0]?.code)
-    : (adminInfo.universityCode ?? undefined);
-
-  const [clubMasterData, ...clubApplicationResults] = await Promise.all([
-    getClubMasterApplications({ page: 1, size: 100, universityCode }),
-    ...APPLICATION_STATUSES.map((status) =>
-      getClubApplications({ status, page: 1, size: 100, universityCode }),
-    ),
-  ]);
-
-  const clubMasterApplications = clubMasterData?.applications ?? [];
-  const clubApplications = clubApplicationResults.flatMap(
-    (result) => result?.applications ?? [],
-  );
+  const {
+    universities,
+    universityCode,
+    clubMasterApplications,
+    clubApplications,
+  } = await getDashboardData(adminInfo, selectedFromUrl);
 
   return (
     <Suspense>

--- a/src/app/(admin)/dashboard/(main)/page.tsx
+++ b/src/app/(admin)/dashboard/(main)/page.tsx
@@ -4,12 +4,18 @@ import AdminDashboardView from '@/views/admin/ui/AdminDashboardView';
 import getAdminInfo from '@/features/admin/api/getAdminInfo';
 import getClubMasterApplications from '@/features/admin/api/getClubMasterApplications';
 import getClubApplications from '@/features/admin/api/getClubApplications';
-import getAdminClubs from '@/features/admin/api/getAdminClubs';
 import getUniversities from '@/entities/university/api/getUniversities';
+import type { ApplicationStatus } from '@/features/admin/model/dashboard-types';
 
 interface DashboardPageProps {
   searchParams: Promise<{ universityCode?: string }>;
 }
+
+const APPLICATION_STATUSES: ApplicationStatus[] = [
+  'PENDING',
+  'APPROVED',
+  'REJECTED',
+];
 
 async function DashboardPage({ searchParams }: DashboardPageProps) {
   const adminInfo = await getAdminInfo();
@@ -34,34 +40,23 @@ async function DashboardPage({ searchParams }: DashboardPageProps) {
     ? (selectedFromUrl ?? universities[0]?.code)
     : (adminInfo.universityCode ?? undefined);
 
-  const [clubMasterData, clubApplicationData, clubsData] = await Promise.all([
+  const [clubMasterData, ...clubApplicationResults] = await Promise.all([
     getClubMasterApplications({ page: 1, size: 100, universityCode }),
-    getClubApplications({
-      status: 'PENDING',
-      page: 1,
-      size: 100,
-      universityCode,
-    }),
-    getAdminClubs({ page: 1, size: 100, universityCode }),
+    ...APPLICATION_STATUSES.map((status) =>
+      getClubApplications({ status, page: 1, size: 100, universityCode }),
+    ),
   ]);
 
   const clubMasterApplications = clubMasterData?.applications ?? [];
-  const clubApplications = clubApplicationData?.applications ?? [];
-
-  const totalClubs = clubsData?.page?.totalElements ?? 0;
-  const pendingMasterCount = clubMasterApplications.filter(
-    (application) => application.status === 'PENDING',
-  ).length;
-  const pendingClubCount = clubApplicationData?.page?.totalElements ?? 0;
+  const clubApplications = clubApplicationResults.flatMap(
+    (result) => result?.applications ?? [],
+  );
 
   return (
     <Suspense>
       <AdminDashboardView
         clubMasterApplications={clubMasterApplications}
         clubApplications={clubApplications}
-        totalClubs={totalClubs}
-        pendingMasterCount={pendingMasterCount}
-        pendingClubCount={pendingClubCount}
         role={adminInfo.role}
         universities={universities}
         selectedCode={universityCode ?? ''}

--- a/src/app/(admin)/dashboard/(main)/page.tsx
+++ b/src/app/(admin)/dashboard/(main)/page.tsx
@@ -15,10 +15,16 @@ async function DashboardPage() {
   const clubApplications = clubApplicationData?.applications ?? [];
   const clubs = clubsData?.clubs ?? [];
 
-  const totalClubs = clubsData?.pagination?.totalElements ?? 0;
-  const pendingMasterCount = clubMasterData?.pagination?.totalElements ?? 0;
+  const totalClubs = clubsData?.page?.totalElements ?? 0;
+  const pendingMasterCount = clubMasterApplications.filter(
+    (application) => application.status === 'PENDING',
+  ).length;
   const pendingClubCount = clubApplicationData?.page?.totalElements ?? 0;
-  const totalMasters = clubs.filter((club) => club.clubMaster !== null).length;
+  const totalMasters = new Set(
+    clubs
+      .filter((club) => club.clubMaster !== null)
+      .map((club) => club.clubMaster!.id),
+  ).size;
 
   return (
     <Suspense>

--- a/src/app/[universityCode]/(main)/my/applications/create/page.tsx
+++ b/src/app/[universityCode]/(main)/my/applications/create/page.tsx
@@ -1,0 +1,35 @@
+import { getSession } from '@/shared/lib/cookie-session';
+import LoginRequired from '@/shared/ui/login-required';
+import getClubApplicationStatus from '@/entities/my/api/getClubApplicationStatus';
+import { toCreateCardItem } from '@/entities/my/lib/application-card';
+import ClubApplicationList from '@/features/my/ui/club-application-list';
+
+interface PageProps {
+  params: Promise<{ universityCode: string }>;
+}
+
+async function Page({ params }: PageProps) {
+  const { universityCode } = await params;
+  const session = await getSession();
+
+  if (!session) {
+    return <LoginRequired />;
+  }
+
+  const clubApplicationStatus = await getClubApplicationStatus();
+  const items = (clubApplicationStatus.data?.clubApplications ?? []).map(
+    toCreateCardItem,
+  );
+
+  return (
+    <div className="mx-auto w-full px-4 sm:w-lg">
+      <ClubApplicationList
+        title="동아리 생성 신청"
+        items={items}
+        universityCode={universityCode}
+      />
+    </div>
+  );
+}
+
+export default Page;

--- a/src/app/[universityCode]/(main)/my/applications/create/page.tsx
+++ b/src/app/[universityCode]/(main)/my/applications/create/page.tsx
@@ -2,6 +2,7 @@ import { getSession } from '@/shared/lib/cookie-session';
 import LoginRequired from '@/shared/ui/login-required';
 import getClubApplicationStatus from '@/entities/my/api/getClubApplicationStatus';
 import { toCreateCardItem } from '@/entities/my/lib/application-card';
+import { APPLICATION_SECTION } from '@/entities/my/model/constants';
 import ClubApplicationList from '@/features/my/ui/club-application-list';
 
 interface PageProps {
@@ -24,7 +25,7 @@ async function Page({ params }: PageProps) {
   return (
     <div className="mx-auto w-full px-4 sm:w-lg">
       <ClubApplicationList
-        title="동아리 생성 신청"
+        title={APPLICATION_SECTION.create.title}
         items={items}
         universityCode={universityCode}
       />

--- a/src/app/[universityCode]/(main)/my/applications/master/page.tsx
+++ b/src/app/[universityCode]/(main)/my/applications/master/page.tsx
@@ -17,9 +17,7 @@ async function Page({ params }: PageProps) {
   }
 
   const clubMasterStatus = await getMyClubMasterApplications();
-  const items = (clubMasterStatus.data?.applications ?? []).map(
-    toMasterCardItem,
-  );
+  const items = (clubMasterStatus.data ?? []).map(toMasterCardItem);
 
   return (
     <div className="mx-auto w-full px-4 sm:w-lg">

--- a/src/app/[universityCode]/(main)/my/applications/master/page.tsx
+++ b/src/app/[universityCode]/(main)/my/applications/master/page.tsx
@@ -26,7 +26,6 @@ async function Page({ params }: PageProps) {
         title={APPLICATION_SECTION.master.title}
         items={items}
         universityCode={universityCode}
-        showLogo
       />
     </div>
   );

--- a/src/app/[universityCode]/(main)/my/applications/master/page.tsx
+++ b/src/app/[universityCode]/(main)/my/applications/master/page.tsx
@@ -1,0 +1,36 @@
+import { getSession } from '@/shared/lib/cookie-session';
+import LoginRequired from '@/shared/ui/login-required';
+import getMyClubMasterApplications from '@/entities/my/api/getMyClubMasterApplications';
+import { toMasterCardItem } from '@/entities/my/lib/application-card';
+import ClubApplicationList from '@/features/my/ui/club-application-list';
+
+interface PageProps {
+  params: Promise<{ universityCode: string }>;
+}
+
+async function Page({ params }: PageProps) {
+  const { universityCode } = await params;
+  const session = await getSession();
+
+  if (!session) {
+    return <LoginRequired />;
+  }
+
+  const clubMasterStatus = await getMyClubMasterApplications();
+  const items = (clubMasterStatus.data?.applications ?? []).map(
+    toMasterCardItem,
+  );
+
+  return (
+    <div className="mx-auto w-full px-4 sm:w-lg">
+      <ClubApplicationList
+        title="동아리 & 동아리장 신청"
+        items={items}
+        universityCode={universityCode}
+        showLogo
+      />
+    </div>
+  );
+}
+
+export default Page;

--- a/src/app/[universityCode]/(main)/my/applications/master/page.tsx
+++ b/src/app/[universityCode]/(main)/my/applications/master/page.tsx
@@ -2,6 +2,7 @@ import { getSession } from '@/shared/lib/cookie-session';
 import LoginRequired from '@/shared/ui/login-required';
 import getMyClubMasterApplications from '@/entities/my/api/getMyClubMasterApplications';
 import { toMasterCardItem } from '@/entities/my/lib/application-card';
+import { APPLICATION_SECTION } from '@/entities/my/model/constants';
 import ClubApplicationList from '@/features/my/ui/club-application-list';
 
 interface PageProps {
@@ -22,7 +23,7 @@ async function Page({ params }: PageProps) {
   return (
     <div className="mx-auto w-full px-4 sm:w-lg">
       <ClubApplicationList
-        title="동아리 & 동아리장 신청"
+        title={APPLICATION_SECTION.master.title}
         items={items}
         universityCode={universityCode}
         showLogo

--- a/src/app/[universityCode]/(main)/my/page.tsx
+++ b/src/app/[universityCode]/(main)/my/page.tsx
@@ -1,12 +1,16 @@
 import MyPage from '@/entities/my/ui/my-page';
 
 interface PageProps {
+  params: Promise<{ universityCode: string }>;
   searchParams: Promise<{ newUser?: string }>;
 }
 
-async function Page({ searchParams }: PageProps) {
+async function Page({ params, searchParams }: PageProps) {
+  const { universityCode } = await params;
   const { newUser } = await searchParams;
-  return <MyPage isNewUser={newUser === 'true'} />;
+  return (
+    <MyPage universityCode={universityCode} isNewUser={newUser === 'true'} />
+  );
 }
 
 export default Page;

--- a/src/app/api/auth/dashboard-logout/route.ts
+++ b/src/app/api/auth/dashboard-logout/route.ts
@@ -1,9 +1,15 @@
 /* eslint-disable import/prefer-default-export */
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { DASHBOARD_SESSION_COOKIE_NAME } from '@/shared/lib/dashboard-session';
 
 export async function POST() {
   const response = NextResponse.json({ ok: true });
+  response.cookies.delete(DASHBOARD_SESSION_COOKIE_NAME);
+  return response;
+}
+
+export async function GET(req: NextRequest) {
+  const response = NextResponse.redirect(new URL('/dashboard/login', req.url));
   response.cookies.delete(DASHBOARD_SESSION_COOKIE_NAME);
   return response;
 }

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -8,6 +8,10 @@ export async function GET() {
     return NextResponse.json(null);
   }
 
+  if (session.expiresAt && Date.now() >= session.expiresAt) {
+    return NextResponse.json(null);
+  }
+
   return NextResponse.json({
     user: session.user,
     role: session.role,

--- a/src/entities/my/api/getMyClubMasterApplications.tsx
+++ b/src/entities/my/api/getMyClubMasterApplications.tsx
@@ -1,0 +1,24 @@
+import api from '@/shared/api/auth-api';
+import { ApiResponse } from '@/shared/model/type';
+import createErrorResponse from '@/shared/lib/error-message';
+import { MyClubMasterApplicationListType } from '../model/type';
+
+async function getMyClubMasterApplications() {
+  try {
+    const response: ApiResponse<MyClubMasterApplicationListType> = await api
+      .get('club-master-applications/me', {
+        cache: 'no-store',
+        next: { tags: ['club-master-applications-me'] },
+      })
+      .json();
+    return {
+      ok: true,
+      data: response.data,
+      status: 200,
+    };
+  } catch (error) {
+    return createErrorResponse(error as Error);
+  }
+}
+
+export default getMyClubMasterApplications;

--- a/src/entities/my/api/getMyClubMasterApplications.tsx
+++ b/src/entities/my/api/getMyClubMasterApplications.tsx
@@ -1,11 +1,11 @@
 import api from '@/shared/api/auth-api';
 import { ApiResponse } from '@/shared/model/type';
 import createErrorResponse from '@/shared/lib/error-message';
-import { MyClubMasterApplicationListType } from '../model/type';
+import { MyClubMasterApplicationType } from '../model/type';
 
 async function getMyClubMasterApplications() {
   try {
-    const response: ApiResponse<MyClubMasterApplicationListType> = await api
+    const response: ApiResponse<MyClubMasterApplicationType[]> = await api
       .get('club-master-applications/me', {
         cache: 'no-store',
         next: { tags: ['club-master-applications-me'] },

--- a/src/entities/my/lib/application-card.ts
+++ b/src/entities/my/lib/application-card.ts
@@ -1,4 +1,3 @@
-import { getUniversityName } from '@/shared/lib/universityMeta';
 import {
   ApplicationCardItem,
   ClubApplicationType,
@@ -24,10 +23,10 @@ export function toMasterCardItem(
   return {
     id: application.id,
     clubName: application.clubName,
-    universityName: getUniversityName(application.universityCode),
+    universityName: application.universityName,
     status: application.status,
     rejectReason: application.rejectReason,
-    logo: application.logo ?? null,
+    logo: null,
     createdAt: application.createdAt,
   };
 }

--- a/src/entities/my/lib/application-card.ts
+++ b/src/entities/my/lib/application-card.ts
@@ -1,0 +1,41 @@
+import { getUniversityName } from '@/shared/lib/universityMeta';
+import {
+  ApplicationCardItem,
+  ClubApplicationType,
+  MyClubMasterApplicationType,
+} from '../model/type';
+
+export function toCreateCardItem(
+  application: ClubApplicationType,
+): ApplicationCardItem {
+  return {
+    id: application.clubApplicationId,
+    clubName: application.clubName,
+    universityName: application.universityName,
+    status: application.status,
+    rejectReason: application.rejectReason,
+    createdAt: application.createdAt,
+  };
+}
+
+export function toMasterCardItem(
+  application: MyClubMasterApplicationType,
+): ApplicationCardItem {
+  return {
+    id: application.id,
+    clubName: application.clubName,
+    universityName: getUniversityName(application.universityCode),
+    status: application.status,
+    rejectReason: application.rejectReason,
+    logo: application.logo ?? null,
+    createdAt: application.createdAt,
+  };
+}
+
+export function sortByLatest(
+  items: ApplicationCardItem[],
+): ApplicationCardItem[] {
+  return [...items].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+}

--- a/src/entities/my/lib/application-card.ts
+++ b/src/entities/my/lib/application-card.ts
@@ -26,7 +26,6 @@ export function toMasterCardItem(
     universityName: application.universityName,
     status: application.status,
     rejectReason: application.rejectReason,
-    logo: null,
     createdAt: application.createdAt,
   };
 }

--- a/src/entities/my/model/constants.ts
+++ b/src/entities/my/model/constants.ts
@@ -1,0 +1,11 @@
+/* eslint-disable import/prefer-default-export */
+export const APPLICATION_SECTION = {
+  master: {
+    title: '동아리 & 동아리장 신청',
+    path: 'master',
+  },
+  create: {
+    title: '동아리 생성 신청',
+    path: 'create',
+  },
+} as const;

--- a/src/entities/my/model/type.ts
+++ b/src/entities/my/model/type.ts
@@ -24,17 +24,13 @@ export interface ClubApplicationListType {
 
 export interface MyClubMasterApplicationType {
   id: number;
-  universityCode: string;
+  universityName: string;
   clubName: string;
   userName: string;
   status: ClubApplicationStatus;
   rejectReason: string | null;
-  logo?: string | null;
   createdAt: string;
-}
-
-export interface MyClubMasterApplicationListType {
-  applications: MyClubMasterApplicationType[];
+  updatedAt?: string;
 }
 
 export interface ApplicationCardItem {

--- a/src/entities/my/model/type.ts
+++ b/src/entities/my/model/type.ts
@@ -22,4 +22,29 @@ export interface ClubApplicationListType {
   clubApplications: ClubApplicationType[];
 }
 
+export interface MyClubMasterApplicationType {
+  id: number;
+  universityCode: string;
+  clubName: string;
+  userName: string;
+  status: ClubApplicationStatus;
+  rejectReason: string | null;
+  logo?: string | null;
+  createdAt: string;
+}
+
+export interface MyClubMasterApplicationListType {
+  applications: MyClubMasterApplicationType[];
+}
+
+export interface ApplicationCardItem {
+  id: number;
+  clubName: string;
+  universityName: string;
+  status: ClubApplicationStatus;
+  rejectReason: string | null;
+  logo?: string | null;
+  createdAt: string;
+}
+
 export default UserInfoType;

--- a/src/entities/my/model/type.ts
+++ b/src/entities/my/model/type.ts
@@ -39,7 +39,6 @@ export interface ApplicationCardItem {
   universityName: string;
   status: ClubApplicationStatus;
   rejectReason: string | null;
-  logo?: string | null;
   createdAt: string;
 }
 

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -10,6 +10,11 @@ import { getUniversityName } from '@/shared/lib/universityMeta';
 import getUniversities from '@/entities/university/api/getUniversities';
 import getMyInfo from '@/entities/my/api/getMyInfo';
 import getClubApplicationStatus from '@/entities/my/api/getClubApplicationStatus';
+import getMyClubMasterApplications from '@/entities/my/api/getMyClubMasterApplications';
+import {
+  toCreateCardItem,
+  toMasterCardItem,
+} from '@/entities/my/lib/application-card';
 import InfoRow from '@/entities/my/ui/info-row';
 import EmailChangeDialog from '@/features/my/ui/email-change-dialog';
 import EmailDeleteButton from '@/features/my/ui/email-delete-button';
@@ -17,18 +22,26 @@ import MailNotificationToggle from '@/features/my/ui/mail-notification-toggle';
 import LogoutLink from '@/features/my/ui/logout-link';
 import ClubApplicationStatus from '@/features/my/ui/club-application-status';
 
-async function MyPage({ isNewUser = false }: { isNewUser?: boolean }) {
+async function MyPage({
+  universityCode,
+  isNewUser = false,
+}: {
+  universityCode: string;
+  isNewUser?: boolean;
+}) {
   const session = await getSession();
 
   if (!session) {
     return <LoginRequired />;
   }
 
-  const [myInfo, universitiesRes, clubApplicationStatus] = await Promise.all([
-    getMyInfo(),
-    getUniversities(),
-    getClubApplicationStatus(),
-  ]);
+  const [myInfo, universitiesRes, clubApplicationStatus, clubMasterStatus] =
+    await Promise.all([
+      getMyInfo(),
+      getUniversities(),
+      getClubApplicationStatus(),
+      getMyClubMasterApplications(),
+    ]);
 
   if (!myInfo.ok || !myInfo.data) {
     return <ErrorBoundaryUi />;
@@ -36,7 +49,12 @@ async function MyPage({ isNewUser = false }: { isNewUser?: boolean }) {
 
   const user = myInfo.data;
   const universities = universitiesRes.data?.universities ?? [];
-  const clubApplications = clubApplicationStatus.data?.clubApplications ?? [];
+  const createItems = (clubApplicationStatus.data?.clubApplications ?? []).map(
+    toCreateCardItem,
+  );
+  const masterItems = (clubMasterStatus.data?.applications ?? []).map(
+    toMasterCardItem,
+  );
   const userRole = session?.role || UserRole.NORMAL;
   const isAdmin = userRole !== UserRole.NORMAL;
 
@@ -52,9 +70,11 @@ async function MyPage({ isNewUser = false }: { isNewUser?: boolean }) {
           </div>
         </div>
 
-        {clubApplications.length > 0 && (
-          <ClubApplicationStatus applications={clubApplications} />
-        )}
+        <ClubApplicationStatus
+          createItems={createItems}
+          masterItems={masterItems}
+          universityCode={universityCode}
+        />
 
         <div className="flex flex-col">
           <span className="mb-4 font-semibold">내 정보</span>

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -52,9 +52,7 @@ async function MyPage({
   const createItems = (clubApplicationStatus.data?.clubApplications ?? []).map(
     toCreateCardItem,
   );
-  const masterItems = (clubMasterStatus.data?.applications ?? []).map(
-    toMasterCardItem,
-  );
+  const masterItems = (clubMasterStatus.data ?? []).map(toMasterCardItem);
   const userRole = session?.role || UserRole.NORMAL;
   const isAdmin = userRole !== UserRole.NORMAL;
 

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -15,6 +15,7 @@ import EmailChangeDialog from '@/features/my/ui/email-change-dialog';
 import EmailDeleteButton from '@/features/my/ui/email-delete-button';
 import MailNotificationToggle from '@/features/my/ui/mail-notification-toggle';
 import LogoutLink from '@/features/my/ui/logout-link';
+import WithdrawButton from '@/features/my/ui/withdraw-button';
 import ClubApplicationStatus from '@/features/my/ui/club-application-status';
 
 async function MyPage({ isNewUser = false }: { isNewUser?: boolean }) {
@@ -95,8 +96,11 @@ async function MyPage({ isNewUser = false }: { isNewUser?: boolean }) {
               universities={universities}
             />
           </div>
-          <div className="mb-15 lg:hidden">
+          <div className="lg:hidden">
             <LogoutLink />
+          </div>
+          <div className="mt-2 mb-15">
+            <WithdrawButton />
           </div>
         </div>
       </div>

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -96,7 +96,7 @@ async function MyPage({ isNewUser = false }: { isNewUser?: boolean }) {
               universities={universities}
             />
           </div>
-          <div className="lg:hidden">
+          <div>
             <LogoutLink />
           </div>
           <div className="mt-2 mb-15">

--- a/src/features/admin/api/getAdminClubs.ts
+++ b/src/features/admin/api/getAdminClubs.ts
@@ -13,7 +13,7 @@ interface Params {
 
 interface Response {
   clubs: AdminClub[];
-  pagination: PaginationMeta;
+  page: PaginationMeta;
 }
 
 async function getAdminClubs(params: Params): Promise<Response | null> {

--- a/src/features/admin/api/getClubMasterApplications.ts
+++ b/src/features/admin/api/getClubMasterApplications.ts
@@ -12,7 +12,7 @@ interface Params {
 
 interface Response {
   applications: ClubMasterApplication[];
-  page: PaginationMeta;
+  pagination: PaginationMeta;
 }
 
 async function getClubMasterApplications(

--- a/src/features/admin/api/getClubMasterApplications.ts
+++ b/src/features/admin/api/getClubMasterApplications.ts
@@ -12,7 +12,7 @@ interface Params {
 
 interface Response {
   applications: ClubMasterApplication[];
-  pagination: PaginationMeta;
+  page: PaginationMeta;
 }
 
 async function getClubMasterApplications(

--- a/src/features/admin/api/getDashboardData.ts
+++ b/src/features/admin/api/getDashboardData.ts
@@ -1,0 +1,52 @@
+import 'server-only';
+import getUniversities from '@/entities/university/api/getUniversities';
+import getClubMasterApplications from '@/features/admin/api/getClubMasterApplications';
+import getClubApplications from '@/features/admin/api/getClubApplications';
+import type {
+  AdminInfo,
+  ApplicationStatus,
+} from '@/features/admin/model/dashboard-types';
+
+const APPLICATION_STATUSES: ApplicationStatus[] = [
+  'PENDING',
+  'APPROVED',
+  'REJECTED',
+];
+
+async function getDashboardData(
+  adminInfo: AdminInfo,
+  selectedFromUrl?: string,
+) {
+  const isMokkojiAdmin = adminInfo.role === 'MOKKOJI_ADMIN';
+
+  const universitiesResult = await getUniversities();
+  const universities =
+    universitiesResult?.ok && universitiesResult.data
+      ? universitiesResult.data.universities.map((university) => ({
+          code: university.code,
+          name: university.name,
+        }))
+      : [];
+
+  const universityCode = isMokkojiAdmin
+    ? (selectedFromUrl ?? universities[0]?.code)
+    : (adminInfo.universityCode ?? undefined);
+
+  const [clubMasterData, ...clubApplicationResults] = await Promise.all([
+    getClubMasterApplications({ page: 1, size: 100, universityCode }),
+    ...APPLICATION_STATUSES.map((status) =>
+      getClubApplications({ status, page: 1, size: 100, universityCode }),
+    ),
+  ]);
+
+  return {
+    universities,
+    universityCode,
+    clubMasterApplications: clubMasterData?.applications ?? [],
+    clubApplications: clubApplicationResults.flatMap(
+      (result) => result?.applications ?? [],
+    ),
+  };
+}
+
+export default getDashboardData;

--- a/src/features/admin/model/dashboard-types.ts
+++ b/src/features/admin/model/dashboard-types.ts
@@ -47,6 +47,24 @@ export interface AdminClub {
   } | null;
 }
 
+export type ApplicationKind = 'club' | 'master';
+
+export interface ApplicationCardItem {
+  key: string;
+  kind: ApplicationKind;
+  applicationId: number;
+  clubName: string;
+  universityName: string;
+  applicantName: string;
+  status: ApplicationStatus;
+  createdAt: string;
+  category?: string;
+  affiliation?: string;
+  logo?: string;
+  instagram?: string;
+  description?: string;
+}
+
 export interface PaginationMeta {
   page: number;
   size: number;

--- a/src/features/admin/ui/ApplicationCard.tsx
+++ b/src/features/admin/ui/ApplicationCard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import Image from 'next/image';
 import type { ApplicationCardItem } from '@/features/admin/model/dashboard-types';
 import { ClubCategoryLabel, ClubCategory } from '@/shared/model/type';
 import RejectReasonDialog from './RejectReasonDialog';
@@ -28,6 +27,7 @@ function ApplicationCard({ item, onApprove, onReject }: ApplicationCardProps) {
   const instagramHref = item.instagram
     ? resolveInstagramHref(item.instagram)
     : null;
+  const hasLogo = !!item.logo && /^https?:\/\//.test(item.logo);
 
   const handleApprove = () => {
     onApprove();
@@ -48,14 +48,13 @@ function ApplicationCard({ item, onApprove, onReject }: ApplicationCardProps) {
               {item.applicantName}
             </span>
             <div className="flex items-center gap-6">
-              <div className="relative h-[52px] w-[52px] shrink-0 overflow-hidden rounded-full bg-[#F8F8F8]">
-                {item.logo && (
-                  <Image
+              <div className="h-[52px] w-[52px] shrink-0 overflow-hidden rounded-full bg-[#F8F8F8]">
+                {hasLogo && (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
                     src={item.logo}
                     alt={`${item.clubName} 로고`}
-                    fill
-                    sizes="52px"
-                    className="object-cover"
+                    className="h-full w-full object-cover"
                   />
                 )}
               </div>

--- a/src/features/admin/ui/ApplicationCard.tsx
+++ b/src/features/admin/ui/ApplicationCard.tsx
@@ -114,7 +114,7 @@ function ApplicationCard({ item, onApprove, onReject }: ApplicationCardProps) {
                   <button
                     type="button"
                     onClick={() => setDescriptionOpen((previous) => !previous)}
-                    className="border-b border-[#8B95A1] text-[12px] leading-[100%] font-normal text-[#8B95A1]"
+                    className="cursor-pointer border-b border-[#8B95A1] text-[12px] leading-[100%] font-normal text-[#8B95A1]"
                   >
                     한 줄 소개 보기
                   </button>
@@ -135,14 +135,14 @@ function ApplicationCard({ item, onApprove, onReject }: ApplicationCardProps) {
               <button
                 type="button"
                 onClick={handleApprove}
-                className="flex h-9 w-[72px] items-center justify-center rounded-[30px] bg-[#4AF38A] text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#000000] transition-colors hover:bg-[#22CF64]"
+                className="flex h-9 w-[72px] cursor-pointer items-center justify-center rounded-[30px] bg-[#4AF38A] text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#000000] transition-colors hover:bg-[#22CF64]"
               >
                 승인하기
               </button>
               <button
                 type="button"
                 onClick={() => setRejectDialogOpen(true)}
-                className="flex h-9 w-[72px] items-center justify-center rounded-[30px] border border-[#22CF64] bg-white text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#22CF64] transition-colors hover:bg-[#f0fff6]"
+                className="flex h-9 w-[72px] cursor-pointer items-center justify-center rounded-[30px] border border-[#22CF64] bg-white text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#22CF64] transition-colors hover:bg-[#f0fff6]"
               >
                 반려하기
               </button>

--- a/src/features/admin/ui/ApplicationCard.tsx
+++ b/src/features/admin/ui/ApplicationCard.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import type { ApplicationCardItem } from '@/features/admin/model/dashboard-types';
+import { ClubCategoryLabel, ClubCategory } from '@/shared/model/type';
+import RejectReasonDialog from './RejectReasonDialog';
+import ApproveCompleteDialog from './ApproveCompleteDialog';
+
+interface ApplicationCardProps {
+  item: ApplicationCardItem;
+  onApprove: () => void;
+  onReject: (rejectReason?: string) => void;
+}
+
+function ApplicationCard({ item, onApprove, onReject }: ApplicationCardProps) {
+  const [rejectDialogOpen, setRejectDialogOpen] = useState(false);
+  const [approveCompleteDialogOpen, setApproveCompleteDialogOpen] =
+    useState(false);
+  const [descriptionOpen, setDescriptionOpen] = useState(false);
+
+  const formattedDate = item.createdAt.slice(0, 10).replace(/-/g, '.');
+  const categoryLabel = item.category
+    ? (ClubCategoryLabel[item.category as ClubCategory] ?? item.category)
+    : null;
+  const resolveInstagramHref = (instagram: string) =>
+    instagram.startsWith('http') ? instagram : `https://${instagram}`;
+  const instagramHref = item.instagram
+    ? resolveInstagramHref(item.instagram)
+    : null;
+
+  const handleApprove = () => {
+    onApprove();
+    setApproveCompleteDialogOpen(true);
+  };
+
+  const handleRejectConfirm = (reason?: string) => {
+    onReject(reason);
+    setRejectDialogOpen(false);
+  };
+
+  return (
+    <>
+      <div className="flex w-full items-center justify-between border-b border-[#D6D6D6] py-3">
+        <div className="flex items-center gap-20">
+          <div className="flex items-center gap-8">
+            <span className="w-8 shrink-0 text-center text-[12px] leading-[100%] font-normal text-[#474747]">
+              {item.applicantName}
+            </span>
+            <div className="flex items-center gap-6">
+              <div className="relative h-[52px] w-[52px] shrink-0 overflow-hidden rounded-full bg-[#F8F8F8]">
+                {item.logo && (
+                  <Image
+                    src={item.logo}
+                    alt={`${item.clubName} 로고`}
+                    fill
+                    sizes="52px"
+                    className="object-cover"
+                  />
+                )}
+              </div>
+              <div className="flex flex-col gap-3">
+                <div className="flex w-fit items-center justify-center rounded-[30px] border border-[#22CF64] px-2.5 py-1.5">
+                  <span className="text-[12px] leading-[100%] font-normal text-[#22CF64]">
+                    {item.universityName}
+                  </span>
+                </div>
+                <div className="flex flex-col gap-px">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-[20px] leading-[140%] font-semibold tracking-[-0.03em] text-[#000000]">
+                      {item.clubName}
+                    </span>
+                    {categoryLabel && (
+                      <span className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#8B95A1]">
+                        {categoryLabel}
+                      </span>
+                    )}
+                    {item.affiliation && (
+                      <>
+                        <span className="h-0.5 w-0.5 rounded-full bg-[#D6D6D6]" />
+                        <span className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#8B95A1]">
+                          {item.affiliation}
+                        </span>
+                      </>
+                    )}
+                  </div>
+                  <span className="text-[12px] leading-[140%] font-normal text-[#8B95A1]">
+                    {formattedDate}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {(instagramHref || item.description) && (
+            <div className="flex items-center gap-5">
+              {instagramHref && (
+                <a
+                  href={instagramHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 rounded-[20px] border border-[#E2E2E2]/70 bg-white py-2 pr-3 pl-2"
+                >
+                  <span className="text-[8px] leading-[10px] text-[#6A6B6B]">
+                    🔗
+                  </span>
+                  <span className="text-[10px] leading-[12px] font-normal tracking-[-0.03em] text-[#6A6B6B]">
+                    {item.instagram}
+                  </span>
+                </a>
+              )}
+              {item.description && (
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => setDescriptionOpen((previous) => !previous)}
+                    className="border-b border-[#8B95A1] text-[12px] leading-[100%] font-normal text-[#8B95A1]"
+                  >
+                    한 줄 소개 보기
+                  </button>
+                  {descriptionOpen && (
+                    <div className="absolute top-6 left-0 z-10 w-[240px] rounded-[12px] border border-[#E2E2E2] bg-white p-3 text-[12px] leading-[140%] font-medium text-[#474747] shadow-md">
+                      {item.description}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          {item.status === 'PENDING' ? (
+            <>
+              <button
+                type="button"
+                onClick={handleApprove}
+                className="flex h-9 w-[72px] items-center justify-center rounded-[30px] bg-[#4AF38A] text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#000000] transition-colors hover:bg-[#22CF64]"
+              >
+                승인하기
+              </button>
+              <button
+                type="button"
+                onClick={() => setRejectDialogOpen(true)}
+                className="flex h-9 w-[72px] items-center justify-center rounded-[30px] border border-[#22CF64] bg-white text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#22CF64] transition-colors hover:bg-[#f0fff6]"
+              >
+                반려하기
+              </button>
+            </>
+          ) : (
+            <span
+              className={`text-[14px] leading-[140%] font-medium tracking-[-0.03em] ${item.status === 'APPROVED' ? 'text-[#22CF64]' : 'text-[#8B95A1]'}`}
+            >
+              {item.status === 'APPROVED' ? '승인됨' : '반려됨'}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <RejectReasonDialog
+        open={rejectDialogOpen}
+        onClose={() => setRejectDialogOpen(false)}
+        onConfirm={handleRejectConfirm}
+      />
+
+      <ApproveCompleteDialog
+        open={approveCompleteDialogOpen}
+        onClose={() => setApproveCompleteDialogOpen(false)}
+      />
+    </>
+  );
+}
+
+export default ApplicationCard;

--- a/src/features/admin/ui/ApproveCompleteDialog.tsx
+++ b/src/features/admin/ui/ApproveCompleteDialog.tsx
@@ -34,7 +34,7 @@ function ApproveCompleteDialog({ open, onClose }: ApproveCompleteDialogProps) {
             <button
               type="button"
               onClick={onClose}
-              className="flex h-[51px] w-full items-center justify-center rounded-[12px] bg-[#4AF38A] text-[16px] leading-[140%] font-medium text-[#474747] transition-colors hover:bg-[#22CF64]"
+              className="flex h-[51px] w-full cursor-pointer items-center justify-center rounded-[12px] bg-[#4AF38A] text-[16px] leading-[140%] font-medium text-[#474747] transition-colors hover:bg-[#22CF64]"
             >
               완료
             </button>

--- a/src/features/admin/ui/RejectReasonDialog.tsx
+++ b/src/features/admin/ui/RejectReasonDialog.tsx
@@ -54,7 +54,7 @@ function RejectReasonDialog({
             <button
               type="button"
               onClick={handleConfirm}
-              className="flex h-[51px] w-full items-center justify-center rounded-[12px] bg-[#4AF38A] text-[16px] leading-[140%] font-medium text-[#474747] transition-colors hover:bg-[#22CF64]"
+              className="flex h-[51px] w-full cursor-pointer items-center justify-center rounded-[12px] bg-[#4AF38A] text-[16px] leading-[140%] font-medium text-[#474747] transition-colors hover:bg-[#22CF64]"
             >
               완료
             </button>

--- a/src/features/admin/ui/SubTabButton.tsx
+++ b/src/features/admin/ui/SubTabButton.tsx
@@ -13,8 +13,8 @@ function SubTabButton({
       onClick={onClick}
       className={
         isActive
-          ? 'flex h-[38px] items-center justify-center rounded-[30px] bg-[#000000] px-[14px] text-[16px] leading-[140%] font-medium text-white'
-          : 'flex h-[38px] items-center justify-center rounded-[30px] border border-[#D6D6D6] px-[14px] text-[16px] leading-[140%] font-medium text-[#7F7F7F]'
+          ? 'flex h-[38px] cursor-pointer items-center justify-center rounded-[30px] bg-[#000000] px-[14px] text-[16px] leading-[140%] font-medium text-white'
+          : 'flex h-[38px] cursor-pointer items-center justify-center rounded-[30px] border border-[#D6D6D6] px-[14px] text-[16px] leading-[140%] font-medium text-[#7F7F7F]'
       }
     >
       {children}

--- a/src/features/my/api/deleteUser.tsx
+++ b/src/features/my/api/deleteUser.tsx
@@ -1,0 +1,20 @@
+'use server';
+
+import api from '@/shared/api/auth-api';
+import ErrorHandler from '@/shared/lib/error-message';
+
+async function deleteUser() {
+  try {
+    await api.delete('users');
+
+    return {
+      ok: true,
+      message: '회원 탈퇴가 완료되었습니다.',
+      status: 200,
+    };
+  } catch (e) {
+    return ErrorHandler(e as Error);
+  }
+}
+
+export default deleteUser;

--- a/src/features/my/ui/club-application-card.tsx
+++ b/src/features/my/ui/club-application-card.tsx
@@ -12,39 +12,25 @@ import {
   DialogTrigger,
 } from '@/shared/ui/dialog';
 import { Button } from '@/shared/ui/button';
-import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
 import { ApplicationCardItem } from '@/entities/my/model/type';
 
 type ClubApplicationCardProps = {
   item: ApplicationCardItem;
-  showLogo?: boolean;
 };
 
-function ClubApplicationCard({
-  item,
-  showLogo = false,
-}: ClubApplicationCardProps) {
-  const { clubName, universityName, status, createdAt, rejectReason, logo } =
-    item;
+function ClubApplicationCard({ item }: ClubApplicationCardProps) {
+  const { clubName, universityName, status, createdAt, rejectReason } = item;
 
   return (
     <li className="flex flex-col gap-3 rounded-2xl border border-[#22CF64] p-4">
-      <div className="flex items-center gap-4">
-        {showLogo && (
-          <Avatar className="size-13">
-            <AvatarImage src={logo ?? ''} alt={clubName} />
-            <AvatarFallback />
-          </Avatar>
-        )}
-        <div className="flex flex-col gap-1">
-          <span className="font-semibold">
-            {clubName}{' '}
-            <span className="text-text-tertiary text-lg">{universityName}</span>
-          </span>
-          <span className="text-text-tertiary text-sm">
-            신청일시 | {dayjs(createdAt).format('YYYY.MM.DD')}
-          </span>
-        </div>
+      <div className="flex flex-col gap-1">
+        <span className="font-semibold">
+          {clubName}{' '}
+          <span className="text-text-tertiary text-lg">{universityName}</span>
+        </span>
+        <span className="text-text-tertiary text-sm">
+          신청일시 | {dayjs(createdAt).format('YYYY.MM.DD')}
+        </span>
       </div>
 
       <div className="h-0.5 w-full rounded-full bg-[#f8f8f8]">

--- a/src/features/my/ui/club-application-card.tsx
+++ b/src/features/my/ui/club-application-card.tsx
@@ -12,26 +12,39 @@ import {
   DialogTrigger,
 } from '@/shared/ui/dialog';
 import { Button } from '@/shared/ui/button';
-import { ClubApplicationType } from '@/entities/my/model/type';
+import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
+import { ApplicationCardItem } from '@/entities/my/model/type';
 
 type ClubApplicationCardProps = {
-  application: ClubApplicationType;
+  item: ApplicationCardItem;
+  showLogo?: boolean;
 };
 
-function ClubApplicationCard({ application }: ClubApplicationCardProps) {
-  const { clubName, universityName, status, createdAt, rejectReason } =
-    application;
+function ClubApplicationCard({
+  item,
+  showLogo = false,
+}: ClubApplicationCardProps) {
+  const { clubName, universityName, status, createdAt, rejectReason, logo } =
+    item;
 
   return (
     <li className="flex flex-col gap-3 rounded-2xl border border-[#22CF64] p-4">
-      <div className="flex flex-col gap-1">
-        <span className="font-semibold">
-          {clubName}{' '}
-          <span className="text-text-tertiary text-lg">{universityName}</span>
-        </span>
-        <span className="text-text-tertiary text-sm">
-          신청일시 | {dayjs(createdAt).format('YYYY.MM.DD')}
-        </span>
+      <div className="flex items-center gap-4">
+        {showLogo && (
+          <Avatar className="size-13">
+            <AvatarImage src={logo ?? ''} alt={clubName} />
+            <AvatarFallback />
+          </Avatar>
+        )}
+        <div className="flex flex-col gap-1">
+          <span className="font-semibold">
+            {clubName}{' '}
+            <span className="text-text-tertiary text-lg">{universityName}</span>
+          </span>
+          <span className="text-text-tertiary text-sm">
+            신청일시 | {dayjs(createdAt).format('YYYY.MM.DD')}
+          </span>
+        </div>
       </div>
 
       <div className="h-0.5 w-full rounded-full bg-[#f8f8f8]">

--- a/src/features/my/ui/club-application-list.tsx
+++ b/src/features/my/ui/club-application-list.tsx
@@ -8,14 +8,12 @@ type ClubApplicationListProps = {
   title: string;
   items: ApplicationCardItem[];
   universityCode: string;
-  showLogo?: boolean;
 };
 
 function ClubApplicationList({
   title,
   items,
   universityCode,
-  showLogo = false,
 }: ClubApplicationListProps) {
   const myHref = `/${universityCode}/my`;
   const sortedItems = sortByLatest(items);
@@ -36,11 +34,7 @@ function ClubApplicationList({
       {sortedItems.length > 0 ? (
         <ul className="flex flex-col gap-3">
           {sortedItems.map((item) => (
-            <ClubApplicationCard
-              key={item.id}
-              item={item}
-              showLogo={showLogo}
-            />
+            <ClubApplicationCard key={item.id} item={item} />
           ))}
         </ul>
       ) : (

--- a/src/features/my/ui/club-application-list.tsx
+++ b/src/features/my/ui/club-application-list.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ApplicationCardItem } from '@/entities/my/model/type';
+import { sortByLatest } from '@/entities/my/lib/application-card';
+import ClubApplicationCard from './club-application-card';
+
+type ClubApplicationListProps = {
+  title: string;
+  items: ApplicationCardItem[];
+  universityCode: string;
+  showLogo?: boolean;
+};
+
+function ClubApplicationList({
+  title,
+  items,
+  universityCode,
+  showLogo = false,
+}: ClubApplicationListProps) {
+  const myHref = `/${universityCode}/my`;
+  const sortedItems = sortByLatest(items);
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="text-text-tertiary flex items-center gap-0.5 text-sm">
+        <Link href={myHref}>마이페이지</Link>
+        <ChevronRight className="size-3.5" />
+        <span className="text-text-secondary">{title}</span>
+      </div>
+
+      <Link href={myHref} className="flex items-center gap-1 font-semibold">
+        <ChevronLeft className="size-4" />
+        {title}
+      </Link>
+
+      {sortedItems.length > 0 ? (
+        <ul className="flex flex-col gap-3">
+          {sortedItems.map((item) => (
+            <ClubApplicationCard
+              key={item.id}
+              item={item}
+              showLogo={showLogo}
+            />
+          ))}
+        </ul>
+      ) : (
+        <p className="text-text-tertiary py-10 text-center text-sm">
+          신청 내역이 없습니다.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default ClubApplicationList;

--- a/src/features/my/ui/club-application-status.tsx
+++ b/src/features/my/ui/club-application-status.tsx
@@ -8,14 +8,12 @@ type ApplicationSectionProps = {
   title: string;
   moreHref: string;
   items: ApplicationCardItem[];
-  showLogo?: boolean;
 };
 
 function ApplicationSection({
   title,
   moreHref,
   items,
-  showLogo = false,
 }: ApplicationSectionProps) {
   if (items.length === 0) {
     return null;
@@ -32,7 +30,7 @@ function ApplicationSection({
         </Link>
       </div>
       <ul>
-        <ClubApplicationCard item={latest} showLogo={showLogo} />
+        <ClubApplicationCard item={latest} />
       </ul>
     </div>
   );
@@ -61,7 +59,6 @@ function ClubApplicationStatus({
           title={APPLICATION_SECTION.master.title}
           moreHref={`/${universityCode}/my/applications/${APPLICATION_SECTION.master.path}`}
           items={masterItems}
-          showLogo
         />
         <ApplicationSection
           title={APPLICATION_SECTION.create.title}

--- a/src/features/my/ui/club-application-status.tsx
+++ b/src/features/my/ui/club-application-status.tsx
@@ -1,22 +1,73 @@
-import { ClubApplicationType } from '@/entities/my/model/type';
+import Link from 'next/link';
+import { ApplicationCardItem } from '@/entities/my/model/type';
+import { sortByLatest } from '@/entities/my/lib/application-card';
 import ClubApplicationCard from './club-application-card';
 
-type ClubApplicationStatusProps = {
-  applications: ClubApplicationType[];
+type ApplicationSectionProps = {
+  title: string;
+  moreHref: string;
+  items: ApplicationCardItem[];
+  showLogo?: boolean;
 };
 
-function ClubApplicationStatus({ applications }: ClubApplicationStatusProps) {
+function ApplicationSection({
+  title,
+  moreHref,
+  items,
+  showLogo = false,
+}: ApplicationSectionProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  const latest = sortByLatest(items)[0];
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-[#7F7F7F]">{title}</span>
+        <Link href={moreHref} className="text-sm text-[#8B95A1]">
+          더보기
+        </Link>
+      </div>
+      <ul>
+        <ClubApplicationCard item={latest} showLogo={showLogo} />
+      </ul>
+    </div>
+  );
+}
+
+type ClubApplicationStatusProps = {
+  createItems: ApplicationCardItem[];
+  masterItems: ApplicationCardItem[];
+  universityCode: string;
+};
+
+function ClubApplicationStatus({
+  createItems,
+  masterItems,
+  universityCode,
+}: ClubApplicationStatusProps) {
+  if (createItems.length === 0 && masterItems.length === 0) {
+    return null;
+  }
+
   return (
     <div className="mb-10 flex flex-col gap-3">
       <div className="font-semibold">신청 현황</div>
-      <ul className="flex flex-col gap-3">
-        {applications.map((application) => (
-          <ClubApplicationCard
-            key={application.clubApplicationId}
-            application={application}
-          />
-        ))}
-      </ul>
+      <div className="flex flex-col gap-5">
+        <ApplicationSection
+          title="동아리 & 동아리장 신청"
+          moreHref={`/${universityCode}/my/applications/master`}
+          items={masterItems}
+          showLogo
+        />
+        <ApplicationSection
+          title="동아리 생성 신청"
+          moreHref={`/${universityCode}/my/applications/create`}
+          items={createItems}
+        />
+      </div>
     </div>
   );
 }

--- a/src/features/my/ui/club-application-status.tsx
+++ b/src/features/my/ui/club-application-status.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { ApplicationCardItem } from '@/entities/my/model/type';
+import { APPLICATION_SECTION } from '@/entities/my/model/constants';
 import { sortByLatest } from '@/entities/my/lib/application-card';
 import ClubApplicationCard from './club-application-card';
 
@@ -25,8 +26,8 @@ function ApplicationSection({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between">
-        <span className="text-sm text-[#7F7F7F]">{title}</span>
-        <Link href={moreHref} className="text-sm text-[#8B95A1]">
+        <span className="text-text-tertiary text-sm">{title}</span>
+        <Link href={moreHref} className="text-text-secondary text-sm">
           더보기
         </Link>
       </div>
@@ -57,14 +58,14 @@ function ClubApplicationStatus({
       <div className="font-semibold">신청 현황</div>
       <div className="flex flex-col gap-5">
         <ApplicationSection
-          title="동아리 & 동아리장 신청"
-          moreHref={`/${universityCode}/my/applications/master`}
+          title={APPLICATION_SECTION.master.title}
+          moreHref={`/${universityCode}/my/applications/${APPLICATION_SECTION.master.path}`}
           items={masterItems}
           showLogo
         />
         <ApplicationSection
-          title="동아리 생성 신청"
-          moreHref={`/${universityCode}/my/applications/create`}
+          title={APPLICATION_SECTION.create.title}
+          moreHref={`/${universityCode}/my/applications/${APPLICATION_SECTION.create.path}`}
           items={createItems}
         />
       </div>

--- a/src/features/my/ui/logout-link.tsx
+++ b/src/features/my/ui/logout-link.tsx
@@ -1,16 +1,19 @@
 'use client';
 
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
+import { useSession } from '@/shared/lib/session-context';
 
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
 export default function LogoutLink() {
   const router = useRouter();
+  const { refresh } = useSession();
   const universityCode = useUniversityCode();
 
   const handleLogout = async () => {
     await fetch('/api/auth/logout', { method: 'POST' });
+    refresh();
     router.push(`/${universityCode}`);
     router.refresh();
   };

--- a/src/features/my/ui/withdraw-button.tsx
+++ b/src/features/my/ui/withdraw-button.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'react-toastify';
+import Image from 'next/image';
+import useUniversityCode from '@/shared/hooks/useUniversityCode';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/shared/ui/dialog';
+import { Button } from '@/shared/ui/button';
+import deleteUser from '../api/deleteUser';
+
+export default function WithdrawButton() {
+  const router = useRouter();
+  const universityCode = useUniversityCode();
+  const [open, setOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleWithdraw = async () => {
+    setSubmitting(true);
+    const response = await deleteUser();
+    if (!response.ok) {
+      toast.error(response.message);
+      setSubmitting(false);
+      return;
+    }
+    await fetch('/api/auth/logout', { method: 'POST' });
+    toast.success('회원 탈퇴가 완료되었습니다.');
+    setOpen(false);
+    router.push(`/${universityCode}`);
+    router.refresh();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="text-text-secondary mt-2 flex items-center gap-2 text-sm hover:underline"
+        >
+          회원 탈퇴
+          <Image src="/nextBlack.svg" alt="arrow" width={8} height={12} />
+        </button>
+      </DialogTrigger>
+
+      <DialogContent
+        aria-describedby="withdraw-desc"
+        className="w-[400px] rounded-2xl"
+      >
+        <DialogHeader>
+          <DialogTitle className="font-semibold">회원 탈퇴</DialogTitle>
+          <DialogDescription id="withdraw-desc" className="text-sm">
+            탈퇴 시 계정과 관련된 모든 데이터가 삭제되며 복구할 수 없습니다.
+            <br />
+            <br />
+            정말 탈퇴하시겠습니까?
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={submitting}
+          >
+            취소
+          </Button>
+          <Button
+            className="bg-red-500 text-white hover:bg-red-600"
+            onClick={handleWithdraw}
+            disabled={submitting}
+          >
+            {submitting ? '탈퇴 중…' : '탈퇴'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/my/ui/withdraw-button.tsx
+++ b/src/features/my/ui/withdraw-button.tsx
@@ -43,7 +43,7 @@ export default function WithdrawButton() {
       <DialogTrigger asChild>
         <button
           type="button"
-          className="text-text-secondary mt-2 flex items-center gap-2 text-sm hover:underline"
+          className="mt-2 flex items-center gap-2 text-[#FF383C] hover:underline"
         >
           회원 탈퇴
           <Image src="/nextBlack.svg" alt="arrow" width={8} height={12} />
@@ -57,7 +57,10 @@ export default function WithdrawButton() {
         <DialogHeader>
           <DialogTitle className="font-semibold">회원 탈퇴</DialogTitle>
           <DialogDescription id="withdraw-desc" className="text-sm">
-            탈퇴 시 계정과 관련된 모든 데이터가 삭제되며 복구할 수 없습니다.
+            탈퇴 시 계정과 관련된{' '}
+            <span className="font-semibold underline">
+              모든 데이터가 삭제되며 복구할 수 없습니다.
+            </span>
             <br />
             <br />
             정말 탈퇴하시겠습니까?

--- a/src/features/my/ui/withdraw-button.tsx
+++ b/src/features/my/ui/withdraw-button.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import Image from 'next/image';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
+import { useSession } from '@/shared/lib/session-context';
 import {
   Dialog,
   DialogTrigger,
@@ -19,6 +20,7 @@ import deleteUser from '../api/deleteUser';
 
 export default function WithdrawButton() {
   const router = useRouter();
+  const { refresh } = useSession();
   const universityCode = useUniversityCode();
   const [open, setOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -32,6 +34,7 @@ export default function WithdrawButton() {
       return;
     }
     await fetch('/api/auth/logout', { method: 'POST' });
+    refresh();
     toast.success('회원 탈퇴가 완료되었습니다.');
     setOpen(false);
     router.push(`/${universityCode}`);

--- a/src/mocks/handlers/clubMaster.ts
+++ b/src/mocks/handlers/clubMaster.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies, import/prefer-default-export */
 import { http, HttpResponse, passthrough } from 'msw';
+import { getUniversityName } from '@/shared/lib/universityMeta';
 import { clubApplications, myClubMasterApplications } from '../data';
 
 const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? '';
@@ -30,7 +31,17 @@ export const clubMasterHandlers = [
   ),
 
   http.get(url('/club-master-applications/me'), () =>
-    HttpResponse.json({ data: { applications: myClubMasterApplications } }),
+    HttpResponse.json({
+      data: myClubMasterApplications.map((application) => ({
+        id: application.id,
+        universityName: getUniversityName(application.universityCode),
+        clubName: application.clubName,
+        userName: application.userName,
+        status: application.status,
+        rejectReason: application.rejectReason ?? null,
+        createdAt: application.createdAt,
+      })),
+    }),
   ),
 
   http.post(

--- a/src/mocks/handlers/clubMaster.ts
+++ b/src/mocks/handlers/clubMaster.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies, import/prefer-default-export */
 import { http, HttpResponse, passthrough } from 'msw';
-import { myClubMasterApplications } from '../data';
+import { clubApplications, myClubMasterApplications } from '../data';
 
 const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? '';
 
@@ -8,6 +8,21 @@ const url = (path: string) => `${baseUrl}${path}`;
 
 export const clubMasterHandlers = [
   http.post(url('/club-applications'), () => passthrough()),
+
+  http.get(url('/club-applications/me'), () =>
+    HttpResponse.json({
+      data: {
+        clubApplications: clubApplications.map((application) => ({
+          clubApplicationId: application.applicationId,
+          universityName: application.universityName,
+          clubName: application.clubName,
+          status: application.status,
+          rejectReason: application.rejectReason,
+          createdAt: application.createdAt,
+        })),
+      },
+    }),
+  ),
 
   http.post(
     url('/club-master-applications'),

--- a/src/shared/lib/session-context.tsx
+++ b/src/shared/lib/session-context.tsx
@@ -64,12 +64,9 @@ export function AppSessionProvider({
   useEffect(() => {
     if (!session?.expiresAt) return undefined;
     const delay = session.expiresAt - Date.now();
-    if (delay > 0) {
-      const timer = setTimeout(() => window.location.reload(), delay);
-      return () => clearTimeout(timer);
-    }
-    window.location.reload();
-    return undefined;
+    if (delay <= 0) return undefined;
+    const timer = setTimeout(() => window.location.reload(), delay);
+    return () => clearTimeout(timer);
   }, [session?.expiresAt]);
 
   const value = useMemo(

--- a/src/views/admin/ui/AdminDashboardView.tsx
+++ b/src/views/admin/ui/AdminDashboardView.tsx
@@ -10,7 +10,6 @@ interface AdminDashboardViewProps {
   totalClubs: number;
   pendingMasterCount: number;
   pendingClubCount: number;
-  totalMasters: number;
 }
 
 function AdminDashboardView({
@@ -19,7 +18,6 @@ function AdminDashboardView({
   totalClubs,
   pendingMasterCount,
   pendingClubCount,
-  totalMasters,
 }: AdminDashboardViewProps) {
   return (
     <div className="flex flex-col gap-8 px-[140px] pt-4 pb-10">
@@ -52,15 +50,7 @@ function AdminDashboardView({
           </div>
           <div className="relative h-[117px] w-[176px] rounded-[20px] bg-[#F8F8F8]">
             <span className="absolute top-4 left-5 text-[16px] leading-[140%] font-medium text-[#474747]">
-              승인 대기
-            </span>
-            <span className="absolute right-5 bottom-4 text-[36px] leading-[140%] font-bold text-[#474747]">
-              {pendingMasterCount}건
-            </span>
-          </div>
-          <div className="relative h-[117px] w-[176px] rounded-[20px] bg-[#F8F8F8]">
-            <span className="absolute top-4 left-5 text-[16px] leading-[140%] font-medium text-[#474747]">
-              신규 신청
+              동아리 신청
             </span>
             <span className="absolute right-5 bottom-4 text-[36px] leading-[140%] font-bold text-[#474747]">
               {pendingClubCount}건
@@ -68,10 +58,10 @@ function AdminDashboardView({
           </div>
           <div className="relative h-[117px] w-[176px] rounded-[20px] bg-[#F8F8F8]">
             <span className="absolute top-4 left-5 text-[16px] leading-[140%] font-medium text-[#474747]">
-              전체 동아리장
+              동아리장 신청
             </span>
             <span className="absolute right-5 bottom-4 text-[36px] leading-[140%] font-bold text-[#474747]">
-              {totalMasters}명
+              {pendingMasterCount}건
             </span>
           </div>
         </div>

--- a/src/views/admin/ui/AdminDashboardView.tsx
+++ b/src/views/admin/ui/AdminDashboardView.tsx
@@ -32,7 +32,7 @@ function AdminDashboardView({
       <div className="flex items-center justify-between">
         <button
           type="button"
-          className="flex h-[50px] items-center justify-center rounded-[30px] bg-[#4AF38A] px-5 text-[16px] leading-[140%] font-medium text-[#000000]"
+          className="flex h-[50px] cursor-pointer items-center justify-center rounded-[30px] bg-[#4AF38A] px-5 text-[16px] leading-[140%] font-medium text-[#000000]"
         >
           대시보드
         </button>

--- a/src/views/admin/ui/AdminDashboardView.tsx
+++ b/src/views/admin/ui/AdminDashboardView.tsx
@@ -10,9 +10,6 @@ import type { UniversityOption } from '@/entities/university/model/type';
 interface AdminDashboardViewProps {
   clubMasterApplications: ClubMasterApplication[];
   clubApplications: ClubApplication[];
-  totalClubs: number;
-  pendingMasterCount: number;
-  pendingClubCount: number;
   role: AdminRole;
   universities: UniversityOption[];
   selectedCode: string;
@@ -21,9 +18,6 @@ interface AdminDashboardViewProps {
 function AdminDashboardView({
   clubMasterApplications,
   clubApplications,
-  totalClubs,
-  pendingMasterCount,
-  pendingClubCount,
   role,
   universities,
   selectedCode,
@@ -54,57 +48,19 @@ function AdminDashboardView({
         )}
       </div>
 
-      <div className="flex flex-col gap-8">
-        <div className="flex flex-col gap-1">
-          <h2 className="text-[20px] leading-[140%] font-semibold tracking-[-0.03em] text-[#000000]">
-            전체 동아리 현황
-          </h2>
-          <p className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#8B95A1]">
-            학교 동아리 현황과 신청을 한눈에 관리할 수 있어요.
-          </p>
-        </div>
-        <div className="flex items-center gap-5">
-          <div className="relative h-[117px] w-[176px] rounded-[20px] bg-[#F8F8F8]">
-            <span className="absolute top-4 left-5 text-[16px] leading-[140%] font-medium text-[#474747]">
-              등록된 동아리
-            </span>
-            <span className="absolute right-5 bottom-4 text-[36px] leading-[140%] font-bold text-[#474747]">
-              {totalClubs}개
-            </span>
-          </div>
-          <div className="relative h-[117px] w-[176px] rounded-[20px] bg-[#F8F8F8]">
-            <span className="absolute top-4 left-5 text-[16px] leading-[140%] font-medium text-[#474747]">
-              동아리 신청
-            </span>
-            <span className="absolute right-5 bottom-4 text-[36px] leading-[140%] font-bold text-[#474747]">
-              {pendingClubCount}건
-            </span>
-          </div>
-          <div className="relative h-[117px] w-[176px] rounded-[20px] bg-[#F8F8F8]">
-            <span className="absolute top-4 left-5 text-[16px] leading-[140%] font-medium text-[#474747]">
-              동아리장 신청
-            </span>
-            <span className="absolute right-5 bottom-4 text-[36px] leading-[140%] font-bold text-[#474747]">
-              {pendingMasterCount}건
-            </span>
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-1">
-            <h3 className="text-[20px] leading-[140%] font-semibold tracking-[-0.03em] text-[#000000]">
-              최근 승인 대기 신청
-            </h3>
-            <p className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#8B95A1]">
-              현재 승인 대기 중인 신청을 확인하고 처리할 수 있어요.
-            </p>
-          </div>
-          <ClubMasterApplicationWidget
-            initialClubApplications={clubApplications}
-            initialClubMasterApplications={clubMasterApplications}
-          />
-        </div>
+      <div className="flex flex-col gap-1">
+        <h2 className="text-[20px] leading-[140%] font-semibold tracking-[-0.03em] text-[#000000]">
+          승인 대기 신청
+        </h2>
+        <p className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#8B95A1]">
+          현재 승인 대기 중인 신청을 확인하고 처리할 수 있어요.
+        </p>
       </div>
+
+      <ClubMasterApplicationWidget
+        initialClubApplications={clubApplications}
+        initialClubMasterApplications={clubMasterApplications}
+      />
     </div>
   );
 }

--- a/src/widgets/admin/ui/AdminUniversitySelectWidget.tsx
+++ b/src/widgets/admin/ui/AdminUniversitySelectWidget.tsx
@@ -30,7 +30,7 @@ function AdminUniversitySelectWidget({
 
   return (
     <Select value={selectedCode} onValueChange={changeUniversity}>
-      <SelectTrigger className="w-[200px]">
+      <SelectTrigger className="w-[200px] cursor-pointer">
         <SelectValue placeholder="학교를 선택해주세요" />
       </SelectTrigger>
       <SelectContent>

--- a/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
+++ b/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
@@ -14,7 +14,7 @@ import rejectClubMasterApplication from '@/features/admin/api/rejectClubMasterAp
 import approveClubApplication from '@/features/admin/api/approveClubApplication';
 import rejectClubApplication from '@/features/admin/api/rejectClubApplication';
 
-type KindFilter = 'all' | 'clubOnly';
+type KindFilter = 'clubApplication' | 'clubMaster';
 
 const STATUS_TABS: { label: string; value: ApplicationStatus }[] = [
   { label: '진행 중', value: 'PENDING' },
@@ -31,7 +31,7 @@ function ClubMasterApplicationWidget({
   initialClubApplications,
   initialClubMasterApplications,
 }: ClubMasterApplicationWidgetProps) {
-  const [kindFilter, setKindFilter] = useState<KindFilter>('all');
+  const [kindFilter, setKindFilter] = useState<KindFilter>('clubApplication');
   const [statusTab, setStatusTab] = useState<ApplicationStatus>('PENDING');
   const [clubApplications, setClubApplications] = useState(
     initialClubApplications,
@@ -42,30 +42,8 @@ function ClubMasterApplicationWidget({
   const [, startTransition] = useTransition();
 
   const items = useMemo<ApplicationCardItem[]>(() => {
-    const clubItems: ApplicationCardItem[] = clubApplications.map(
-      (application) => ({
-        key: `club-${application.applicationId}`,
-        kind: 'club',
-        applicationId: application.applicationId,
-        clubName: application.clubName,
-        universityName: application.universityName,
-        applicantName: application.applicantName,
-        status: application.status,
-        createdAt: application.createdAt,
-        category: application.category,
-        affiliation: application.affiliation,
-        logo: application.logo,
-        instagram: application.instagram,
-        description: application.description,
-      }),
-    );
-
-    if (kindFilter === 'clubOnly') {
-      return clubItems;
-    }
-
-    const masterItems: ApplicationCardItem[] = clubMasterApplications.map(
-      (application) => ({
+    if (kindFilter === 'clubMaster') {
+      return clubMasterApplications.map((application) => ({
         key: `master-${application.id}`,
         kind: 'master',
         applicationId: application.id,
@@ -74,10 +52,24 @@ function ClubMasterApplicationWidget({
         applicantName: application.userName,
         status: application.status,
         createdAt: application.createdAt,
-      }),
-    );
+      }));
+    }
 
-    return [...clubItems, ...masterItems];
+    return clubApplications.map((application) => ({
+      key: `club-${application.applicationId}`,
+      kind: 'club',
+      applicationId: application.applicationId,
+      clubName: application.clubName,
+      universityName: application.universityName,
+      applicantName: application.applicantName,
+      status: application.status,
+      createdAt: application.createdAt,
+      category: application.category,
+      affiliation: application.affiliation,
+      logo: application.logo,
+      instagram: application.instagram,
+      description: application.description,
+    }));
   }, [clubApplications, clubMasterApplications, kindFilter]);
 
   const visibleItems = items.filter((item) => item.status === statusTab);
@@ -134,16 +126,16 @@ function ClubMasterApplicationWidget({
     <div className="flex flex-col gap-6">
       <div className="flex gap-3">
         <SubTabButton
-          isActive={kindFilter === 'all'}
-          onClick={() => setKindFilter('all')}
+          isActive={kindFilter === 'clubApplication'}
+          onClick={() => setKindFilter('clubApplication')}
         >
           동아리 생성 &amp; 동아리장
         </SubTabButton>
         <SubTabButton
-          isActive={kindFilter === 'clubOnly'}
-          onClick={() => setKindFilter('clubOnly')}
+          isActive={kindFilter === 'clubMaster'}
+          onClick={() => setKindFilter('clubMaster')}
         >
-          동아리 생성
+          동아리장
         </SubTabButton>
       </div>
 

--- a/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
+++ b/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
@@ -154,7 +154,7 @@ function ClubMasterApplicationWidget({
               key={tab.value}
               type="button"
               onClick={() => setStatusTab(tab.value)}
-              className="flex w-20 flex-col items-center gap-[5px]"
+              className="flex w-20 cursor-pointer flex-col items-center gap-[5px]"
             >
               <span
                 className={`text-[16px] leading-[140%] font-semibold tracking-[-0.03em] ${statusTab === tab.value ? 'text-[#22CF64]' : 'text-[#8B95A1]'}`}
@@ -168,7 +168,7 @@ function ClubMasterApplicationWidget({
           ))}
         </div>
 
-        <div className="flex w-full flex-col border-t border-[#8B95A1]">
+        <div className="flex w-full flex-col">
           {visibleItems.length === 0 ? (
             <div className="py-8 text-center text-[16px] leading-[140%] font-medium text-[#8B95A1]">
               신청 내역이 없습니다.

--- a/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
+++ b/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
@@ -1,20 +1,26 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useMemo, useState, useTransition } from 'react';
 import type {
   ClubMasterApplication,
   ClubApplication,
   ApplicationStatus,
+  ApplicationCardItem,
 } from '@/features/admin/model/dashboard-types';
-import ApplicationTableRow from '@/features/admin/ui/ApplicationTableRow';
+import ApplicationCard from '@/features/admin/ui/ApplicationCard';
 import SubTabButton from '@/features/admin/ui/SubTabButton';
-import TableHeaderCell from '@/features/admin/ui/TableHeaderCell';
 import approveClubMasterApplication from '@/features/admin/api/approveClubMasterApplication';
 import rejectClubMasterApplication from '@/features/admin/api/rejectClubMasterApplication';
 import approveClubApplication from '@/features/admin/api/approveClubApplication';
 import rejectClubApplication from '@/features/admin/api/rejectClubApplication';
 
-type SubTab = 'combined' | 'masterOnly';
+type KindFilter = 'all' | 'clubOnly';
+
+const STATUS_TABS: { label: string; value: ApplicationStatus }[] = [
+  { label: '진행 중', value: 'PENDING' },
+  { label: '승인', value: 'APPROVED' },
+  { label: '반려', value: 'REJECTED' },
+];
 
 interface ClubMasterApplicationWidgetProps {
   initialClubApplications: ClubApplication[];
@@ -25,7 +31,8 @@ function ClubMasterApplicationWidget({
   initialClubApplications,
   initialClubMasterApplications,
 }: ClubMasterApplicationWidgetProps) {
-  const [activeTab, setActiveTab] = useState<SubTab>('combined');
+  const [kindFilter, setKindFilter] = useState<KindFilter>('all');
+  const [statusTab, setStatusTab] = useState<ApplicationStatus>('PENDING');
   const [clubApplications, setClubApplications] = useState(
     initialClubApplications,
   );
@@ -34,173 +41,150 @@ function ClubMasterApplicationWidget({
   );
   const [, startTransition] = useTransition();
 
-  const pendingClubApplications = clubApplications.filter(
-    (a) => a.status === 'PENDING',
-  );
-  const pendingMasterApplications = clubMasterApplications.filter(
-    (a) => a.status === 'PENDING',
-  );
+  const items = useMemo<ApplicationCardItem[]>(() => {
+    const clubItems: ApplicationCardItem[] = clubApplications.map(
+      (application) => ({
+        key: `club-${application.applicationId}`,
+        kind: 'club',
+        applicationId: application.applicationId,
+        clubName: application.clubName,
+        universityName: application.universityName,
+        applicantName: application.applicantName,
+        status: application.status,
+        createdAt: application.createdAt,
+        category: application.category,
+        affiliation: application.affiliation,
+        logo: application.logo,
+        instagram: application.instagram,
+        description: application.description,
+      }),
+    );
 
-  const handleCombinedApprove = (applicationId: number) => {
-    startTransition(async () => {
-      const [clubSuccess, masterSuccess] = await Promise.all([
-        approveClubApplication(applicationId),
-        approveClubMasterApplication(applicationId),
-      ]);
-      if (clubSuccess && masterSuccess) {
-        setClubApplications((previous) =>
-          previous.map((a) =>
-            a.applicationId === applicationId
-              ? { ...a, status: 'APPROVED' as ApplicationStatus }
-              : a,
-          ),
-        );
-        setClubMasterApplications((previous) =>
-          previous.map((a) =>
-            a.id === applicationId
-              ? { ...a, status: 'APPROVED' as ApplicationStatus }
-              : a,
-          ),
-        );
-      }
-    });
-  };
+    if (kindFilter === 'clubOnly') {
+      return clubItems;
+    }
 
-  const handleCombinedReject = (
-    applicationId: number,
-    rejectReason?: string,
+    const masterItems: ApplicationCardItem[] = clubMasterApplications.map(
+      (application) => ({
+        key: `master-${application.id}`,
+        kind: 'master',
+        applicationId: application.id,
+        clubName: application.clubName,
+        universityName: application.universityName,
+        applicantName: application.userName,
+        status: application.status,
+        createdAt: application.createdAt,
+      }),
+    );
+
+    return [...clubItems, ...masterItems];
+  }, [clubApplications, clubMasterApplications, kindFilter]);
+
+  const visibleItems = items.filter((item) => item.status === statusTab);
+
+  const updateStatus = (
+    item: ApplicationCardItem,
+    status: ApplicationStatus,
+    rejectReason: string | null = null,
   ) => {
-    startTransition(async () => {
-      const success = await rejectClubApplication(applicationId, rejectReason);
-      if (success) {
-        setClubApplications((previous) =>
-          previous.map((a) =>
-            a.applicationId === applicationId
-              ? {
-                  ...a,
-                  status: 'REJECTED' as ApplicationStatus,
-                  rejectReason: rejectReason ?? null,
-                }
-              : a,
-          ),
-        );
-      }
-    });
-  };
-
-  const handleMasterApprove = (applicationId: number) => {
-    startTransition(async () => {
-      const success = await approveClubMasterApplication(applicationId);
-      if (success) {
-        setClubMasterApplications((previous) =>
-          previous.map((a) =>
-            a.id === applicationId
-              ? { ...a, status: 'APPROVED' as ApplicationStatus }
-              : a,
-          ),
-        );
-      }
-    });
-  };
-
-  const handleMasterReject = (applicationId: number, rejectReason?: string) => {
-    startTransition(async () => {
-      const success = await rejectClubMasterApplication(
-        applicationId,
-        rejectReason,
+    if (item.kind === 'club') {
+      setClubApplications((previous) =>
+        previous.map((application) =>
+          application.applicationId === item.applicationId
+            ? { ...application, status, rejectReason }
+            : application,
+        ),
       );
+    } else {
+      setClubMasterApplications((previous) =>
+        previous.map((application) =>
+          application.id === item.applicationId
+            ? { ...application, status, rejectReason }
+            : application,
+        ),
+      );
+    }
+  };
+
+  const handleApprove = (item: ApplicationCardItem) => {
+    startTransition(async () => {
+      const success =
+        item.kind === 'club'
+          ? await approveClubApplication(item.applicationId)
+          : await approveClubMasterApplication(item.applicationId);
       if (success) {
-        setClubMasterApplications((previous) =>
-          previous.map((a) =>
-            a.id === applicationId
-              ? {
-                  ...a,
-                  status: 'REJECTED' as ApplicationStatus,
-                  rejectReason: rejectReason ?? null,
-                }
-              : a,
-          ),
-        );
+        updateStatus(item, 'APPROVED');
+      }
+    });
+  };
+
+  const handleReject = (item: ApplicationCardItem, rejectReason?: string) => {
+    startTransition(async () => {
+      const success =
+        item.kind === 'club'
+          ? await rejectClubApplication(item.applicationId, rejectReason)
+          : await rejectClubMasterApplication(item.applicationId, rejectReason);
+      if (success) {
+        updateStatus(item, 'REJECTED', rejectReason ?? null);
       }
     });
   };
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex gap-2">
+    <div className="flex flex-col gap-6">
+      <div className="flex gap-3">
         <SubTabButton
-          isActive={activeTab === 'combined'}
-          onClick={() => setActiveTab('combined')}
+          isActive={kindFilter === 'all'}
+          onClick={() => setKindFilter('all')}
         >
-          동아리장 &amp; 동아리 생성
+          동아리 생성 &amp; 동아리장
         </SubTabButton>
         <SubTabButton
-          isActive={activeTab === 'masterOnly'}
-          onClick={() => setActiveTab('masterOnly')}
+          isActive={kindFilter === 'clubOnly'}
+          onClick={() => setKindFilter('clubOnly')}
         >
-          동아리장
+          동아리 생성
         </SubTabButton>
       </div>
 
-      {activeTab === 'combined' && (
-        <div className="flex w-full flex-col">
-          <div className="flex w-full items-center border-t border-b border-[#8B95A1] py-2">
-            <TableHeaderCell width="w-[120px]">신청일자</TableHeaderCell>
-            <TableHeaderCell width="w-[160px]">동아리명</TableHeaderCell>
-            <TableHeaderCell width="w-[100px]">분류</TableHeaderCell>
-            <TableHeaderCell width="flex-1">신청자</TableHeaderCell>
-            <TableHeaderCell width="w-[152px]">상태</TableHeaderCell>
-          </div>
-          {pendingClubApplications.length === 0 ? (
-            <div className="py-8 text-center text-[16px] leading-[140%] font-medium text-[#8B95A1]">
-              신청 내역이 없습니다.
-            </div>
-          ) : (
-            pendingClubApplications.map((application) => (
-              <ApplicationTableRow
-                key={application.applicationId}
-                applicationId={application.applicationId}
-                clubName={application.clubName}
-                applicantName={application.applicantName}
-                category={application.category}
-                status={application.status}
-                createdAt={application.createdAt}
-                onApprove={handleCombinedApprove}
-                onReject={handleCombinedReject}
+      <div className="flex flex-col gap-6">
+        <div className="flex">
+          {STATUS_TABS.map((tab) => (
+            <button
+              key={tab.value}
+              type="button"
+              onClick={() => setStatusTab(tab.value)}
+              className="flex w-20 flex-col items-center gap-[5px]"
+            >
+              <span
+                className={`text-[16px] leading-[140%] font-semibold tracking-[-0.03em] ${statusTab === tab.value ? 'text-[#22CF64]' : 'text-[#8B95A1]'}`}
+              >
+                {tab.label}
+              </span>
+              <span
+                className={`h-px w-full ${statusTab === tab.value ? 'bg-[#22CF64]' : 'bg-transparent'}`}
               />
-            ))
-          )}
+            </button>
+          ))}
         </div>
-      )}
 
-      {activeTab === 'masterOnly' && (
-        <div className="flex w-full flex-col">
-          <div className="flex w-full items-center border-t border-b border-[#8B95A1] py-2">
-            <TableHeaderCell width="w-[120px]">신청일자</TableHeaderCell>
-            <TableHeaderCell width="w-[160px]">동아리명</TableHeaderCell>
-            <TableHeaderCell width="flex-1">신청자</TableHeaderCell>
-            <TableHeaderCell width="w-[152px]">상태</TableHeaderCell>
-          </div>
-          {pendingMasterApplications.length === 0 ? (
+        <div className="flex w-full flex-col border-t border-[#8B95A1]">
+          {visibleItems.length === 0 ? (
             <div className="py-8 text-center text-[16px] leading-[140%] font-medium text-[#8B95A1]">
               신청 내역이 없습니다.
             </div>
           ) : (
-            pendingMasterApplications.map((application) => (
-              <ApplicationTableRow
-                key={application.id}
-                applicationId={application.id}
-                clubName={application.clubName}
-                applicantName={application.userName}
-                status={application.status}
-                createdAt={application.createdAt}
-                onApprove={handleMasterApprove}
-                onReject={handleMasterReject}
+            visibleItems.map((item) => (
+              <ApplicationCard
+                key={item.key}
+                item={item}
+                onApprove={() => handleApprove(item)}
+                onReject={(rejectReason) => handleReject(item, rejectReason)}
               />
             ))
           )}
         </div>
-      )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#549

> QA #14 (관리자 페이지 대시보드 - 동아리 현황 수치 오류)

## 📝작업 내용

새 디자인에 맞춰 대시보드를 재설계하면서 QA #14의 현황 수치 오류를 해소했습니다.

- **전체 동아리 현황 카드 섹션 제거**: 새 디자인에서 해당 섹션이 사라지며, 문제였던 수치 오류(등록 동아리 0개·승인 대기 과다 집계·전체 동아리장 오표기)가 함께 해소됨
- **승인 대기 신청 리스트 중심으로 재편**: 카드형 로우(`ApplicationCard`)로 전환
- **필터 탭을 API별 단일 데이터셋으로 매핑**
  - `동아리 생성 & 동아리장` → `admin/club-applications`
  - `동아리장` → `admin/club-master-applications`
- **상태 탭 추가**: 진행 중 / 승인 / 반려
- **관리자 권한 분기 유지**: 총동연=선택 학교, 학교관리자=본인 학교 (#561 기반)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 이 PR은 **#561(560 브랜치)에 스택**되어 있습니다. base가 `560-feat-admin-dashboard-auth`이며, #561 머지 후 develop로 자동 재지정됩니다.