### PR TITLE
[#575] fix: 상세페이지 양옆 마진 폭 조정

### DIFF
--- a/src/app/[universityCode]/(main)/club/[id]/layout.tsx
+++ b/src/app/[universityCode]/(main)/club/[id]/layout.tsx
@@ -4,7 +4,7 @@ export default function Layout({
   children: React.ReactNode;
 }>) {
   return (
-    <main className="flex w-[95vw] flex-col items-center justify-center">
+    <main className="flex w-[95vw] flex-col items-center justify-center lg:w-[60%] lg:max-w-[60%] lg:min-w-[60%]">
       {children}
     </main>
   );

--- a/src/entities/club/ui/club-detail-skeleton.tsx
+++ b/src/entities/club/ui/club-detail-skeleton.tsx
@@ -2,7 +2,7 @@ const dummyTabs = [1, 2, 3];
 
 function ClubDetailSkeleton() {
   return (
-    <div className="mt-5 w-full px-5 lg:mt-[35px] lg:w-[60%] lg:max-w-[60%] lg:min-w-[60%]">
+    <div className="mt-5 w-full lg:mt-[35px]">
       <header className="w-full">
         <div className="flex flex-row items-center gap-3.5 lg:mb-5 lg:gap-4">
           <div className="hidden h-[72px] w-[72px] rounded-full bg-gray-300 sm:block" />


### PR DESCRIPTION
## #️⃣연관된 이슈

> #575 

## 📝작업 내용

> 상세페이지 양옆 마진이 너무 작아 넓게 보이던 UI를 수정했습니다.

- 코드를 확인해보니 실제로 상세페이지의 양옆 마진 없이 w-[95vw]만 적용되어 있는 상태였습니다. 즉 누군가의 작업 중에 마진 관련 코드가 삭제된 상태였던 것 같습니다.

- 근데 로컬에서는 그동안 마진이 있는 것처럼 보여서 문제를 못 느끼고 있었는데, 원인을 찾아보니 `Turbopack` dev 서버의 캐시 문제였습니다.
-> `pnpm dev(Turbopack)`로 계속 띄워두고 작업하다 보니, 마진이 삭제되기 이전 스타일이 반영된 캐시가 그대로 남아서 화면에는 마진이 있는 것처럼 보였던 것 같습니다.
-> `pnpm build && pnpm start`로 새로 빌드하니 `.next` 캐시가 새로 생성되면서 실제 코드 상태(마진 없음)가 그대로 드러났고, 그제서야 문제를 발견할 수 있었습니다.


- 그래서 이번 PR에서 양옆 마진을 주는 코드를 다시 추가해서 수정했습니다.
* 참고로 앞으로 비슷하게 "로컬 화면과 실제 코드가 달라 보이는" 상황이 생기면 `rm -rf .next` 후 `pnpm dev`로 다시 켜보면 캐시 이슈인지 빠르게 확인할 수 있을 것 같습니다!

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 혹시 제가 말한 캐시 이슈가 아니라 다른 이슈라고 생각이 되는 부분이 있다면 공유해주세요!!