### PR TITLE
feat: 마이페이지 신청 현황 동아리 생성/동아리장 2섹션 분리

### DIFF
--- a/src/app/[universityCode]/(main)/my/applications/create/page.tsx
+++ b/src/app/[universityCode]/(main)/my/applications/create/page.tsx
@@ -1,0 +1,35 @@
+import { getSession } from '@/shared/lib/cookie-session';
+import LoginRequired from '@/shared/ui/login-required';
+import getClubApplicationStatus from '@/entities/my/api/getClubApplicationStatus';
+import { toCreateCardItem } from '@/entities/my/lib/application-card';
+import ClubApplicationList from '@/features/my/ui/club-application-list';
+
+interface PageProps {
+  params: Promise<{ universityCode: string }>;
+}
+
+async function Page({ params }: PageProps) {
+  const { universityCode } = await params;
+  const session = await getSession();
+
+  if (!session) {
+    return <LoginRequired />;
+  }
+
+  const clubApplicationStatus = await getClubApplicationStatus();
+  const items = (clubApplicationStatus.data?.clubApplications ?? []).map(
+    toCreateCardItem,
+  );
+
+  return (
+    <div className="mx-auto w-full px-4 sm:w-lg">
+      <ClubApplicationList
+        title="동아리 생성 신청"
+        items={items}
+        universityCode={universityCode}
+      />
+    </div>
+  );
+}
+
+export default Page;

--- a/src/app/[universityCode]/(main)/my/applications/create/page.tsx
+++ b/src/app/[universityCode]/(main)/my/applications/create/page.tsx
@@ -2,6 +2,7 @@ import { getSession } from '@/shared/lib/cookie-session';
 import LoginRequired from '@/shared/ui/login-required';
 import getClubApplicationStatus from '@/entities/my/api/getClubApplicationStatus';
 import { toCreateCardItem } from '@/entities/my/lib/application-card';
