### PR TITLE
refactor: admin API 응답 형식을 공통 ApiResponse로 통일

### DIFF
--- a/.claude/agents/api-builder.md
+++ b/.claude/agents/api-builder.md
@@ -32,28 +32,40 @@ Your role: **API spec → `features/{domain}/api/` Server Action files**
 
 ### Response Return Pattern
 
-**Query (GET) — return data directly:**
-```typescript
-'use server';
-import api from '@/shared/api/auth-api';
-import { DomainType } from '@/entities/{domain}/model/type';
-import { ApiResponse } from '@/shared/model/type';
+**Every API function — GET and mutation alike — returns the standard `{ ok, message, data, status }` response.**
+Never return a bare `T | null` or `boolean`: doing so collapses 401 / 403 / 500 / network failure into a single
+value, and the UI can no longer tell "no data" from "request failed" or show the server's own message.
 
-async function getDomainItem(id: number): Promise<DomainType | null> {
+Always type the ky response as `ApiResponse<T>` — the backend sends all four fields, so typing it as
+`{ data: T }` hides `ok` / `message` / `status` from TypeScript and lets an `ok: false` body pass as success.
+
+**Query (GET):**
+```typescript
+import api from '@/shared/api/auth-api';
+import createErrorResponse from '@/shared/lib/error-message';
+import { ApiResponse } from '@/shared/model/type';
+import { DomainType } from '@/entities/{domain}/model/type';
+
+async function getDomainItem(id: number) {
   try {
-    const response: ApiResponse<DomainType> = await api
+    const response = await api
       .get(`endpoint/${id}`)
-      .json();
-    return response.data ?? null;
-  } catch {
-    return null;
+      .json<ApiResponse<DomainType>>();
+
+    if (!response.data) {
+      return { ok: false, message: '데이터 없음', data: undefined, status: 200 };
+    }
+
+    return { ok: true, message: '성공', data: response.data, status: 200 };
+  } catch (e) {
+    return createErrorResponse(e as Error);
   }
 }
 
 export default getDomainItem;
 ```
 
-**Modification (POST/PATCH/DELETE) — return ok/message/status:**
+**Modification (POST/PATCH/DELETE):**
 ```typescript
 'use server';
 import api from '@/shared/api/auth-api';
