### PR TITLE
style: button, a 태그에 cursor pointer 글로벌 적용

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -271,6 +271,11 @@ html::-webkit-scrollbar {
   h4 {
     @apply cursor-default;
   }
+
+  button,
+  a {
+    @apply cursor-pointer;
+  }
 }
 
 @theme inline {


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

- `globals.css`에 `button`, `a` 태그의 `cursor: pointer`를 글로벌로 적용
- 기존에 개별 컴포넌트마다 `cursor-pointer` 클래스를 붙여야 했던 문제 해소

## 💬리뷰 요구사항(선택)