### PR TITLE
fix: 관리자 대시보드 현황 수치 오류 수정 및 승인 대기 신청 화면 재설계(merge)

### DIFF
--- a/src/app/(admin)/dashboard/(main)/page.tsx
+++ b/src/app/(admin)/dashboard/(main)/page.tsx
@@ -21,7 +21,7 @@ async function DashboardPage({ searchParams }: DashboardPageProps) {
   const adminInfo = await getAdminInfo();
 
   if (!adminInfo) {
-    redirect('/dashboard/login');
+    redirect('/api/auth/dashboard-logout');
   }
 
   const isMokkojiAdmin = adminInfo.role === 'MOKKOJI_ADMIN';

--- a/src/app/(admin)/dashboard/(main)/page.tsx
+++ b/src/app/(admin)/dashboard/(main)/page.tsx
@@ -13,18 +13,12 @@ async function DashboardPage() {
 
   const clubMasterApplications = clubMasterData?.applications ?? [];
   const clubApplications = clubApplicationData?.applications ?? [];
-  const clubs = clubsData?.clubs ?? [];
 
   const totalClubs = clubsData?.page?.totalElements ?? 0;
   const pendingMasterCount = clubMasterApplications.filter(
     (application) => application.status === 'PENDING',
   ).length;
   const pendingClubCount = clubApplicationData?.page?.totalElements ?? 0;
-  const totalMasters = new Set(
-    clubs
-      .filter((club) => club.clubMaster !== null)
-      .map((club) => club.clubMaster!.id),
-  ).size;
 
   return (
     <Suspense>
@@ -34,7 +28,6 @@ async function DashboardPage() {
         totalClubs={totalClubs}
         pendingMasterCount={pendingMasterCount}
         pendingClubCount={pendingClubCount}
-        totalMasters={totalMasters}
       />
     </Suspense>
   );

--- a/src/app/(admin)/dashboard/(main)/page.tsx
+++ b/src/app/(admin)/dashboard/(main)/page.tsx
@@ -2,20 +2,11 @@ import { Suspense } from 'react';
 import { redirect } from 'next/navigation';
 import AdminDashboardView from '@/views/admin/ui/AdminDashboardView';
 import getAdminInfo from '@/features/admin/api/getAdminInfo';
-import getClubMasterApplications from '@/features/admin/api/getClubMasterApplications';
-import getClubApplications from '@/features/admin/api/getClubApplications';
-import getUniversities from '@/entities/university/api/getUniversities';
-import type { ApplicationStatus } from '@/features/admin/model/dashboard-types';
+import getDashboardData from '@/features/admin/api/getDashboardData';
 
 interface DashboardPageProps {
   searchParams: Promise<{ universityCode?: string }>;
 }
-
-const APPLICATION_STATUSES: ApplicationStatus[] = [
-  'PENDING',
-  'APPROVED',
-  'REJECTED',
-];
 
 async function DashboardPage({ searchParams }: DashboardPageProps) {
   const adminInfo = await getAdminInfo();
@@ -24,33 +15,13 @@ async function DashboardPage({ searchParams }: DashboardPageProps) {
     redirect('/api/auth/dashboard-logout');
   }
 
-  const isMokkojiAdmin = adminInfo.role === 'MOKKOJI_ADMIN';
-
-  const universitiesResult = await getUniversities();
-  const universities =
-    universitiesResult?.ok && universitiesResult.data
-      ? universitiesResult.data.universities.map((university) => ({
-          code: university.code,
-          name: university.name,
-        }))
-      : [];
-
   const { universityCode: selectedFromUrl } = await searchParams;
-  const universityCode = isMokkojiAdmin
-    ? (selectedFromUrl ?? universities[0]?.code)
-    : (adminInfo.universityCode ?? undefined);
-
-  const [clubMasterData, ...clubApplicationResults] = await Promise.all([
-    getClubMasterApplications({ page: 1, size: 100, universityCode }),
-    ...APPLICATION_STATUSES.map((status) =>
-      getClubApplications({ status, page: 1, size: 100, universityCode }),
-    ),
-  ]);
-
-  const clubMasterApplications = clubMasterData?.applications ?? [];
-  const clubApplications = clubApplicationResults.flatMap(
-    (result) => result?.applications ?? [],
-  );
+  const {
+    universities,
+    universityCode,
+    clubMasterApplications,
+    clubApplications,
+  } = await getDashboardData(adminInfo, selectedFromUrl);
 
   return (
     <Suspense>

--- a/src/app/(admin)/dashboard/(main)/page.tsx
+++ b/src/app/(admin)/dashboard/(main)/page.tsx
@@ -4,12 +4,18 @@ import AdminDashboardView from '@/views/admin/ui/AdminDashboardView';
 import getAdminInfo from '@/features/admin/api/getAdminInfo';
 import getClubMasterApplications from '@/features/admin/api/getClubMasterApplications';
 import getClubApplications from '@/features/admin/api/getClubApplications';
-import getAdminClubs from '@/features/admin/api/getAdminClubs';
 import getUniversities from '@/entities/university/api/getUniversities';
+import type { ApplicationStatus } from '@/features/admin/model/dashboard-types';
 
 interface DashboardPageProps {
   searchParams: Promise<{ universityCode?: string }>;
 }
+
+const APPLICATION_STATUSES: ApplicationStatus[] = [
+  'PENDING',
+  'APPROVED',
+  'REJECTED',
+];
 
 async function DashboardPage({ searchParams }: DashboardPageProps) {
   const adminInfo = await getAdminInfo();
@@ -34,34 +40,23 @@ async function DashboardPage({ searchParams }: DashboardPageProps) {
     ? (selectedFromUrl ?? universities[0]?.code)
     : (adminInfo.universityCode ?? undefined);
 
-  const [clubMasterData, clubApplicationData, clubsData] = await Promise.all([
+  const [clubMasterData, ...clubApplicationResults] = await Promise.all([
     getClubMasterApplications({ page: 1, size: 100, universityCode }),
-    getClubApplications({
-      status: 'PENDING',
-      page: 1,
-      size: 100,
-      universityCode,
-    }),
-    getAdminClubs({ page: 1, size: 100, universityCode }),
+    ...APPLICATION_STATUSES.map((status) =>
+      getClubApplications({ status, page: 1, size: 100, universityCode }),
+    ),
   ]);
 
   const clubMasterApplications = clubMasterData?.applications ?? [];
-  const clubApplications = clubApplicationData?.applications ?? [];
-
-  const totalClubs = clubsData?.page?.totalElements ?? 0;
-  const pendingMasterCount = clubMasterApplications.filter(
-    (application) => application.status === 'PENDING',
-  ).length;
-  const pendingClubCount = clubApplicationData?.page?.totalElements ?? 0;
+  const clubApplications = clubApplicationResults.flatMap(
+    (result) => result?.applications ?? [],
+  );
 
   return (
     <Suspense>
       <AdminDashboardView
         clubMasterApplications={clubMasterApplications}
         clubApplications={clubApplications}
-        totalClubs={totalClubs}
-        pendingMasterCount={pendingMasterCount}
-        pendingClubCount={pendingClubCount}
         role={adminInfo.role}
         universities={universities}
         selectedCode={universityCode ?? ''}

--- a/src/app/(admin)/dashboard/(main)/page.tsx
+++ b/src/app/(admin)/dashboard/(main)/page.tsx
@@ -15,10 +15,16 @@ async function DashboardPage() {
   const clubApplications = clubApplicationData?.applications ?? [];
   const clubs = clubsData?.clubs ?? [];
 
-  const totalClubs = clubsData?.pagination?.totalElements ?? 0;
-  const pendingMasterCount = clubMasterData?.pagination?.totalElements ?? 0;
+  const totalClubs = clubsData?.page?.totalElements ?? 0;
+  const pendingMasterCount = clubMasterApplications.filter(
+    (application) => application.status === 'PENDING',
+  ).length;
   const pendingClubCount = clubApplicationData?.page?.totalElements ?? 0;
-  const totalMasters = clubs.filter((club) => club.clubMaster !== null).length;
+  const totalMasters = new Set(
+    clubs
+      .filter((club) => club.clubMaster !== null)
+      .map((club) => club.clubMaster!.id),
+  ).size;
 
   return (
     <Suspense>

--- a/src/app/api/auth/dashboard-logout/route.ts
+++ b/src/app/api/auth/dashboard-logout/route.ts
@@ -1,9 +1,15 @@
 /* eslint-disable import/prefer-default-export */
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { DASHBOARD_SESSION_COOKIE_NAME } from '@/shared/lib/dashboard-session';
 
 export async function POST() {
   const response = NextResponse.json({ ok: true });
+  response.cookies.delete(DASHBOARD_SESSION_COOKIE_NAME);
+  return response;
+}
+
+export async function GET(req: NextRequest) {
+  const response = NextResponse.redirect(new URL('/dashboard/login', req.url));
   response.cookies.delete(DASHBOARD_SESSION_COOKIE_NAME);
   return response;
 }

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -8,6 +8,10 @@ export async function GET() {
     return NextResponse.json(null);
   }
 
+  if (session.expiresAt && Date.now() >= session.expiresAt) {
+    return NextResponse.json(null);
+  }
+
   return NextResponse.json({
     user: session.user,
     role: session.role,

--- a/src/features/admin/api/getAdminClubs.ts
+++ b/src/features/admin/api/getAdminClubs.ts
@@ -13,7 +13,7 @@ interface Params {
 
 interface Response {
   clubs: AdminClub[];
-  pagination: PaginationMeta;
+  page: PaginationMeta;
 }
 
 async function getAdminClubs(params: Params): Promise<Response | null> {

--- a/src/features/admin/api/getClubMasterApplications.ts
+++ b/src/features/admin/api/getClubMasterApplications.ts
@@ -12,7 +12,7 @@ interface Params {
 
 interface Response {
   applications: ClubMasterApplication[];
-  page: PaginationMeta;
+  pagination: PaginationMeta;
 }
 
 async function getClubMasterApplications(

--- a/src/features/admin/api/getClubMasterApplications.ts
+++ b/src/features/admin/api/getClubMasterApplications.ts
@@ -12,7 +12,7 @@ interface Params {
 
 interface Response {
   applications: ClubMasterApplication[];
-  pagination: PaginationMeta;
+  page: PaginationMeta;
 }
 
 async function getClubMasterApplications(

--- a/src/features/admin/api/getDashboardData.ts
+++ b/src/features/admin/api/getDashboardData.ts
@@ -1,0 +1,52 @@
+import 'server-only';
+import getUniversities from '@/entities/university/api/getUniversities';
+import getClubMasterApplications from '@/features/admin/api/getClubMasterApplications';
+import getClubApplications from '@/features/admin/api/getClubApplications';
+import type {
+  AdminInfo,
+  ApplicationStatus,
+} from '@/features/admin/model/dashboard-types';
+
+const APPLICATION_STATUSES: ApplicationStatus[] = [
+  'PENDING',
+  'APPROVED',
+  'REJECTED',
+];
+
+async function getDashboardData(
+  adminInfo: AdminInfo,
+  selectedFromUrl?: string,
+) {
+  const isMokkojiAdmin = adminInfo.role === 'MOKKOJI_ADMIN';
+
+  const universitiesResult = await getUniversities();
+  const universities =
+    universitiesResult?.ok && universitiesResult.data
+      ? universitiesResult.data.universities.map((university) => ({
+          code: university.code,
+          name: university.name,
+        }))
+      : [];
+
+  const universityCode = isMokkojiAdmin
+    ? (selectedFromUrl ?? universities[0]?.code)
+    : (adminInfo.universityCode ?? undefined);
+
+  const [clubMasterData, ...clubApplicationResults] = await Promise.all([
+    getClubMasterApplications({ page: 1, size: 100, universityCode }),
+    ...APPLICATION_STATUSES.map((status) =>
+      getClubApplications({ status, page: 1, size: 100, universityCode }),
+    ),
+  ]);
+
+  return {
+    universities,
+    universityCode,
+    clubMasterApplications: clubMasterData?.applications ?? [],
+    clubApplications: clubApplicationResults.flatMap(
+      (result) => result?.applications ?? [],
+    ),
+  };
+}
+
+export default getDashboardData;

--- a/src/features/admin/model/dashboard-types.ts
+++ b/src/features/admin/model/dashboard-types.ts
@@ -47,6 +47,24 @@ export interface AdminClub {
   } | null;
 }
 
+export type ApplicationKind = 'club' | 'master';
+
+export interface ApplicationCardItem {
+  key: string;
+  kind: ApplicationKind;
+  applicationId: number;
+  clubName: string;
+  universityName: string;
+  applicantName: string;
+  status: ApplicationStatus;
+  createdAt: string;
+  category?: string;
+  affiliation?: string;
+  logo?: string;
+  instagram?: string;
+  description?: string;
+}
+
 export interface PaginationMeta {
   page: number;
   size: number;

--- a/src/features/admin/ui/ApplicationCard.tsx
+++ b/src/features/admin/ui/ApplicationCard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import Image from 'next/image';
 import type { ApplicationCardItem } from '@/features/admin/model/dashboard-types';
 import { ClubCategoryLabel, ClubCategory } from '@/shared/model/type';
 import RejectReasonDialog from './RejectReasonDialog';
@@ -28,6 +27,7 @@ function ApplicationCard({ item, onApprove, onReject }: ApplicationCardProps) {
   const instagramHref = item.instagram
     ? resolveInstagramHref(item.instagram)
     : null;
+  const hasLogo = !!item.logo && /^https?:\/\//.test(item.logo);
 
   const handleApprove = () => {
     onApprove();
@@ -48,14 +48,13 @@ function ApplicationCard({ item, onApprove, onReject }: ApplicationCardProps) {
               {item.applicantName}
             </span>
             <div className="flex items-center gap-6">
-              <div className="relative h-[52px] w-[52px] shrink-0 overflow-hidden rounded-full bg-[#F8F8F8]">
-                {item.logo && (
-                  <Image
+              <div className="h-[52px] w-[52px] shrink-0 overflow-hidden rounded-full bg-[#F8F8F8]">
+                {hasLogo && (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
                     src={item.logo}
                     alt={`${item.clubName} 로고`}
-                    fill
-                    sizes="52px"
-                    className="object-cover"
+                    className="h-full w-full object-cover"
                   />
                 )}
               </div>

--- a/src/features/admin/ui/ApplicationCard.tsx
+++ b/src/features/admin/ui/ApplicationCard.tsx
@@ -114,7 +114,7 @@ function ApplicationCard({ item, onApprove, onReject }: ApplicationCardProps) {
                   <button
                     type="button"
                     onClick={() => setDescriptionOpen((previous) => !previous)}
-                    className="border-b border-[#8B95A1] text-[12px] leading-[100%] font-normal text-[#8B95A1]"
+                    className="cursor-pointer border-b border-[#8B95A1] text-[12px] leading-[100%] font-normal text-[#8B95A1]"
                   >
                     한 줄 소개 보기
                   </button>
@@ -135,14 +135,14 @@ function ApplicationCard({ item, onApprove, onReject }: ApplicationCardProps) {
               <button
                 type="button"
                 onClick={handleApprove}
-                className="flex h-9 w-[72px] items-center justify-center rounded-[30px] bg-[#4AF38A] text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#000000] transition-colors hover:bg-[#22CF64]"
+                className="flex h-9 w-[72px] cursor-pointer items-center justify-center rounded-[30px] bg-[#4AF38A] text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#000000] transition-colors hover:bg-[#22CF64]"
               >
                 승인하기
               </button>
               <button
                 type="button"
                 onClick={() => setRejectDialogOpen(true)}
-                className="flex h-9 w-[72px] items-center justify-center rounded-[30px] border border-[#22CF64] bg-white text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#22CF64] transition-colors hover:bg-[#f0fff6]"
+                className="flex h-9 w-[72px] cursor-pointer items-center justify-center rounded-[30px] border border-[#22CF64] bg-white text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#22CF64] transition-colors hover:bg-[#f0fff6]"
               >
                 반려하기
               </button>

--- a/src/features/admin/ui/ApplicationCard.tsx
+++ b/src/features/admin/ui/ApplicationCard.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import type { ApplicationCardItem } from '@/features/admin/model/dashboard-types';
+import { ClubCategoryLabel, ClubCategory } from '@/shared/model/type';
+import RejectReasonDialog from './RejectReasonDialog';
+import ApproveCompleteDialog from './ApproveCompleteDialog';
+
+interface ApplicationCardProps {
+  item: ApplicationCardItem;
+  onApprove: () => void;
+  onReject: (rejectReason?: string) => void;
+}
+
+function ApplicationCard({ item, onApprove, onReject }: ApplicationCardProps) {
+  const [rejectDialogOpen, setRejectDialogOpen] = useState(false);
+  const [approveCompleteDialogOpen, setApproveCompleteDialogOpen] =
+    useState(false);
+  const [descriptionOpen, setDescriptionOpen] = useState(false);
+
+  const formattedDate = item.createdAt.slice(0, 10).replace(/-/g, '.');
+  const categoryLabel = item.category
+    ? (ClubCategoryLabel[item.category as ClubCategory] ?? item.category)
+    : null;
+  const resolveInstagramHref = (instagram: string) =>
+    instagram.startsWith('http') ? instagram : `https://${instagram}`;
+  const instagramHref = item.instagram
+    ? resolveInstagramHref(item.instagram)
+    : null;
+
+  const handleApprove = () => {
+    onApprove();
+    setApproveCompleteDialogOpen(true);
+  };
+
+  const handleRejectConfirm = (reason?: string) => {
+    onReject(reason);
+    setRejectDialogOpen(false);
+  };
+
+  return (
+    <>
+      <div className="flex w-full items-center justify-between border-b border-[#D6D6D6] py-3">
+        <div className="flex items-center gap-20">
+          <div className="flex items-center gap-8">
+            <span className="w-8 shrink-0 text-center text-[12px] leading-[100%] font-normal text-[#474747]">
+              {item.applicantName}
+            </span>
+            <div className="flex items-center gap-6">
+              <div className="relative h-[52px] w-[52px] shrink-0 overflow-hidden rounded-full bg-[#F8F8F8]">
+                {item.logo && (
+                  <Image
+                    src={item.logo}
+                    alt={`${item.clubName} 로고`}
+                    fill
+                    sizes="52px"
+                    className="object-cover"
+                  />
+                )}
+              </div>
+              <div className="flex flex-col gap-3">
+                <div className="flex w-fit items-center justify-center rounded-[30px] border border-[#22CF64] px-2.5 py-1.5">
+                  <span className="text-[12px] leading-[100%] font-normal text-[#22CF64]">
+                    {item.universityName}
+                  </span>
+                </div>
+                <div className="flex flex-col gap-px">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-[20px] leading-[140%] font-semibold tracking-[-0.03em] text-[#000000]">
+                      {item.clubName}
+                    </span>
+                    {categoryLabel && (
+                      <span className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#8B95A1]">
+                        {categoryLabel}
+                      </span>
+                    )}
+                    {item.affiliation && (
+                      <>
+                        <span className="h-0.5 w-0.5 rounded-full bg-[#D6D6D6]" />
+                        <span className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#8B95A1]">
+                          {item.affiliation}
+                        </span>
+                      </>
+                    )}
+                  </div>
+                  <span className="text-[12px] leading-[140%] font-normal text-[#8B95A1]">
+                    {formattedDate}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {(instagramHref || item.description) && (
+            <div className="flex items-center gap-5">
+              {instagramHref && (
+                <a
+                  href={instagramHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 rounded-[20px] border border-[#E2E2E2]/70 bg-white py-2 pr-3 pl-2"
+                >
+                  <span className="text-[8px] leading-[10px] text-[#6A6B6B]">
+                    🔗
+                  </span>
+                  <span className="text-[10px] leading-[12px] font-normal tracking-[-0.03em] text-[#6A6B6B]">
+                    {item.instagram}
+                  </span>
+                </a>
+              )}
+              {item.description && (
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => setDescriptionOpen((previous) => !previous)}
+                    className="border-b border-[#8B95A1] text-[12px] leading-[100%] font-normal text-[#8B95A1]"
+                  >
+                    한 줄 소개 보기
+                  </button>
+                  {descriptionOpen && (
+                    <div className="absolute top-6 left-0 z-10 w-[240px] rounded-[12px] border border-[#E2E2E2] bg-white p-3 text-[12px] leading-[140%] font-medium text-[#474747] shadow-md">
+                      {item.description}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          {item.status === 'PENDING' ? (
+            <>
+              <button
+                type="button"
+                onClick={handleApprove}
+                className="flex h-9 w-[72px] items-center justify-center rounded-[30px] bg-[#4AF38A] text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#000000] transition-colors hover:bg-[#22CF64]"
+              >
+                승인하기
+              </button>
+              <button
+                type="button"
+                onClick={() => setRejectDialogOpen(true)}
+                className="flex h-9 w-[72px] items-center justify-center rounded-[30px] border border-[#22CF64] bg-white text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#22CF64] transition-colors hover:bg-[#f0fff6]"
+              >
+                반려하기
+              </button>
+            </>
+          ) : (
+            <span
+              className={`text-[14px] leading-[140%] font-medium tracking-[-0.03em] ${item.status === 'APPROVED' ? 'text-[#22CF64]' : 'text-[#8B95A1]'}`}
+            >
+              {item.status === 'APPROVED' ? '승인됨' : '반려됨'}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <RejectReasonDialog
+        open={rejectDialogOpen}
+        onClose={() => setRejectDialogOpen(false)}
+        onConfirm={handleRejectConfirm}
+      />
+
+      <ApproveCompleteDialog
+        open={approveCompleteDialogOpen}
+        onClose={() => setApproveCompleteDialogOpen(false)}
+      />
+    </>
+  );
+}
+
+export default ApplicationCard;

--- a/src/features/admin/ui/ApproveCompleteDialog.tsx
+++ b/src/features/admin/ui/ApproveCompleteDialog.tsx
@@ -34,7 +34,7 @@ function ApproveCompleteDialog({ open, onClose }: ApproveCompleteDialogProps) {
             <button
               type="button"
               onClick={onClose}
-              className="flex h-[51px] w-full items-center justify-center rounded-[12px] bg-[#4AF38A] text-[16px] leading-[140%] font-medium text-[#474747] transition-colors hover:bg-[#22CF64]"
+              className="flex h-[51px] w-full cursor-pointer items-center justify-center rounded-[12px] bg-[#4AF38A] text-[16px] leading-[140%] font-medium text-[#474747] transition-colors hover:bg-[#22CF64]"
             >
               완료
             </button>

--- a/src/features/admin/ui/RejectReasonDialog.tsx
+++ b/src/features/admin/ui/RejectReasonDialog.tsx
@@ -54,7 +54,7 @@ function RejectReasonDialog({
             <button
               type="button"
               onClick={handleConfirm}
-              className="flex h-[51px] w-full items-center justify-center rounded-[12px] bg-[#4AF38A] text-[16px] leading-[140%] font-medium text-[#474747] transition-colors hover:bg-[#22CF64]"
+              className="flex h-[51px] w-full cursor-pointer items-center justify-center rounded-[12px] bg-[#4AF38A] text-[16px] leading-[140%] font-medium text-[#474747] transition-colors hover:bg-[#22CF64]"
             >
               완료
             </button>

--- a/src/features/admin/ui/SubTabButton.tsx
+++ b/src/features/admin/ui/SubTabButton.tsx
@@ -13,8 +13,8 @@ function SubTabButton({
       onClick={onClick}
       className={
         isActive
-          ? 'flex h-[38px] items-center justify-center rounded-[30px] bg-[#000000] px-[14px] text-[16px] leading-[140%] font-medium text-white'
-          : 'flex h-[38px] items-center justify-center rounded-[30px] border border-[#D6D6D6] px-[14px] text-[16px] leading-[140%] font-medium text-[#7F7F7F]'
+          ? 'flex h-[38px] cursor-pointer items-center justify-center rounded-[30px] bg-[#000000] px-[14px] text-[16px] leading-[140%] font-medium text-white'
+          : 'flex h-[38px] cursor-pointer items-center justify-center rounded-[30px] border border-[#D6D6D6] px-[14px] text-[16px] leading-[140%] font-medium text-[#7F7F7F]'
       }
     >
       {children}

--- a/src/shared/lib/session-context.tsx
+++ b/src/shared/lib/session-context.tsx
@@ -64,12 +64,9 @@ export function AppSessionProvider({
   useEffect(() => {
     if (!session?.expiresAt) return undefined;
     const delay = session.expiresAt - Date.now();
-    if (delay > 0) {
-      const timer = setTimeout(() => window.location.reload(), delay);
-      return () => clearTimeout(timer);
-    }
-    window.location.reload();
-    return undefined;
+    if (delay <= 0) return undefined;
+    const timer = setTimeout(() => window.location.reload(), delay);
+    return () => clearTimeout(timer);
   }, [session?.expiresAt]);
 
   const value = useMemo(

--- a/src/views/admin/ui/AdminDashboardView.tsx
+++ b/src/views/admin/ui/AdminDashboardView.tsx
@@ -10,7 +10,6 @@ interface AdminDashboardViewProps {
   totalClubs: number;
   pendingMasterCount: number;
   pendingClubCount: number;
-  totalMasters: number;
 }
 
 function AdminDashboardView({
@@ -19,7 +18,6 @@ function AdminDashboardView({
   totalClubs,
   pendingMasterCount,
   pendingClubCount,
-  totalMasters,
 }: AdminDashboardViewProps) {
   return (
     <div className="flex flex-col gap-8 px-[140px] pt-4 pb-10">
@@ -52,15 +50,7 @@ function AdminDashboardView({
           </div>
           <div className="relative h-[117px] w-[176px] rounded-[20px] bg-[#F8F8F8]">
             <span className="absolute top-4 left-5 text-[16px] leading-[140%] font-medium text-[#474747]">
-              승인 대기
-            </span>
-            <span className="absolute right-5 bottom-4 text-[36px] leading-[140%] font-bold text-[#474747]">
-              {pendingMasterCount}건
-            </span>
-          </div>
-          <div className="relative h-[117px] w-[176px] rounded-[20px] bg-[#F8F8F8]">
-            <span className="absolute top-4 left-5 text-[16px] leading-[140%] font-medium text-[#474747]">
-              신규 신청
+              동아리 신청
             </span>
             <span className="absolute right-5 bottom-4 text-[36px] leading-[140%] font-bold text-[#474747]">
               {pendingClubCount}건
@@ -68,10 +58,10 @@ function AdminDashboardView({
           </div>
           <div className="relative h-[117px] w-[176px] rounded-[20px] bg-[#F8F8F8]">
             <span className="absolute top-4 left-5 text-[16px] leading-[140%] font-medium text-[#474747]">
-              전체 동아리장
+              동아리장 신청
             </span>
             <span className="absolute right-5 bottom-4 text-[36px] leading-[140%] font-bold text-[#474747]">
-              {totalMasters}명
+              {pendingMasterCount}건
             </span>
           </div>
         </div>

--- a/src/views/admin/ui/AdminDashboardView.tsx
+++ b/src/views/admin/ui/AdminDashboardView.tsx
@@ -32,7 +32,7 @@ function AdminDashboardView({
       <div className="flex items-center justify-between">
         <button
           type="button"
-          className="flex h-[50px] items-center justify-center rounded-[30px] bg-[#4AF38A] px-5 text-[16px] leading-[140%] font-medium text-[#000000]"
+          className="flex h-[50px] cursor-pointer items-center justify-center rounded-[30px] bg-[#4AF38A] px-5 text-[16px] leading-[140%] font-medium text-[#000000]"
         >
           대시보드
         </button>

--- a/src/views/admin/ui/AdminDashboardView.tsx
+++ b/src/views/admin/ui/AdminDashboardView.tsx
@@ -10,9 +10,6 @@ import type { UniversityOption } from '@/entities/university/model/type';
 interface AdminDashboardViewProps {
   clubMasterApplications: ClubMasterApplication[];
   clubApplications: ClubApplication[];
-  totalClubs: number;
-  pendingMasterCount: number;
-  pendingClubCount: number;
   role: AdminRole;
   universities: UniversityOption[];
   selectedCode: string;
@@ -21,9 +18,6 @@ interface AdminDashboardViewProps {
 function AdminDashboardView({
   clubMasterApplications,
   clubApplications,
-  totalClubs,
-  pendingMasterCount,
-  pendingClubCount,
   role,
   universities,
   selectedCode,
@@ -54,57 +48,19 @@ function AdminDashboardView({
         )}
       </div>
 
-      <div className="flex flex-col gap-8">
-        <div className="flex flex-col gap-1">
-          <h2 className="text-[20px] leading-[140%] font-semibold tracking-[-0.03em] text-[#000000]">
-            전체 동아리 현황
-          </h2>
-          <p className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#8B95A1]">
-            학교 동아리 현황과 신청을 한눈에 관리할 수 있어요.
-          </p>
-        </div>
-        <div className="flex items-center gap-5">
-          <div className="relative h-[117px] w-[176px] rounded-[20px] bg-[#F8F8F8]">
-            <span className="absolute top-4 left-5 text-[16px] leading-[140%] font-medium text-[#474747]">
-              등록된 동아리
-            </span>
-            <span className="absolute right-5 bottom-4 text-[36px] leading-[140%] font-bold text-[#474747]">
-              {totalClubs}개
-            </span>
-          </div>
-          <div className="relative h-[117px] w-[176px] rounded-[20px] bg-[#F8F8F8]">
-            <span className="absolute top-4 left-5 text-[16px] leading-[140%] font-medium text-[#474747]">
-              동아리 신청
-            </span>
-            <span className="absolute right-5 bottom-4 text-[36px] leading-[140%] font-bold text-[#474747]">
-              {pendingClubCount}건
-            </span>
-          </div>
-          <div className="relative h-[117px] w-[176px] rounded-[20px] bg-[#F8F8F8]">
-            <span className="absolute top-4 left-5 text-[16px] leading-[140%] font-medium text-[#474747]">
-              동아리장 신청
-            </span>
-            <span className="absolute right-5 bottom-4 text-[36px] leading-[140%] font-bold text-[#474747]">
-              {pendingMasterCount}건
-            </span>
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-1">
-            <h3 className="text-[20px] leading-[140%] font-semibold tracking-[-0.03em] text-[#000000]">
-              최근 승인 대기 신청
-            </h3>
-            <p className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#8B95A1]">
-              현재 승인 대기 중인 신청을 확인하고 처리할 수 있어요.
-            </p>
-          </div>
-          <ClubMasterApplicationWidget
-            initialClubApplications={clubApplications}
-            initialClubMasterApplications={clubMasterApplications}
-          />
-        </div>
+      <div className="flex flex-col gap-1">
+        <h2 className="text-[20px] leading-[140%] font-semibold tracking-[-0.03em] text-[#000000]">
+          승인 대기 신청
+        </h2>
+        <p className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#8B95A1]">
+          현재 승인 대기 중인 신청을 확인하고 처리할 수 있어요.
+        </p>
       </div>
+
+      <ClubMasterApplicationWidget
+        initialClubApplications={clubApplications}
+        initialClubMasterApplications={clubMasterApplications}
+      />
     </div>
   );
 }

--- a/src/widgets/admin/ui/AdminUniversitySelectWidget.tsx
+++ b/src/widgets/admin/ui/AdminUniversitySelectWidget.tsx
@@ -30,7 +30,7 @@ function AdminUniversitySelectWidget({
 
   return (
     <Select value={selectedCode} onValueChange={changeUniversity}>
-      <SelectTrigger className="w-[200px]">
+      <SelectTrigger className="w-[200px] cursor-pointer">
         <SelectValue placeholder="학교를 선택해주세요" />
       </SelectTrigger>
       <SelectContent>

--- a/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
+++ b/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
@@ -14,7 +14,7 @@ import rejectClubMasterApplication from '@/features/admin/api/rejectClubMasterAp
 import approveClubApplication from '@/features/admin/api/approveClubApplication';
 import rejectClubApplication from '@/features/admin/api/rejectClubApplication';
 
-type KindFilter = 'all' | 'clubOnly';
+type KindFilter = 'clubApplication' | 'clubMaster';
 
 const STATUS_TABS: { label: string; value: ApplicationStatus }[] = [
   { label: '진행 중', value: 'PENDING' },
@@ -31,7 +31,7 @@ function ClubMasterApplicationWidget({
   initialClubApplications,
   initialClubMasterApplications,
 }: ClubMasterApplicationWidgetProps) {
-  const [kindFilter, setKindFilter] = useState<KindFilter>('all');
+  const [kindFilter, setKindFilter] = useState<KindFilter>('clubApplication');
   const [statusTab, setStatusTab] = useState<ApplicationStatus>('PENDING');
   const [clubApplications, setClubApplications] = useState(
     initialClubApplications,
@@ -42,30 +42,8 @@ function ClubMasterApplicationWidget({
   const [, startTransition] = useTransition();
 
   const items = useMemo<ApplicationCardItem[]>(() => {
-    const clubItems: ApplicationCardItem[] = clubApplications.map(
-      (application) => ({
-        key: `club-${application.applicationId}`,
-        kind: 'club',
-        applicationId: application.applicationId,
-        clubName: application.clubName,
-        universityName: application.universityName,
-        applicantName: application.applicantName,
-        status: application.status,
-        createdAt: application.createdAt,
-        category: application.category,
-        affiliation: application.affiliation,
-        logo: application.logo,
-        instagram: application.instagram,
-        description: application.description,
-      }),
-    );
-
-    if (kindFilter === 'clubOnly') {
-      return clubItems;
-    }
-
-    const masterItems: ApplicationCardItem[] = clubMasterApplications.map(
-      (application) => ({
+    if (kindFilter === 'clubMaster') {
+      return clubMasterApplications.map((application) => ({
         key: `master-${application.id}`,
         kind: 'master',
         applicationId: application.id,
@@ -74,10 +52,24 @@ function ClubMasterApplicationWidget({
         applicantName: application.userName,
         status: application.status,
         createdAt: application.createdAt,
-      }),
-    );
+      }));
+    }
 
-    return [...clubItems, ...masterItems];
+    return clubApplications.map((application) => ({
+      key: `club-${application.applicationId}`,
+      kind: 'club',
+      applicationId: application.applicationId,
+      clubName: application.clubName,
+      universityName: application.universityName,
+      applicantName: application.applicantName,
+      status: application.status,
+      createdAt: application.createdAt,
+      category: application.category,
+      affiliation: application.affiliation,
+      logo: application.logo,
+      instagram: application.instagram,
+      description: application.description,
+    }));
   }, [clubApplications, clubMasterApplications, kindFilter]);
 
   const visibleItems = items.filter((item) => item.status === statusTab);
@@ -134,16 +126,16 @@ function ClubMasterApplicationWidget({
     <div className="flex flex-col gap-6">
       <div className="flex gap-3">
         <SubTabButton
-          isActive={kindFilter === 'all'}
-          onClick={() => setKindFilter('all')}
+          isActive={kindFilter === 'clubApplication'}
+          onClick={() => setKindFilter('clubApplication')}
         >
           동아리 생성 &amp; 동아리장
         </SubTabButton>
         <SubTabButton
-          isActive={kindFilter === 'clubOnly'}
-          onClick={() => setKindFilter('clubOnly')}
+          isActive={kindFilter === 'clubMaster'}
+          onClick={() => setKindFilter('clubMaster')}
         >
-          동아리 생성
+          동아리장
         </SubTabButton>
       </div>
 

--- a/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
+++ b/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
@@ -154,7 +154,7 @@ function ClubMasterApplicationWidget({
               key={tab.value}
               type="button"
               onClick={() => setStatusTab(tab.value)}
-              className="flex w-20 flex-col items-center gap-[5px]"
+              className="flex w-20 cursor-pointer flex-col items-center gap-[5px]"
             >
               <span
                 className={`text-[16px] leading-[140%] font-semibold tracking-[-0.03em] ${statusTab === tab.value ? 'text-[#22CF64]' : 'text-[#8B95A1]'}`}
@@ -168,7 +168,7 @@ function ClubMasterApplicationWidget({
           ))}
         </div>
 
-        <div className="flex w-full flex-col border-t border-[#8B95A1]">
+        <div className="flex w-full flex-col">
           {visibleItems.length === 0 ? (
             <div className="py-8 text-center text-[16px] leading-[140%] font-medium text-[#8B95A1]">
               신청 내역이 없습니다.

--- a/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
+++ b/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
@@ -1,20 +1,26 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useMemo, useState, useTransition } from 'react';
 import type {
   ClubMasterApplication,
   ClubApplication,
   ApplicationStatus,
+  ApplicationCardItem,
 } from '@/features/admin/model/dashboard-types';
-import ApplicationTableRow from '@/features/admin/ui/ApplicationTableRow';
+import ApplicationCard from '@/features/admin/ui/ApplicationCard';
 import SubTabButton from '@/features/admin/ui/SubTabButton';
-import TableHeaderCell from '@/features/admin/ui/TableHeaderCell';
 import approveClubMasterApplication from '@/features/admin/api/approveClubMasterApplication';
 import rejectClubMasterApplication from '@/features/admin/api/rejectClubMasterApplication';
 import approveClubApplication from '@/features/admin/api/approveClubApplication';
 import rejectClubApplication from '@/features/admin/api/rejectClubApplication';
 
-type SubTab = 'combined' | 'masterOnly';
+type KindFilter = 'all' | 'clubOnly';
+
+const STATUS_TABS: { label: string; value: ApplicationStatus }[] = [
+  { label: '진행 중', value: 'PENDING' },
+  { label: '승인', value: 'APPROVED' },
+  { label: '반려', value: 'REJECTED' },
+];
 
 interface ClubMasterApplicationWidgetProps {
   initialClubApplications: ClubApplication[];
@@ -25,7 +31,8 @@ function ClubMasterApplicationWidget({
   initialClubApplications,
   initialClubMasterApplications,
 }: ClubMasterApplicationWidgetProps) {
-  const [activeTab, setActiveTab] = useState<SubTab>('combined');
+  const [kindFilter, setKindFilter] = useState<KindFilter>('all');
+  const [statusTab, setStatusTab] = useState<ApplicationStatus>('PENDING');
   const [clubApplications, setClubApplications] = useState(
     initialClubApplications,
   );
@@ -34,173 +41,150 @@ function ClubMasterApplicationWidget({
   );
   const [, startTransition] = useTransition();
 
-  const pendingClubApplications = clubApplications.filter(
-    (a) => a.status === 'PENDING',
-  );
-  const pendingMasterApplications = clubMasterApplications.filter(
-    (a) => a.status === 'PENDING',
-  );
+  const items = useMemo<ApplicationCardItem[]>(() => {
+    const clubItems: ApplicationCardItem[] = clubApplications.map(
+      (application) => ({
+        key: `club-${application.applicationId}`,
+        kind: 'club',
+        applicationId: application.applicationId,
+        clubName: application.clubName,
+        universityName: application.universityName,
+        applicantName: application.applicantName,
+        status: application.status,
+        createdAt: application.createdAt,
+        category: application.category,
+        affiliation: application.affiliation,
+        logo: application.logo,
+        instagram: application.instagram,
+        description: application.description,
+      }),
+    );
 
-  const handleCombinedApprove = (applicationId: number) => {
-    startTransition(async () => {
-      const [clubSuccess, masterSuccess] = await Promise.all([
-        approveClubApplication(applicationId),
-        approveClubMasterApplication(applicationId),
-      ]);
-      if (clubSuccess && masterSuccess) {
-        setClubApplications((previous) =>
-          previous.map((a) =>
-            a.applicationId === applicationId
-              ? { ...a, status: 'APPROVED' as ApplicationStatus }
-              : a,
-          ),
-        );
-        setClubMasterApplications((previous) =>
-          previous.map((a) =>
-            a.id === applicationId
-              ? { ...a, status: 'APPROVED' as ApplicationStatus }
-              : a,
-          ),
-        );
-      }
-    });
-  };
+    if (kindFilter === 'clubOnly') {
+      return clubItems;
+    }
 
-  const handleCombinedReject = (
-    applicationId: number,
-    rejectReason?: string,
+    const masterItems: ApplicationCardItem[] = clubMasterApplications.map(
+      (application) => ({
+        key: `master-${application.id}`,
+        kind: 'master',
+        applicationId: application.id,
+        clubName: application.clubName,
+        universityName: application.universityName,
+        applicantName: application.userName,
+        status: application.status,
+        createdAt: application.createdAt,
+      }),
+    );
+
+    return [...clubItems, ...masterItems];
+  }, [clubApplications, clubMasterApplications, kindFilter]);
+
+  const visibleItems = items.filter((item) => item.status === statusTab);
+
+  const updateStatus = (
+    item: ApplicationCardItem,
+    status: ApplicationStatus,
+    rejectReason: string | null = null,
   ) => {
-    startTransition(async () => {
-      const success = await rejectClubApplication(applicationId, rejectReason);
-      if (success) {
-        setClubApplications((previous) =>
-          previous.map((a) =>
-            a.applicationId === applicationId
-              ? {
-                  ...a,
-                  status: 'REJECTED' as ApplicationStatus,
-                  rejectReason: rejectReason ?? null,
-                }
-              : a,
-          ),
-        );
-      }
-    });
-  };
-
-  const handleMasterApprove = (applicationId: number) => {
-    startTransition(async () => {
-      const success = await approveClubMasterApplication(applicationId);
-      if (success) {
-        setClubMasterApplications((previous) =>
-          previous.map((a) =>
-            a.id === applicationId
-              ? { ...a, status: 'APPROVED' as ApplicationStatus }
-              : a,
-          ),
-        );
-      }
-    });
-  };
-
-  const handleMasterReject = (applicationId: number, rejectReason?: string) => {
-    startTransition(async () => {
-      const success = await rejectClubMasterApplication(
-        applicationId,
-        rejectReason,
+    if (item.kind === 'club') {
+      setClubApplications((previous) =>
+        previous.map((application) =>
+          application.applicationId === item.applicationId
+            ? { ...application, status, rejectReason }
+            : application,
+        ),
       );
+    } else {
+      setClubMasterApplications((previous) =>
+        previous.map((application) =>
+          application.id === item.applicationId
+            ? { ...application, status, rejectReason }
+            : application,
+        ),
+      );
+    }
+  };
+
+  const handleApprove = (item: ApplicationCardItem) => {
+    startTransition(async () => {
+      const success =
+        item.kind === 'club'
+          ? await approveClubApplication(item.applicationId)
+          : await approveClubMasterApplication(item.applicationId);
       if (success) {
-        setClubMasterApplications((previous) =>
-          previous.map((a) =>
-            a.id === applicationId
-              ? {
-                  ...a,
-                  status: 'REJECTED' as ApplicationStatus,
-                  rejectReason: rejectReason ?? null,
-                }
-              : a,
-          ),
-        );
+        updateStatus(item, 'APPROVED');
+      }
+    });
+  };
+
+  const handleReject = (item: ApplicationCardItem, rejectReason?: string) => {
+    startTransition(async () => {
+      const success =
+        item.kind === 'club'
+          ? await rejectClubApplication(item.applicationId, rejectReason)
+          : await rejectClubMasterApplication(item.applicationId, rejectReason);
+      if (success) {
+        updateStatus(item, 'REJECTED', rejectReason ?? null);
       }
     });
   };
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex gap-2">
+    <div className="flex flex-col gap-6">
+      <div className="flex gap-3">
         <SubTabButton
-          isActive={activeTab === 'combined'}
-          onClick={() => setActiveTab('combined')}
+          isActive={kindFilter === 'all'}
+          onClick={() => setKindFilter('all')}
         >
-          동아리장 &amp; 동아리 생성
+          동아리 생성 &amp; 동아리장
         </SubTabButton>
         <SubTabButton
-          isActive={activeTab === 'masterOnly'}
-          onClick={() => setActiveTab('masterOnly')}
+          isActive={kindFilter === 'clubOnly'}
+          onClick={() => setKindFilter('clubOnly')}
         >
-          동아리장
+          동아리 생성
         </SubTabButton>
       </div>
 
-      {activeTab === 'combined' && (
-        <div className="flex w-full flex-col">
-          <div className="flex w-full items-center border-t border-b border-[#8B95A1] py-2">
-            <TableHeaderCell width="w-[120px]">신청일자</TableHeaderCell>
-            <TableHeaderCell width="w-[160px]">동아리명</TableHeaderCell>
-            <TableHeaderCell width="w-[100px]">분류</TableHeaderCell>
-            <TableHeaderCell width="flex-1">신청자</TableHeaderCell>
-            <TableHeaderCell width="w-[152px]">상태</TableHeaderCell>
-          </div>
-          {pendingClubApplications.length === 0 ? (
-            <div className="py-8 text-center text-[16px] leading-[140%] font-medium text-[#8B95A1]">
-              신청 내역이 없습니다.
-            </div>
-          ) : (
-            pendingClubApplications.map((application) => (
-              <ApplicationTableRow
-                key={application.applicationId}
-                applicationId={application.applicationId}
-                clubName={application.clubName}
-                applicantName={application.applicantName}
-                category={application.category}
-                status={application.status}
-                createdAt={application.createdAt}
-                onApprove={handleCombinedApprove}
-                onReject={handleCombinedReject}
+      <div className="flex flex-col gap-6">
+        <div className="flex">
+          {STATUS_TABS.map((tab) => (
+            <button
+              key={tab.value}
+              type="button"
+              onClick={() => setStatusTab(tab.value)}
+              className="flex w-20 flex-col items-center gap-[5px]"
+            >
+              <span
+                className={`text-[16px] leading-[140%] font-semibold tracking-[-0.03em] ${statusTab === tab.value ? 'text-[#22CF64]' : 'text-[#8B95A1]'}`}
+              >
+                {tab.label}
+              </span>
+              <span
+                className={`h-px w-full ${statusTab === tab.value ? 'bg-[#22CF64]' : 'bg-transparent'}`}
               />
-            ))
-          )}
+            </button>
+          ))}
         </div>
-      )}
 
-      {activeTab === 'masterOnly' && (
-        <div className="flex w-full flex-col">
-          <div className="flex w-full items-center border-t border-b border-[#8B95A1] py-2">
-            <TableHeaderCell width="w-[120px]">신청일자</TableHeaderCell>
-            <TableHeaderCell width="w-[160px]">동아리명</TableHeaderCell>
-            <TableHeaderCell width="flex-1">신청자</TableHeaderCell>
-            <TableHeaderCell width="w-[152px]">상태</TableHeaderCell>
-          </div>
-          {pendingMasterApplications.length === 0 ? (
+        <div className="flex w-full flex-col border-t border-[#8B95A1]">
+          {visibleItems.length === 0 ? (
             <div className="py-8 text-center text-[16px] leading-[140%] font-medium text-[#8B95A1]">
               신청 내역이 없습니다.
             </div>
           ) : (
-            pendingMasterApplications.map((application) => (
-              <ApplicationTableRow
-                key={application.id}
-                applicationId={application.id}
-                clubName={application.clubName}
-                applicantName={application.userName}
-                status={application.status}
-                createdAt={application.createdAt}
-                onApprove={handleMasterApprove}
-                onReject={handleMasterReject}
+            visibleItems.map((item) => (
+              <ApplicationCard
+                key={item.key}
+                item={item}
+                onApprove={() => handleApprove(item)}
+                onReject={(rejectReason) => handleReject(item, rejectReason)}
               />
             ))
           )}
         </div>
-      )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#549

## 📝작업 내용

머지 순서 실수로 인한 후속 PR입니다.

- 원래 계획: `549-fix-admin-dashboard-stats` → `560-feat-admin-dashboard-auth` (#562) 를 먼저 머지하고, 그다음 `560` → `develop` (#561) 을 머지해야 했습니다.
- 실제로는 #561(560→develop)이 먼저 머지되고, #562(549→560)가 그 다음에 머지되면서 549의 변경 사항이 develop에 반영되지 못했습니다.
- 이 PR은 그 사이 develop에 추가로 머지된 변경 사항(#554 동아리 관리 탭, #566 admin API 응답 포맷 통일, #559/#546 등)을 549 브랜치에 다시 merge하고 충돌을 해결해 549의 내용을 develop에 정상 반영합니다.

**549에서 반영되는 주요 변경**
- 관리자 인증 실패 시 세션 쿠키 제거로 대시보드 리다이렉트 루프 해결
- 대시보드 API 응답 필드명(page, pagination) 실제 스펙 정합화
- 승인 대기 신청 중심으로 대시보드 UI 재구성 (신청 카드 로우, 상태 탭·필터칩)
- 필터 탭을 API별 단일 데이터셋으로 매핑
- 대시보드 데이터 조회 로직을 `getDashboardData`로 추상화, page에서 분리
- 만료 세션 무한 리로드 루프 차단

**develop과의 충돌 해결 내역**
- `AdminDashboardView`: develop에 새로 추가된 '전체 동아리 현황' 통계 카드(#566)는 제거하고, 549가 재편한 '승인 대기 신청' 중심 UI로 통일했습니다. 더 이상 쓰이지 않는 `DashboardSummary` 타입과 `getDashboardSummary.ts`도 함께 정리했습니다.
- `ClubMasterApplicationWidget`: 549가 kind 기반으로 단순화한 개별 승인/반려 흐름은 유지하면서, develop에서 추가된 승인/반려 실패 시 toast 에러 메시지 노출(#566)을 이식했습니다. develop에 있던 '클럽+동아리장 동시 승인' 로직은 549의 단순화된 흐름을 우선해 제거했습니다.
- `page.tsx`: develop에서 추가된 `AdminMainView`(동아리 관리 탭) 래핑 구조는 유지하고, 데이터 조회는 549의 `getDashboardData` 기반으로 연결했습니다.
- `getDashboardData.ts`: develop에서 `getClubMasterApplications`/`getClubApplications` 응답이 공통 `ApiResponse` 포맷으로 바뀐 것에 맞춰 `result.data?.applications`를 참조하도록 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

충돌 해결 과정에서 두 가지 기능적 판단을 내렸습니다. 의도와 다르면 알려주세요.

1. develop에 있던 '전체 동아리 현황' 통계 카드 UI를 제거하고 549의 재편된 화면으로 통일한 것
2. '동아리 생성' 탭에서 클럽+동아리장 신청을 함께 승인하던 로직을 제거하고, 항목 kind별 개별 승인/반려로 단순화한 것