@@ -73,24 +85,37 @@ export async function postDomainItem(body: RequestBodyType) {
 
 **Public API (no authentication):**
 ```typescript
-'use server';
 import serverApi from '@/shared/api/server-api';
-import { PublicType } from '@/entities/{domain}/model/type';
+import createErrorResponse from '@/shared/lib/error-message';
 import { ApiResponse } from '@/shared/model/type';
+import { PublicType } from '@/entities/{domain}/model/type';
 
-async function getPublicList(): Promise<PublicType[] | null> {
+async function getPublicList() {
   try {
-    const response: ApiResponse<{ items: PublicType[] }> = await serverApi
+    const response = await serverApi
       .get('public-endpoint')
-      .json();
-    return response.data?.items ?? null;
-  } catch {
-    return null;
+      .json<ApiResponse<{ items: PublicType[] }>>();
+
+    if (!response.data) {
+      return { ok: false, message: '데이터 없음', data: undefined, status: 200 };
+    }
+
+    return { ok: true, message: '성공', data: response.data.items, status: 200 };
+  } catch (e) {
+    return createErrorResponse(e as Error);
   }
 }
 
 export default getPublicList;
 ```
+
+### `'use server'` — only for Server Actions
+
+`'use server'` marks a function as callable from a client component. Add it only when a client component
+actually invokes the function — in practice, mutations (POST/PATCH/DELETE) and client-triggered queries.
+
+A GET that is awaited inside a Server Component is not a Server Action. Mark it `import 'server-only';`
+instead, so it can never be bundled into the client.
 
 ---
 
@@ -130,15 +155,17 @@ For each API endpoint:
    - `auth: true` → `@/shared/api/auth-api`
    - `auth: false` → `@/shared/api/server-api`
 
-3. **Determine return type**:
-   - GET (query) → `Promise<T | null>`
-   - POST/PATCH/DELETE (modify) → `Promise<{ ok: boolean; message: string; status: number }>`
+3. **Determine return type**: the standard `{ ok, message, data, status }` response for every method.
+   - GET (query) → `{ ok, message, data, status }`
+   - POST/PATCH/DELETE (modify) → `{ ok, message, status }` (no `data` unless the API returns a body)
+   - Type the ky response as `ApiResponse<T>`, never as a bare `{ data: T }`
 
-4. **Error handling**:
-   - Modify function: `createErrorResponse(e as Error, [...custom errors])`
-   - Query function: `catch { return null; }`
+4. **Error handling**: always `createErrorResponse(e as Error, [...custom errors])`.
+   Never `catch { return null; }` — it destroys the status and the server's message.
 
-5. **Server Action declaration**: Add `'use server';` at file top
+5. **Directive at file top**:
+   - Called from a client component (mutations, client-triggered queries) → `'use server';`
+   - Awaited inside a Server Component → `import 'server-only';`
 
 ### Phase 4 — Define Types (if missing)
 
@@ -182,8 +209,21 @@ Implementation:
 ## Forbidden Patterns
 
 ```typescript
-// [Forbidden] Server Action without 'use server'
-async function getData() { ... }
+// [Forbidden] Swallowing the error — 401 / 403 / 500 / network all collapse into null
+} catch {
+  return null;
+}
+
+// [Forbidden] Returning a bare value instead of the standard response
+async function getDomainItem(): Promise<DomainType | null> { ... }
+async function approveItem(): Promise<boolean> { ... }
+
+// [Forbidden] Typing away ok / message / status,
+// so a 200 response carrying `ok: false` passes as success
+const response = await api.get('endpoint').json<{ data: DomainType }>();
+
+// [Forbidden] Client-callable function without 'use server'
+async function postData() { ... }
 
 // [Forbidden] Using ky directly in client components
 // API functions must always be separate files

--- a/src/app/(admin)/dashboard/(main)/page.tsx
+++ b/src/app/(admin)/dashboard/(main)/page.tsx
@@ -2,9 +2,7 @@ import { Suspense } from 'react';
 import { redirect } from 'next/navigation';
 import AdminDashboardView from '@/views/admin/ui/AdminDashboardView';
 import getAdminInfo from '@/features/admin/api/getAdminInfo';
-import getClubMasterApplications from '@/features/admin/api/getClubMasterApplications';
-import getClubApplications from '@/features/admin/api/getClubApplications';
-import getAdminClubs from '@/features/admin/api/getAdminClubs';
+import getDashboardSummary from '@/features/admin/lib/getDashboardSummary';
 import getUniversities from '@/entities/university/api/getUniversities';
 
 export const dynamic = 'force-dynamic';
@@ -40,35 +38,16 @@ async function DashboardPage({ searchParams }: DashboardPageProps) {
     ? (selectedFromUrl ?? universities[0]?.code)
     : (adminInfo.universityCode ?? undefined);
 
-  const [clubMasterData, clubApplicationData, clubsData] = await Promise.all([
-    getClubMasterApplications({ page: 1, size: 100, universityCode }),
-    getClubApplications({
-      status: 'PENDING',
-      page: 1,
-      size: 100,
-      universityCode,
-    }),
-    getAdminClubs({ page: 1, size: 100, universityCode }),
-  ]);
+  const summaryResult = await getDashboardSummary(universityCode);
 
-  const clubMasterApplications = clubMasterData?.applications ?? [];
-  const clubApplications = clubApplicationData?.applications ?? [];
-  const clubs = clubsData?.clubs ?? [];
-
-  const totalClubs = clubsData?.pagination?.totalElements ?? 0;
-  const pendingMasterCount = clubMasterData?.pagination?.totalElements ?? 0;
-  const pendingClubCount = clubApplicationData?.page?.totalElements ?? 0;
-  const totalMasters = clubs.filter((club) => club.clubMaster !== null).length;
+  if (!summaryResult.ok || !summaryResult.data) {
+    throw new Error(summaryResult.message);
+  }
 
   return (
     <Suspense>
       <AdminDashboardView
-        clubMasterApplications={clubMasterApplications}
-        clubApplications={clubApplications}
-        totalClubs={totalClubs}
-        pendingMasterCount={pendingMasterCount}
-        pendingClubCount={pendingClubCount}
-        totalMasters={totalMasters}
+        summary={summaryResult.data}
         role={adminInfo.role}
         universities={universities}
         selectedCode={universityCode ?? ''}

--- a/src/features/admin/api/approveClubApplication.ts
+++ b/src/features/admin/api/approveClubApplication.ts
@@ -1,13 +1,18 @@
 'use server';
 
 import api from '@/shared/api/dashboard-api';
+import createErrorResponse from '@/shared/lib/error-message';
 
-async function approveClubApplication(applicationId: number): Promise<boolean> {
+async function approveClubApplication(applicationId: number) {
   try {
     await api.patch(`admin/club-applications/${applicationId}/approve`);
-    return true;
-  } catch {
-    return false;
+    return {
+      ok: true,
+      message: '동아리 생성 신청을 승인했습니다.',
+      status: 200,
+    };
+  } catch (error) {
+    return createErrorResponse(error as Error);
   }
 }
 

--- a/src/features/admin/api/approveClubMasterApplication.ts
+++ b/src/features/admin/api/approveClubMasterApplication.ts
@@ -1,15 +1,14 @@
 'use server';
 
 import api from '@/shared/api/dashboard-api';
+import createErrorResponse from '@/shared/lib/error-message';
 
-async function approveClubMasterApplication(
-  applicationId: number,
-): Promise<boolean> {
+async function approveClubMasterApplication(applicationId: number) {
   try {
     await api.patch(`admin/club-master-applications/${applicationId}/approve`);
-    return true;
-  } catch {
-    return false;
+    return { ok: true, message: '동아리장 신청을 승인했습니다.', status: 200 };
+  } catch (error) {
+    return createErrorResponse(error as Error);
   }
 }
 

--- a/src/features/admin/api/getAdminClubs.ts
+++ b/src/features/admin/api/getAdminClubs.ts
@@ -1,5 +1,7 @@
 import 'server-only';
 import api from '@/shared/api/dashboard-api';
+import createErrorResponse from '@/shared/lib/error-message';
+import { ApiResponse } from '@/shared/model/type';
 import type {
   AdminClub,
   PaginationMeta,
@@ -11,12 +13,12 @@ interface Params {
   universityCode?: string;
 }
 
-interface Response {
+interface AdminClubsResponse {
   clubs: AdminClub[];
   pagination: PaginationMeta;
 }
 
-async function getAdminClubs(params: Params): Promise<Response | null> {
+async function getAdminClubs(params: Params) {
   try {
     const query = new URLSearchParams({
       page: String(params.page),
@@ -25,13 +27,22 @@ async function getAdminClubs(params: Params): Promise<Response | null> {
     if (params.universityCode)
       query.set('universityCode', params.universityCode);
 
-    const result = await api
+    const response = await api
       .get(`admin/clubs?${query.toString()}`)
-      .json<{ data: Response }>();
+      .json<ApiResponse<AdminClubsResponse>>();
 
-    return result.data ?? null;
-  } catch {
-    return null;
+    if (!response.data) {
+      return {
+        ok: false,
+        message: '데이터 없음',
+        data: undefined,
+        status: 200,
+      };
+    }
+
+    return { ok: true, message: '성공', data: response.data, status: 200 };
+  } catch (error) {
+    return createErrorResponse(error as Error);
   }
 }
 

--- a/src/features/admin/api/getClubApplications.ts
+++ b/src/features/admin/api/getClubApplications.ts
@@ -1,5 +1,7 @@
 import 'server-only';
 import api from '@/shared/api/dashboard-api';
+import createErrorResponse from '@/shared/lib/error-message';
+import { ApiResponse } from '@/shared/model/type';
 import type {
   ClubApplication,
   ApplicationStatus,
@@ -13,12 +15,12 @@ interface Params {
   universityCode?: string;
 }
 
-interface Response {
+interface ClubApplicationsResponse {
   applications: ClubApplication[];
   page: PaginationMeta;
 }
 
-async function getClubApplications(params: Params): Promise<Response | null> {
+async function getClubApplications(params: Params) {
   try {
     const query = new URLSearchParams({
       status: params.status,
@@ -28,13 +30,22 @@ async function getClubApplications(params: Params): Promise<Response | null> {
     if (params.universityCode)
       query.set('universityCode', params.universityCode);
 
-    const result = await api
+    const response = await api
       .get(`admin/club-applications?${query.toString()}`)
-      .json<{ data: Response }>();
+      .json<ApiResponse<ClubApplicationsResponse>>();
 
-    return result.data ?? null;
-  } catch {
-    return null;
+    if (!response.data) {
+      return {
+        ok: false,
+        message: '데이터 없음',
+        data: undefined,
+        status: 200,
+      };
+    }
+
+    return { ok: true, message: '성공', data: response.data, status: 200 };
+  } catch (error) {
+    return createErrorResponse(error as Error);
   }
 }
 

--- a/src/features/admin/api/getClubMasterApplications.ts
+++ b/src/features/admin/api/getClubMasterApplications.ts
@@ -1,5 +1,7 @@
 import 'server-only';
 import api from '@/shared/api/dashboard-api';
+import createErrorResponse from '@/shared/lib/error-message';
+import { ApiResponse } from '@/shared/model/type';
 import type {
   ClubMasterApplication,
   PaginationMeta,
@@ -11,14 +13,12 @@ interface Params {
   universityCode?: string;
 }
 
-interface Response {
+interface ClubMasterApplicationsResponse {
   applications: ClubMasterApplication[];
   pagination: PaginationMeta;
 }
 
-async function getClubMasterApplications(
-  params: Params,
-): Promise<Response | null> {
+async function getClubMasterApplications(params: Params) {
   try {
     const query = new URLSearchParams({
       page: String(params.page),
@@ -27,13 +27,22 @@ async function getClubMasterApplications(
     if (params.universityCode)
       query.set('universityCode', params.universityCode);
 
-    const result = await api
+    const response = await api
       .get(`admin/club-master-applications?${query.toString()}`)
-      .json<{ data: Response }>();
+      .json<ApiResponse<ClubMasterApplicationsResponse>>();
 
-    return result.data ?? null;
-  } catch {
-    return null;
+    if (!response.data) {
+      return {
+        ok: false,
+        message: '데이터 없음',
+        data: undefined,
+        status: 200,
+      };
+    }
+
+    return { ok: true, message: '성공', data: response.data, status: 200 };
+  } catch (error) {
+    return createErrorResponse(error as Error);
   }
 }
 

--- a/src/features/admin/api/rejectClubApplication.ts
+++ b/src/features/admin/api/rejectClubApplication.ts
@@ -1,18 +1,23 @@
 'use server';
 
 import api from '@/shared/api/dashboard-api';
+import createErrorResponse from '@/shared/lib/error-message';
 
 async function rejectClubApplication(
   applicationId: number,
   rejectReason?: string,
-): Promise<boolean> {
+) {
   try {
     await api.patch(`admin/club-applications/${applicationId}/reject`, {
       json: { rejectReason },
     });
-    return true;
-  } catch {
-    return false;
+    return {
+      ok: true,
+      message: '동아리 생성 신청을 반려했습니다.',
+      status: 200,
+    };
+  } catch (error) {
+    return createErrorResponse(error as Error);
   }
 }
 

--- a/src/features/admin/api/rejectClubMasterApplication.ts
+++ b/src/features/admin/api/rejectClubMasterApplication.ts
@@ -1,18 +1,19 @@
 'use server';
 
 import api from '@/shared/api/dashboard-api';
+import createErrorResponse from '@/shared/lib/error-message';
 
 async function rejectClubMasterApplication(
   applicationId: number,
   rejectReason?: string,
-): Promise<boolean> {
+) {
   try {
     await api.patch(`admin/club-master-applications/${applicationId}/reject`, {
       json: { rejectReason },
     });
-    return true;
-  } catch {
-    return false;
+    return { ok: true, message: '동아리장 신청을 반려했습니다.', status: 200 };
+  } catch (error) {
+    return createErrorResponse(error as Error);
   }
 }
 

--- a/src/features/admin/lib/getDashboardSummary.ts
+++ b/src/features/admin/lib/getDashboardSummary.ts
@@ -1,0 +1,60 @@
+import 'server-only';
+import getAdminClubs from '@/features/admin/api/getAdminClubs';
+import getClubApplications from '@/features/admin/api/getClubApplications';
+import getClubMasterApplications from '@/features/admin/api/getClubMasterApplications';
+import type { DashboardSummary } from '@/features/admin/model/dashboard-types';
+
+const SUMMARY_PAGE = 1;
+const SUMMARY_SIZE = 100;
+
+async function getDashboardSummary(universityCode?: string) {
+  const [clubMasterResult, clubApplicationResult, clubsResult] =
+    await Promise.all([
+      getClubMasterApplications({
+        page: SUMMARY_PAGE,
+        size: SUMMARY_SIZE,
+        universityCode,
+      }),
+      getClubApplications({
+        status: 'PENDING',
+        page: SUMMARY_PAGE,
+        size: SUMMARY_SIZE,
+        universityCode,
+      }),
+      getAdminClubs({
+        page: SUMMARY_PAGE,
+        size: SUMMARY_SIZE,
+        universityCode,
+      }),
+    ]);
+
+  const failedResult = [
+    clubMasterResult,
+    clubApplicationResult,
+    clubsResult,
+  ].find((result) => !result.ok);
+
+  if (failedResult) {
+    return {
+      ok: false,
+      message: failedResult.message,
+      data: undefined,
+      status: failedResult.status,
+    };
+  }
+
+  const clubs = clubsResult.data?.clubs ?? [];
+
+  const summary: DashboardSummary = {
+    clubMasterApplications: clubMasterResult.data?.applications ?? [],
+    clubApplications: clubApplicationResult.data?.applications ?? [],
+    totalClubs: clubsResult.data?.pagination?.totalElements ?? 0,
+    pendingMasterCount: clubMasterResult.data?.pagination?.totalElements ?? 0,
+    pendingClubCount: clubApplicationResult.data?.page?.totalElements ?? 0,
+    totalMasters: clubs.filter((club) => club.clubMaster !== null).length,
+  };
+
+  return { ok: true, message: '성공', data: summary, status: 200 };
+}
+
+export default getDashboardSummary;

--- a/src/features/admin/model/dashboard-types.ts
+++ b/src/features/admin/model/dashboard-types.ts
@@ -53,3 +53,12 @@ export interface PaginationMeta {
   totalPages: number;
   totalElements: number;
 }
+
+export interface DashboardSummary {
+  clubMasterApplications: ClubMasterApplication[];
+  clubApplications: ClubApplication[];
+  totalClubs: number;
+  pendingMasterCount: number;
+  pendingClubCount: number;
+  totalMasters: number;
+}

--- a/src/views/admin/ui/AdminDashboardView.tsx
+++ b/src/views/admin/ui/AdminDashboardView.tsx
@@ -1,35 +1,32 @@
 import type {
-  ClubMasterApplication,
-  ClubApplication,
   AdminRole,
+  DashboardSummary,
 } from '@/features/admin/model/dashboard-types';
 import ClubMasterApplicationWidget from '@/widgets/admin/ui/ClubMasterApplicationWidget';
 import AdminUniversitySelectWidget from '@/widgets/admin/ui/AdminUniversitySelectWidget';
 import type { UniversityOption } from '@/entities/university/model/type';
 
 interface AdminDashboardViewProps {
-  clubMasterApplications: ClubMasterApplication[];
-  clubApplications: ClubApplication[];
-  totalClubs: number;
-  pendingMasterCount: number;
-  pendingClubCount: number;
-  totalMasters: number;
+  summary: DashboardSummary;
   role: AdminRole;
   universities: UniversityOption[];
   selectedCode: string;
 }
 
 function AdminDashboardView({
-  clubMasterApplications,
-  clubApplications,
-  totalClubs,
-  pendingMasterCount,
-  pendingClubCount,
-  totalMasters,
+  summary,
   role,
   universities,
   selectedCode,
 }: AdminDashboardViewProps) {
+  const {
+    clubMasterApplications,
+    clubApplications,
+    totalClubs,
+    pendingMasterCount,
+    pendingClubCount,
+    totalMasters,
+  } = summary;
   const isMokkojiAdmin = role === 'MOKKOJI_ADMIN';
   const selectedUniversityName =
     universities.find((university) => university.code === selectedCode)?.name ??

--- a/src/widgets/admin/ui/ClubApplicationWidget.tsx
+++ b/src/widgets/admin/ui/ClubApplicationWidget.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useTransition } from 'react';
+import { toast } from 'react-toastify';
 import type {
   ClubApplication,
   ApplicationStatus,
@@ -35,35 +36,45 @@ function ClubApplicationWidget({
 
   const handleApprove = (applicationId: number) => {
     startTransition(async () => {
-      const success = await approveClubApplication(applicationId);
-      if (success) {
-        setApplications((previous) =>
-          previous.map((application) =>
-            application.applicationId === applicationId
-              ? { ...application, status: 'APPROVED' as ApplicationStatus }
-              : application,
-          ),
-        );
+      const result = await approveClubApplication(applicationId);
+
+      if (!result.ok) {
+        toast.error(result.message);
+        return;
       }
+
+      setApplications((previous) =>
+        previous.map((application) =>
+          application.applicationId === applicationId
+            ? { ...application, status: 'APPROVED' as ApplicationStatus }
+            : application,
+        ),
+      );
+      toast.success(result.message);
     });
   };
 
   const handleReject = (applicationId: number, rejectReason?: string) => {
     startTransition(async () => {
-      const success = await rejectClubApplication(applicationId, rejectReason);
-      if (success) {
-        setApplications((previous) =>
-          previous.map((application) =>
-            application.applicationId === applicationId
-              ? {
-                  ...application,
-                  status: 'REJECTED' as ApplicationStatus,
-                  rejectReason: rejectReason ?? null,
-                }
-              : application,
-          ),
-        );
+      const result = await rejectClubApplication(applicationId, rejectReason);
+
+      if (!result.ok) {
+        toast.error(result.message);
+        return;
       }
+
+      setApplications((previous) =>
+        previous.map((application) =>
+          application.applicationId === applicationId
+            ? {
+                ...application,
+                status: 'REJECTED' as ApplicationStatus,
+                rejectReason: rejectReason ?? null,
+              }
+            : application,
+        ),
+      );
+      toast.success(result.message);
     });
   };
 

--- a/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
+++ b/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useTransition } from 'react';
+import { toast } from 'react-toastify';
 import type {
   ClubMasterApplication,
   ClubApplication,
@@ -43,26 +44,35 @@ function ClubMasterApplicationWidget({
 
   const handleCombinedApprove = (applicationId: number) => {
     startTransition(async () => {
-      const [clubSuccess, masterSuccess] = await Promise.all([
+      const [clubResult, masterResult] = await Promise.all([
         approveClubApplication(applicationId),
         approveClubMasterApplication(applicationId),
       ]);
-      if (clubSuccess && masterSuccess) {
-        setClubApplications((previous) =>
-          previous.map((a) =>
-            a.applicationId === applicationId
-              ? { ...a, status: 'APPROVED' as ApplicationStatus }
-              : a,
-          ),
-        );
-        setClubMasterApplications((previous) =>
-          previous.map((a) =>
-            a.id === applicationId
-              ? { ...a, status: 'APPROVED' as ApplicationStatus }
-              : a,
-          ),
-        );
+
+      const failedResult = [clubResult, masterResult].find(
+        (result) => !result.ok,
+      );
+
+      if (failedResult) {
+        toast.error(failedResult.message);
+        return;
       }
+
+      setClubApplications((previous) =>
+        previous.map((a) =>
+          a.applicationId === applicationId
+            ? { ...a, status: 'APPROVED' as ApplicationStatus }
+            : a,
+        ),
+      );
+      setClubMasterApplications((previous) =>
+        previous.map((a) =>
+          a.id === applicationId
+            ? { ...a, status: 'APPROVED' as ApplicationStatus }
+            : a,
+        ),
+      );
+      toast.success('동아리장 및 동아리 생성 신청을 승인했습니다.');
     });
   };
 
@@ -71,57 +81,72 @@ function ClubMasterApplicationWidget({
     rejectReason?: string,
   ) => {
     startTransition(async () => {
-      const success = await rejectClubApplication(applicationId, rejectReason);
-      if (success) {
-        setClubApplications((previous) =>
-          previous.map((a) =>
-            a.applicationId === applicationId
-              ? {
-                  ...a,
-                  status: 'REJECTED' as ApplicationStatus,
-                  rejectReason: rejectReason ?? null,
-                }
-              : a,
-          ),
-        );
+      const result = await rejectClubApplication(applicationId, rejectReason);
+
+      if (!result.ok) {
+        toast.error(result.message);
+        return;
       }
+
+      setClubApplications((previous) =>
+        previous.map((a) =>
+          a.applicationId === applicationId
+            ? {
+                ...a,
+                status: 'REJECTED' as ApplicationStatus,
+                rejectReason: rejectReason ?? null,
+              }
+            : a,
+        ),
+      );
+      toast.success(result.message);
     });
   };
 
   const handleMasterApprove = (applicationId: number) => {
     startTransition(async () => {
-      const success = await approveClubMasterApplication(applicationId);
-      if (success) {
-        setClubMasterApplications((previous) =>
-          previous.map((a) =>
-            a.id === applicationId
-              ? { ...a, status: 'APPROVED' as ApplicationStatus }
-              : a,
-          ),
-        );
+      const result = await approveClubMasterApplication(applicationId);
+
+      if (!result.ok) {
+        toast.error(result.message);
+        return;
       }
+
+      setClubMasterApplications((previous) =>
+        previous.map((a) =>
+          a.id === applicationId
+            ? { ...a, status: 'APPROVED' as ApplicationStatus }
+            : a,
+        ),
+      );
+      toast.success(result.message);
     });
   };
 
   const handleMasterReject = (applicationId: number, rejectReason?: string) => {
     startTransition(async () => {
-      const success = await rejectClubMasterApplication(
+      const result = await rejectClubMasterApplication(
         applicationId,
         rejectReason,
       );
-      if (success) {
-        setClubMasterApplications((previous) =>
-          previous.map((a) =>
-            a.id === applicationId
-              ? {
-                  ...a,
-                  status: 'REJECTED' as ApplicationStatus,
-                  rejectReason: rejectReason ?? null,
-                }
-              : a,
-          ),
-        );
+
+      if (!result.ok) {
+        toast.error(result.message);
+        return;
       }
+
+      setClubMasterApplications((previous) =>
+        previous.map((a) =>
+          a.id === applicationId
+            ? {
+                ...a,
+                status: 'REJECTED' as ApplicationStatus,
+                rejectReason: rejectReason ?? null,
+              }
+            : a,
+        ),
+      );
+      toast.success(result.message);
     });
   };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#566

## 📝작업 내용

PR #561 리뷰에서 admin 도메인의 API 응답·에러 처리가 다른 도메인과 일관되지 않다는 리뷰가 있었습니다. 
#561 에서는 리뷰 지점인 `getAdminInfo`만 고쳤고, 이 PR에서 나머지를 정리했습니다.

**API 응답 형식 통일 (features/admin/api)**

- GET 3개: `T | null` → `{ ok, message, data, status }`
- 뮤테이션 4개: `boolean` → `createErrorResponse` 기반 응답
- ky 응답을 `{ data: T }`가 아닌 `ApiResponse<T>`로 타이핑

기존 `catch { return null }`은 401/403/500/네트워크 실패를 한 값으로 뭉개서, 서버가 내려준 실패 사유를 UI가 알 수 없었습니다. 조회 실패와 "데이터 없음"도 구분되지 않아 서버 장애 시 빈 목록이 정상처럼 렌더링됐습니다.

**실패 사유 노출 (widgets/admin)**

- 승인/반려 실패 시 조용히 무시하던 것을 `toast.error(result.message)`로 노출

**대시보드 집계 분리 (features/admin/lib)**

- `getDashboardSummary` 신규. page가 직접 알던 `pagination.totalElements`, `page.totalElements`, `clubMaster` 유무 같은 응답 구조를 feature로 내림
- page는 인증 분기와 학교 코드 결정만 담당, 뷰는 낱개 prop 6개 대신 `DashboardSummary` 하나를 받음

**에이전트 표준 갱신 (.claude/agents/api-builder.md)**

- GET에 `Promise<T | null>` + `catch { return null }`을 표준으로 명시하고 있어, 에이전트가 생성하는 코드마다 이 패턴이 재생산되던 원인을 수정
