### PR TITLE
refactor: 동아리생성폼으로 이어지는 배너 추가하기

### DIFF
--- a/src/app/[universityCode]/(main)/support/page.tsx
+++ b/src/app/[universityCode]/(main)/support/page.tsx
@@ -1,7 +1,12 @@
 import SupportPage from '@/views/support/ui/support-page';
 
-function Page() {
-  return <SupportPage />;
+async function Page({
+  params,
+}: {
+  params: Promise<{ universityCode: string }>;
+}) {
+  const { universityCode } = await params;
+  return <SupportPage universityCode={universityCode} />;
 }
 
 export default Page;

--- a/src/features/support/ui/club-application-button.tsx
+++ b/src/features/support/ui/club-application-button.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+import { toast } from 'react-toastify';
+import { useSession } from '@/shared/lib/session-context';
+
+interface ClubApplicationButtonProps {
+  universityCode: string;
+}
+
+function ClubApplicationButton({ universityCode }: ClubApplicationButtonProps) {
+  const { session } = useSession();
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (!session) {
+      e.preventDefault();
+      toast.error('로그인이 필요합니다.');
+    }
+  };
+
+  return (
+    <Link
+      href={`/${universityCode}/club-application`}
+      onClick={handleClick}
+      className="bg-gray4 mt-6 flex w-full items-center justify-between rounded-md p-4"
+    >
+      <span className="text-text-primary text-sm lg:text-base">
+        동아리/동아리장 신청하기
+      </span>
+      <Image src="/nextBlack.svg" alt="바로가기" width={8} height={12} />
+    </Link>
+  );
+}
+
+export default ClubApplicationButton;

--- a/src/views/support/ui/support-page.tsx
+++ b/src/views/support/ui/support-page.tsx
@@ -1,13 +1,19 @@
 import Search from '@/features/support/ui/search';
 import FAQList from '@/widgets/support/faq-list';
 import BugInfoButton from '@/features/support/ui/bug-info-button';
+import ClubApplicationButton from '@/features/support/ui/club-application-button';
 import ScrollProgressBar from '@/shared/ui/scroll-progress-bar';
 
-function SupportPage() {
+interface SupportPageProps {
+  universityCode: string;
+}
+
+function SupportPage({ universityCode }: SupportPageProps) {
   return (
     <>
       <ScrollProgressBar />
       <Search />
+      <ClubApplicationButton universityCode={universityCode} />
       <FAQList />
       <BugInfoButton />
     </>

--- a/src/widgets/club/ui/club-item-client-list.tsx
+++ b/src/widgets/club/ui/club-item-client-list.tsx
@@ -60,6 +60,9 @@ function ClubItemClientList({ clubs }: ClubItemClientListProps) {
   return (
     <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3">
       {items}
+      <div className="hidden sm:col-span-2 sm:block lg:col-span-3">
+        <ClubApplicationBanner universityCode={universityCode} />
+      </div>
     </div>
   );
 }

--- a/src/widgets/support/faq-list.tsx
+++ b/src/widgets/support/faq-list.tsx
@@ -91,7 +91,7 @@ function FAQList() {
   }
 
   return (
-    <div className="mt-10 w-full space-y-6">
+    <div className="mt-8 w-full space-y-6">
       <h2 className="text-primary-500 text-xl font-bold lg:text-2xl">FAQ</h2>
       {faqData.map((item, idx) => (
         <div key={item.question} className="border-b pb-3 lg:pb-4">


### PR DESCRIPTION
## #️⃣연관된 이슈

> #558 

## 📝작업 내용

- 동아리 생성폼으로 진입하는 버튼이 기존에는 모바일 버전에서만 보이도록 되어있었는데 데스크탑 버전에서도 뜨도록 수정
- 고객센터 페이지에도 추가로 보이도록 수정

### 스크린샷 (선택)

피그마 디자인과 동일하게 진행했습니다.

- 전체 동아리 페이지
<img width="1512" height="765" alt="image" src="https://github.com/user-attachments/assets/dbc52e5a-97ef-407b-b6bf-a43face1bea5" />

- 고객센터 페이지
<img width="304" height="666" alt="image" src="https://github.com/user-attachments/assets/5930c3e0-c995-49a6-a195-519ae7ce687b" />

## 💬리뷰 요구사항(선택)