+import { APPLICATION_SECTION } from '@/entities/my/model/constants';
 import ClubApplicationList from '@/features/my/ui/club-application-list';
 
 interface PageProps {
@@ -24,7 +25,7 @@ async function Page({ params }: PageProps) {
   return (
     <div className="mx-auto w-full px-4 sm:w-lg">
       <ClubApplicationList
-        title="동아리 생성 신청"
+        title={APPLICATION_SECTION.create.title}
         items={items}
         universityCode={universityCode}
       />

--- a/src/app/[universityCode]/(main)/my/applications/master/page.tsx
+++ b/src/app/[universityCode]/(main)/my/applications/master/page.tsx
@@ -17,9 +17,7 @@ async function Page({ params }: PageProps) {
   }
 
   const clubMasterStatus = await getMyClubMasterApplications();
-  const items = (clubMasterStatus.data?.applications ?? []).map(
-    toMasterCardItem,
-  );
+  const items = (clubMasterStatus.data ?? []).map(toMasterCardItem);
 
   return (
     <div className="mx-auto w-full px-4 sm:w-lg">

--- a/src/app/[universityCode]/(main)/my/applications/master/page.tsx
+++ b/src/app/[universityCode]/(main)/my/applications/master/page.tsx
@@ -26,7 +26,6 @@ async function Page({ params }: PageProps) {
         title={APPLICATION_SECTION.master.title}
         items={items}
         universityCode={universityCode}
-        showLogo
       />
     </div>
   );

--- a/src/app/[universityCode]/(main)/my/applications/master/page.tsx
+++ b/src/app/[universityCode]/(main)/my/applications/master/page.tsx
@@ -1,0 +1,36 @@
+import { getSession } from '@/shared/lib/cookie-session';
+import LoginRequired from '@/shared/ui/login-required';
+import getMyClubMasterApplications from '@/entities/my/api/getMyClubMasterApplications';
+import { toMasterCardItem } from '@/entities/my/lib/application-card';
+import ClubApplicationList from '@/features/my/ui/club-application-list';
+
+interface PageProps {
+  params: Promise<{ universityCode: string }>;
+}
+
+async function Page({ params }: PageProps) {
+  const { universityCode } = await params;
+  const session = await getSession();
+
+  if (!session) {
+    return <LoginRequired />;
+  }
+
+  const clubMasterStatus = await getMyClubMasterApplications();
+  const items = (clubMasterStatus.data?.applications ?? []).map(
+    toMasterCardItem,
+  );
+
+  return (
+    <div className="mx-auto w-full px-4 sm:w-lg">
+      <ClubApplicationList
+        title="동아리 & 동아리장 신청"
+        items={items}
+        universityCode={universityCode}
+        showLogo
+      />
+    </div>
+  );
+}
+
+export default Page;

--- a/src/app/[universityCode]/(main)/my/applications/master/page.tsx
+++ b/src/app/[universityCode]/(main)/my/applications/master/page.tsx
@@ -2,6 +2,7 @@ import { getSession } from '@/shared/lib/cookie-session';
 import LoginRequired from '@/shared/ui/login-required';
 import getMyClubMasterApplications from '@/entities/my/api/getMyClubMasterApplications';
 import { toMasterCardItem } from '@/entities/my/lib/application-card';
+import { APPLICATION_SECTION } from '@/entities/my/model/constants';
 import ClubApplicationList from '@/features/my/ui/club-application-list';
 
 interface PageProps {
@@ -22,7 +23,7 @@ async function Page({ params }: PageProps) {
   return (
     <div className="mx-auto w-full px-4 sm:w-lg">
       <ClubApplicationList
-        title="동아리 & 동아리장 신청"
+        title={APPLICATION_SECTION.master.title}
         items={items}
         universityCode={universityCode}
         showLogo

--- a/src/app/[universityCode]/(main)/my/page.tsx
+++ b/src/app/[universityCode]/(main)/my/page.tsx
@@ -1,12 +1,16 @@
 import MyPage from '@/entities/my/ui/my-page';
 
 interface PageProps {
+  params: Promise<{ universityCode: string }>;
   searchParams: Promise<{ newUser?: string }>;
 }
 
-async function Page({ searchParams }: PageProps) {
+async function Page({ params, searchParams }: PageProps) {
+  const { universityCode } = await params;
   const { newUser } = await searchParams;
-  return <MyPage isNewUser={newUser === 'true'} />;
+  return (
+    <MyPage universityCode={universityCode} isNewUser={newUser === 'true'} />
+  );
 }
 
 export default Page;

--- a/src/entities/my/api/getMyClubMasterApplications.tsx
+++ b/src/entities/my/api/getMyClubMasterApplications.tsx
@@ -1,0 +1,24 @@
+import api from '@/shared/api/auth-api';
+import { ApiResponse } from '@/shared/model/type';
+import createErrorResponse from '@/shared/lib/error-message';
+import { MyClubMasterApplicationListType } from '../model/type';
+
+async function getMyClubMasterApplications() {
+  try {
+    const response: ApiResponse<MyClubMasterApplicationListType> = await api
+      .get('club-master-applications/me', {
+        cache: 'no-store',
+        next: { tags: ['club-master-applications-me'] },
+      })
+      .json();
+    return {
+      ok: true,
+      data: response.data,
+      status: 200,
+    };
+  } catch (error) {
+    return createErrorResponse(error as Error);
+  }
+}
+
+export default getMyClubMasterApplications;

--- a/src/entities/my/api/getMyClubMasterApplications.tsx
+++ b/src/entities/my/api/getMyClubMasterApplications.tsx
@@ -1,11 +1,11 @@
 import api from '@/shared/api/auth-api';
 import { ApiResponse } from '@/shared/model/type';
 import createErrorResponse from '@/shared/lib/error-message';
-import { MyClubMasterApplicationListType } from '../model/type';
+import { MyClubMasterApplicationType } from '../model/type';
 
 async function getMyClubMasterApplications() {
   try {
-    const response: ApiResponse<MyClubMasterApplicationListType> = await api
+    const response: ApiResponse<MyClubMasterApplicationType[]> = await api
       .get('club-master-applications/me', {
         cache: 'no-store',
         next: { tags: ['club-master-applications-me'] },

--- a/src/entities/my/lib/application-card.ts
+++ b/src/entities/my/lib/application-card.ts
@@ -1,4 +1,3 @@
-import { getUniversityName } from '@/shared/lib/universityMeta';
 import {
   ApplicationCardItem,
   ClubApplicationType,
@@ -24,10 +23,10 @@ export function toMasterCardItem(
   return {
     id: application.id,
     clubName: application.clubName,
-    universityName: getUniversityName(application.universityCode),
+    universityName: application.universityName,
     status: application.status,
     rejectReason: application.rejectReason,
-    logo: application.logo ?? null,
+    logo: null,
     createdAt: application.createdAt,
   };
 }

--- a/src/entities/my/lib/application-card.ts
+++ b/src/entities/my/lib/application-card.ts
@@ -1,0 +1,41 @@
+import { getUniversityName } from '@/shared/lib/universityMeta';
+import {
+  ApplicationCardItem,
+  ClubApplicationType,
+  MyClubMasterApplicationType,
+} from '../model/type';
+
+export function toCreateCardItem(
+  application: ClubApplicationType,
+): ApplicationCardItem {
+  return {
+    id: application.clubApplicationId,
+    clubName: application.clubName,
+    universityName: application.universityName,
+    status: application.status,
+    rejectReason: application.rejectReason,
+    createdAt: application.createdAt,
+  };
+}
+
+export function toMasterCardItem(
+  application: MyClubMasterApplicationType,
+): ApplicationCardItem {
+  return {
+    id: application.id,
+    clubName: application.clubName,
+    universityName: getUniversityName(application.universityCode),
+    status: application.status,
+    rejectReason: application.rejectReason,
+    logo: application.logo ?? null,
+    createdAt: application.createdAt,
+  };
+}
+
+export function sortByLatest(
+  items: ApplicationCardItem[],
+): ApplicationCardItem[] {
+  return [...items].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+}

--- a/src/entities/my/lib/application-card.ts
+++ b/src/entities/my/lib/application-card.ts
@@ -26,7 +26,6 @@ export function toMasterCardItem(
     universityName: application.universityName,
     status: application.status,
     rejectReason: application.rejectReason,
-    logo: null,
     createdAt: application.createdAt,
   };
 }

--- a/src/entities/my/model/constants.ts
+++ b/src/entities/my/model/constants.ts
@@ -1,0 +1,11 @@
+/* eslint-disable import/prefer-default-export */
+export const APPLICATION_SECTION = {
+  master: {
+    title: '동아리 & 동아리장 신청',
+    path: 'master',
+  },
+  create: {
+    title: '동아리 생성 신청',
+    path: 'create',
+  },
+} as const;

--- a/src/entities/my/model/type.ts
+++ b/src/entities/my/model/type.ts
@@ -24,17 +24,13 @@ export interface ClubApplicationListType {
 
 export interface MyClubMasterApplicationType {
   id: number;
-  universityCode: string;
+  universityName: string;
   clubName: string;
   userName: string;
   status: ClubApplicationStatus;
   rejectReason: string | null;
-  logo?: string | null;
   createdAt: string;
-}
-
-export interface MyClubMasterApplicationListType {
-  applications: MyClubMasterApplicationType[];
+  updatedAt?: string;
 }
 
 export interface ApplicationCardItem {

--- a/src/entities/my/model/type.ts
+++ b/src/entities/my/model/type.ts
@@ -22,4 +22,29 @@ export interface ClubApplicationListType {
   clubApplications: ClubApplicationType[];
 }
 
+export interface MyClubMasterApplicationType {
+  id: number;
+  universityCode: string;
+  clubName: string;
+  userName: string;
+  status: ClubApplicationStatus;
+  rejectReason: string | null;
+  logo?: string | null;
+  createdAt: string;
+}
+
+export interface MyClubMasterApplicationListType {
+  applications: MyClubMasterApplicationType[];
+}
+
+export interface ApplicationCardItem {
+  id: number;
+  clubName: string;
+  universityName: string;
+  status: ClubApplicationStatus;
+  rejectReason: string | null;
+  logo?: string | null;
+  createdAt: string;
+}
+
 export default UserInfoType;

--- a/src/entities/my/model/type.ts
+++ b/src/entities/my/model/type.ts
@@ -39,7 +39,6 @@ export interface ApplicationCardItem {
   universityName: string;
   status: ClubApplicationStatus;
   rejectReason: string | null;
-  logo?: string | null;
   createdAt: string;
 }
 

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -10,6 +10,11 @@ import { getUniversityName } from '@/shared/lib/universityMeta';
 import getUniversities from '@/entities/university/api/getUniversities';
 import getMyInfo from '@/entities/my/api/getMyInfo';
 import getClubApplicationStatus from '@/entities/my/api/getClubApplicationStatus';
+import getMyClubMasterApplications from '@/entities/my/api/getMyClubMasterApplications';
+import {
+  toCreateCardItem,
+  toMasterCardItem,
+} from '@/entities/my/lib/application-card';
 import InfoRow from '@/entities/my/ui/info-row';
 import EmailChangeDialog from '@/features/my/ui/email-change-dialog';
 import EmailDeleteButton from '@/features/my/ui/email-delete-button';
@@ -17,18 +22,26 @@ import MailNotificationToggle from '@/features/my/ui/mail-notification-toggle';
 import LogoutLink from '@/features/my/ui/logout-link';
 import ClubApplicationStatus from '@/features/my/ui/club-application-status';
 
-async function MyPage({ isNewUser = false }: { isNewUser?: boolean }) {
+async function MyPage({
+  universityCode,
+  isNewUser = false,
+}: {
+  universityCode: string;
+  isNewUser?: boolean;
+}) {
   const session = await getSession();
 
   if (!session) {
     return <LoginRequired />;
   }
 
-  const [myInfo, universitiesRes, clubApplicationStatus] = await Promise.all([
-    getMyInfo(),
-    getUniversities(),
-    getClubApplicationStatus(),
-  ]);
+  const [myInfo, universitiesRes, clubApplicationStatus, clubMasterStatus] =
+    await Promise.all([
+      getMyInfo(),
+      getUniversities(),
+      getClubApplicationStatus(),
+      getMyClubMasterApplications(),
+    ]);
 
   if (!myInfo.ok || !myInfo.data) {
     return <ErrorBoundaryUi />;
@@ -36,7 +49,12 @@ async function MyPage({ isNewUser = false }: { isNewUser?: boolean }) {
 
   const user = myInfo.data;
   const universities = universitiesRes.data?.universities ?? [];
-  const clubApplications = clubApplicationStatus.data?.clubApplications ?? [];
+  const createItems = (clubApplicationStatus.data?.clubApplications ?? []).map(
+    toCreateCardItem,
+  );
+  const masterItems = (clubMasterStatus.data?.applications ?? []).map(
+    toMasterCardItem,
+  );
   const userRole = session?.role || UserRole.NORMAL;
   const isAdmin = userRole !== UserRole.NORMAL;
 
@@ -52,9 +70,11 @@ async function MyPage({ isNewUser = false }: { isNewUser?: boolean }) {
           </div>
         </div>
 
-        {clubApplications.length > 0 && (
-          <ClubApplicationStatus applications={clubApplications} />
-        )}
+        <ClubApplicationStatus
+          createItems={createItems}
+          masterItems={masterItems}
+          universityCode={universityCode}
+        />
 
         <div className="flex flex-col">
           <span className="mb-4 font-semibold">내 정보</span>

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -52,9 +52,7 @@ async function MyPage({
   const createItems = (clubApplicationStatus.data?.clubApplications ?? []).map(
     toCreateCardItem,
   );
-  const masterItems = (clubMasterStatus.data?.applications ?? []).map(
-    toMasterCardItem,
-  );
+  const masterItems = (clubMasterStatus.data ?? []).map(toMasterCardItem);
   const userRole = session?.role || UserRole.NORMAL;
   const isAdmin = userRole !== UserRole.NORMAL;
 

--- a/src/features/my/ui/club-application-card.tsx
+++ b/src/features/my/ui/club-application-card.tsx
@@ -12,39 +12,25 @@ import {
   DialogTrigger,
 } from '@/shared/ui/dialog';
 import { Button } from '@/shared/ui/button';
-import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
 import { ApplicationCardItem } from '@/entities/my/model/type';
 
 type ClubApplicationCardProps = {
   item: ApplicationCardItem;
-  showLogo?: boolean;
 };
 
-function ClubApplicationCard({
-  item,
-  showLogo = false,
-}: ClubApplicationCardProps) {
-  const { clubName, universityName, status, createdAt, rejectReason, logo } =
-    item;
+function ClubApplicationCard({ item }: ClubApplicationCardProps) {
+  const { clubName, universityName, status, createdAt, rejectReason } = item;
 
   return (
     <li className="flex flex-col gap-3 rounded-2xl border border-[#22CF64] p-4">
-      <div className="flex items-center gap-4">
-        {showLogo && (
-          <Avatar className="size-13">
-            <AvatarImage src={logo ?? ''} alt={clubName} />
-            <AvatarFallback />
-          </Avatar>
-        )}
-        <div className="flex flex-col gap-1">
-          <span className="font-semibold">
-            {clubName}{' '}
-            <span className="text-text-tertiary text-lg">{universityName}</span>
-          </span>
-          <span className="text-text-tertiary text-sm">
-            신청일시 | {dayjs(createdAt).format('YYYY.MM.DD')}
-          </span>
-        </div>
+      <div className="flex flex-col gap-1">
+        <span className="font-semibold">
+          {clubName}{' '}
+          <span className="text-text-tertiary text-lg">{universityName}</span>
+        </span>
+        <span className="text-text-tertiary text-sm">
+          신청일시 | {dayjs(createdAt).format('YYYY.MM.DD')}
+        </span>
       </div>
 
       <div className="h-0.5 w-full rounded-full bg-[#f8f8f8]">

--- a/src/features/my/ui/club-application-card.tsx
+++ b/src/features/my/ui/club-application-card.tsx
@@ -12,26 +12,39 @@ import {
   DialogTrigger,
 } from '@/shared/ui/dialog';
 import { Button } from '@/shared/ui/button';
-import { ClubApplicationType } from '@/entities/my/model/type';
+import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
+import { ApplicationCardItem } from '@/entities/my/model/type';
 
 type ClubApplicationCardProps = {
-  application: ClubApplicationType;
+  item: ApplicationCardItem;
+  showLogo?: boolean;
 };
 
-function ClubApplicationCard({ application }: ClubApplicationCardProps) {
-  const { clubName, universityName, status, createdAt, rejectReason } =
-    application;
+function ClubApplicationCard({
+  item,
+  showLogo = false,
+}: ClubApplicationCardProps) {
+  const { clubName, universityName, status, createdAt, rejectReason, logo } =
+    item;
 
   return (
     <li className="flex flex-col gap-3 rounded-2xl border border-[#22CF64] p-4">
-      <div className="flex flex-col gap-1">
-        <span className="font-semibold">
-          {clubName}{' '}
-          <span className="text-text-tertiary text-lg">{universityName}</span>
-        </span>
-        <span className="text-text-tertiary text-sm">
-          신청일시 | {dayjs(createdAt).format('YYYY.MM.DD')}
-        </span>
+      <div className="flex items-center gap-4">
+        {showLogo && (
+          <Avatar className="size-13">
+            <AvatarImage src={logo ?? ''} alt={clubName} />
+            <AvatarFallback />
+          </Avatar>
+        )}
+        <div className="flex flex-col gap-1">
+          <span className="font-semibold">
+            {clubName}{' '}
+            <span className="text-text-tertiary text-lg">{universityName}</span>
+          </span>
+          <span className="text-text-tertiary text-sm">
+            신청일시 | {dayjs(createdAt).format('YYYY.MM.DD')}
+          </span>
+        </div>
       </div>
 
       <div className="h-0.5 w-full rounded-full bg-[#f8f8f8]">

--- a/src/features/my/ui/club-application-list.tsx
+++ b/src/features/my/ui/club-application-list.tsx
@@ -8,14 +8,12 @@ type ClubApplicationListProps = {
   title: string;
   items: ApplicationCardItem[];
   universityCode: string;
-  showLogo?: boolean;
 };
 
 function ClubApplicationList({
   title,
   items,
   universityCode,
-  showLogo = false,
 }: ClubApplicationListProps) {
   const myHref = `/${universityCode}/my`;
   const sortedItems = sortByLatest(items);
@@ -36,11 +34,7 @@ function ClubApplicationList({
       {sortedItems.length > 0 ? (
         <ul className="flex flex-col gap-3">
           {sortedItems.map((item) => (
-            <ClubApplicationCard
-              key={item.id}
-              item={item}
-              showLogo={showLogo}
-            />
+            <ClubApplicationCard key={item.id} item={item} />
           ))}
         </ul>
       ) : (

--- a/src/features/my/ui/club-application-list.tsx
+++ b/src/features/my/ui/club-application-list.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ApplicationCardItem } from '@/entities/my/model/type';
+import { sortByLatest } from '@/entities/my/lib/application-card';
+import ClubApplicationCard from './club-application-card';
+
+type ClubApplicationListProps = {
+  title: string;
+  items: ApplicationCardItem[];
+  universityCode: string;
+  showLogo?: boolean;
+};
+
+function ClubApplicationList({
+  title,
+  items,
+  universityCode,
+  showLogo = false,
+}: ClubApplicationListProps) {
+  const myHref = `/${universityCode}/my`;
+  const sortedItems = sortByLatest(items);
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="text-text-tertiary flex items-center gap-0.5 text-sm">
+        <Link href={myHref}>마이페이지</Link>
+        <ChevronRight className="size-3.5" />
+        <span className="text-text-secondary">{title}</span>
+      </div>
+
+      <Link href={myHref} className="flex items-center gap-1 font-semibold">
+        <ChevronLeft className="size-4" />
+        {title}
+      </Link>
+
+      {sortedItems.length > 0 ? (
+        <ul className="flex flex-col gap-3">
+          {sortedItems.map((item) => (
+            <ClubApplicationCard
+              key={item.id}
+              item={item}
+              showLogo={showLogo}
+            />
+          ))}
+        </ul>
+      ) : (
+        <p className="text-text-tertiary py-10 text-center text-sm">
+          신청 내역이 없습니다.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default ClubApplicationList;

--- a/src/features/my/ui/club-application-status.tsx
+++ b/src/features/my/ui/club-application-status.tsx
@@ -8,14 +8,12 @@ type ApplicationSectionProps = {
   title: string;
   moreHref: string;
   items: ApplicationCardItem[];
-  showLogo?: boolean;
 };
 
 function ApplicationSection({
   title,
   moreHref,
   items,
-  showLogo = false,
 }: ApplicationSectionProps) {
   if (items.length === 0) {
     return null;
@@ -32,7 +30,7 @@ function ApplicationSection({
         </Link>
       </div>
       <ul>
-        <ClubApplicationCard item={latest} showLogo={showLogo} />
+        <ClubApplicationCard item={latest} />
       </ul>
     </div>
   );
@@ -61,7 +59,6 @@ function ClubApplicationStatus({
           title={APPLICATION_SECTION.master.title}
           moreHref={`/${universityCode}/my/applications/${APPLICATION_SECTION.master.path}`}
           items={masterItems}
-          showLogo
         />
         <ApplicationSection
           title={APPLICATION_SECTION.create.title}

--- a/src/features/my/ui/club-application-status.tsx
+++ b/src/features/my/ui/club-application-status.tsx
@@ -1,22 +1,73 @@
-import { ClubApplicationType } from '@/entities/my/model/type';
+import Link from 'next/link';
+import { ApplicationCardItem } from '@/entities/my/model/type';
+import { sortByLatest } from '@/entities/my/lib/application-card';
 import ClubApplicationCard from './club-application-card';
 
-type ClubApplicationStatusProps = {
-  applications: ClubApplicationType[];
+type ApplicationSectionProps = {
+  title: string;
+  moreHref: string;
+  items: ApplicationCardItem[];
+  showLogo?: boolean;
 };
 
-function ClubApplicationStatus({ applications }: ClubApplicationStatusProps) {
+function ApplicationSection({
+  title,
+  moreHref,
+  items,
+  showLogo = false,
+}: ApplicationSectionProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  const latest = sortByLatest(items)[0];
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-[#7F7F7F]">{title}</span>
+        <Link href={moreHref} className="text-sm text-[#8B95A1]">
+          더보기
+        </Link>
+      </div>
+      <ul>
+        <ClubApplicationCard item={latest} showLogo={showLogo} />
+      </ul>
+    </div>
+  );
+}
+
+type ClubApplicationStatusProps = {
+  createItems: ApplicationCardItem[];
+  masterItems: ApplicationCardItem[];
+  universityCode: string;
+};
+
+function ClubApplicationStatus({
+  createItems,
+  masterItems,
+  universityCode,
+}: ClubApplicationStatusProps) {
+  if (createItems.length === 0 && masterItems.length === 0) {
+    return null;
+  }
+
   return (
     <div className="mb-10 flex flex-col gap-3">
       <div className="font-semibold">신청 현황</div>
-      <ul className="flex flex-col gap-3">
-        {applications.map((application) => (
-          <ClubApplicationCard
-            key={application.clubApplicationId}
-            application={application}
-          />
-        ))}
-      </ul>
+      <div className="flex flex-col gap-5">
+        <ApplicationSection
+          title="동아리 & 동아리장 신청"
+          moreHref={`/${universityCode}/my/applications/master`}
+          items={masterItems}
+          showLogo
+        />
+        <ApplicationSection
+          title="동아리 생성 신청"
+          moreHref={`/${universityCode}/my/applications/create`}
+          items={createItems}
+        />
+      </div>
     </div>
   );
 }

--- a/src/features/my/ui/club-application-status.tsx
+++ b/src/features/my/ui/club-application-status.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { ApplicationCardItem } from '@/entities/my/model/type';
+import { APPLICATION_SECTION } from '@/entities/my/model/constants';
 import { sortByLatest } from '@/entities/my/lib/application-card';
 import ClubApplicationCard from './club-application-card';
 
@@ -25,8 +26,8 @@ function ApplicationSection({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between">
-        <span className="text-sm text-[#7F7F7F]">{title}</span>
-        <Link href={moreHref} className="text-sm text-[#8B95A1]">
+        <span className="text-text-tertiary text-sm">{title}</span>
+        <Link href={moreHref} className="text-text-secondary text-sm">
           더보기
         </Link>
       </div>
@@ -57,14 +58,14 @@ function ClubApplicationStatus({
       <div className="font-semibold">신청 현황</div>
       <div className="flex flex-col gap-5">
         <ApplicationSection
-          title="동아리 & 동아리장 신청"
-          moreHref={`/${universityCode}/my/applications/master`}
+          title={APPLICATION_SECTION.master.title}
+          moreHref={`/${universityCode}/my/applications/${APPLICATION_SECTION.master.path}`}
           items={masterItems}
           showLogo
         />
         <ApplicationSection
-          title="동아리 생성 신청"
-          moreHref={`/${universityCode}/my/applications/create`}
+          title={APPLICATION_SECTION.create.title}
+          moreHref={`/${universityCode}/my/applications/${APPLICATION_SECTION.create.path}`}
           items={createItems}
         />
       </div>

--- a/src/mocks/handlers/clubMaster.ts
+++ b/src/mocks/handlers/clubMaster.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies, import/prefer-default-export */
 import { http, HttpResponse, passthrough } from 'msw';
+import { getUniversityName } from '@/shared/lib/universityMeta';
 import { clubApplications, myClubMasterApplications } from '../data';
 
 const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? '';
@@ -30,7 +31,17 @@ export const clubMasterHandlers = [
   ),
 
   http.get(url('/club-master-applications/me'), () =>
-    HttpResponse.json({ data: { applications: myClubMasterApplications } }),
+    HttpResponse.json({
+      data: myClubMasterApplications.map((application) => ({
+        id: application.id,
+        universityName: getUniversityName(application.universityCode),
+        clubName: application.clubName,
+        userName: application.userName,
+        status: application.status,
+        rejectReason: application.rejectReason ?? null,
+        createdAt: application.createdAt,
+      })),
+    }),
   ),
 
   http.post(

--- a/src/mocks/handlers/clubMaster.ts
+++ b/src/mocks/handlers/clubMaster.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies, import/prefer-default-export */
 import { http, HttpResponse, passthrough } from 'msw';
-import { myClubMasterApplications } from '../data';
+import { clubApplications, myClubMasterApplications } from '../data';
 
 const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? '';
 
@@ -8,6 +8,21 @@ const url = (path: string) => `${baseUrl}${path}`;
 
 export const clubMasterHandlers = [
   http.post(url('/club-applications'), () => passthrough()),
+
+  http.get(url('/club-applications/me'), () =>
+    HttpResponse.json({
+      data: {
+        clubApplications: clubApplications.map((application) => ({
+          clubApplicationId: application.applicationId,
+          universityName: application.universityName,
+          clubName: application.clubName,
+          status: application.status,
+          rejectReason: application.rejectReason,
+          createdAt: application.createdAt,
+        })),
+      },
+    }),
+  ),
 
   http.post(
     url('/club-master-applications'),


### PR DESCRIPTION
## #️⃣연관된 이슈

#563

## 📝작업 내용

마이페이지 신청 현황에서 동아리 생성 신청과 동아리장 권한 신청을 모두 했을 때 동아리장 권한 신청 현황이 누락되던 문제를 수정했습니다.

- 신청 현황을 `동아리 & 동아리장 신청` / `동아리 생성 신청` **2섹션으로 분리**, 각 섹션 최신 1건 노출
- 각 섹션 `더보기` → 타입별 전체 신청 목록 상세 페이지 연결 (`my/applications/master`, `my/applications/create`)
- 동아리장 신청 조회(`club-master-applications/me`) API·타입 신설. 두 신청 응답을 공통 카드 shape으로 정규화
- 동아리장 카드는 로고 표시 variant 적용 (Avatar 폴백으로 안전 렌더)
- 섹션 제목/경로 상수화, raw hex → 디자인 토큰 적용


### 스크린샷 (선택)
<img width="708" height="528" alt="image" src="https://github.com/user-attachments/assets/be0b9c9e-013a-4d06-8d11-51343a5385e8" />
<img width="881" height="718" alt="image" src="https://github.com/user-attachments/assets/d72afbaa-7a42-41d4-98e3-28ad6d881224" />

## 💬리뷰 요구사항(선택)

- `club-master-applications/me` 응답에 **동아리 로고 필드가 없어** 동아리장 카드는 현재 기본 아이콘으로 표시됩니다. 로고 노출 필요 시 백엔드 응답 추가가 필요합니다. 해당 부분은 디자인 파트와 상의 후 진행하겠습니다.