### PR TITLE
feat: 학교 변경 후 해당 학교로 리다이렉트 및 안내 문구 개선

### DIFF
--- a/src/widgets/login/ui/university-select-modal-wrapper.tsx
+++ b/src/widgets/login/ui/university-select-modal-wrapper.tsx
@@ -46,6 +46,10 @@ function UniversitySelectModalWrapper({
 
     setIsConfirmOpen(false);
     setIsOpen(false);
+
+    if (code) {
+      router.push(`/${code}`);
+    }
     router.refresh();
   };
 
@@ -60,6 +64,11 @@ function UniversitySelectModalWrapper({
     setPendingCode(normalizedCode);
     setIsConfirmOpen(true);
   };
+
+  const pendingUniversityName = pendingCode
+    ? (universities.find((university) => university.code === pendingCode)
+        ?.name ?? pendingCode)
+    : null;
 
   return (
     <>
@@ -94,7 +103,20 @@ function UniversitySelectModalWrapper({
               id="university-change-desc"
               className="text-text-secondary text-sm"
             >
-              학교를 변경하면 기존 즐겨찾기가 모두 삭제됩니다. 계속하시겠어요?
+              {pendingUniversityName ? (
+                <>
+                  학교를 변경하게 되면 지금부터 {pendingUniversityName} 모꼬지를
+                  이용하게 되며, 기존 즐겨찾기는 모두 삭제됩니다.
+                  <br />
+                  계속하시겠어요?
+                </>
+              ) : (
+                <>
+                  학교를 변경하게 되면 기존 즐겨찾기는 모두 삭제됩니다.
+                  <br />
+                  계속하시겠어요?
+                </>
+              )}
             </DialogDescription>
           </DialogHeader>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #572 

## 📝작업 내용

- 마이페이지에서 학교 변경 후 변경한 학교 페이지로 이동
- 학교 변경시 페이지 이동이 있다는 문구 추가

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
