### PR TITLE
[#581] feat: 대시보드 동아리관리 동아리명 클릭 시 동아리 페이지 이동

### DIFF
--- a/src/features/admin/ui/ClubManagementRow.tsx
+++ b/src/features/admin/ui/ClubManagementRow.tsx
@@ -1,7 +1,10 @@
+import Link from 'next/link';
 import DeleteIcon from '@/shared/ui/icons/delete-icon';
 
 interface ClubManagementRowProps {
   index: number;
+  clubId: number;
+  universityCode: string;
   name: string;
   category: string;
   disabled?: boolean;
@@ -10,6 +13,8 @@ interface ClubManagementRowProps {
 
 function ClubManagementRow({
   index,
+  clubId,
+  universityCode,
   name,
   category,
   disabled,
@@ -20,9 +25,12 @@ function ClubManagementRow({
       <span className="w-[80px] text-[14px] leading-[140%] font-medium text-[#474747]">
         {index}
       </span>
-      <span className="flex-1 text-[14px] leading-[140%] font-medium text-[#474747]">
+      <Link
+        href={`/${universityCode}/club/${clubId}`}
+        className="flex-1 text-[14px] leading-[140%] font-medium text-[#474747] hover:underline"
+      >
         {name}
-      </span>
+      </Link>
       <span className="w-[160px] text-[14px] leading-[140%] font-medium text-[#474747]">
         {category}
       </span>

--- a/src/widgets/admin/ui/ClubManagementWidget.tsx
+++ b/src/widgets/admin/ui/ClubManagementWidget.tsx
@@ -17,8 +17,13 @@ interface ClubListProps {
 
 function ClubList({ searchClubQuery }: ClubListProps) {
   const queryClient = useQueryClient();
-  const { clubs, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useAdminClubs();
+  const {
+    clubs,
+    universityCode,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useAdminClubs();
 
   const { mutate: deleteClubMutate, isPending: isDeleting } = useMutation({
     ...deleteClubMutationOptions(),
@@ -69,6 +74,8 @@ function ClubList({ searchClubQuery }: ClubListProps) {
         <ClubManagementRow
           key={club.clubId}
           index={index + 1}
+          clubId={club.clubId}
+          universityCode={universityCode}
           name={club.clubName}
           category={ClubCategoryLabel[club.category]}
           disabled={isDeleting}

--- a/src/widgets/admin/ui/use-admin-clubs.ts
+++ b/src/widgets/admin/ui/use-admin-clubs.ts
@@ -14,6 +14,7 @@ function useAdminClubs() {
 
   return {
     clubs,
+    universityCode: adminMe?.universityCode?.toLowerCase() ?? '',
     isLoading: !adminMe || infiniteQuery.isLoading,
     fetchNextPage: infiniteQuery.fetchNextPage,
     hasNextPage: infiniteQuery.hasNextPage,


### PR DESCRIPTION
## #️⃣연관된 이슈
> #581

## 📝작업 내용
- 대시보드 동아리관리 목록에서 동아리명 클릭 시 해당 동아리 상세 페이지(`/{universityCode}/club/{clubId}`)로 이동하도록 Link 추가
- `useAdminClubs` hook에서 URL용 소문자 `universityCode` 반환 추가

## 💬리뷰 요구사항(선택)
- 백엔드 API의 `universityCode`가 대문자(`SEJONG`)로 내려오므로, hook 반환 시점에 `.toLowerCase()`로 URL용 소문자 변환 처리했습니다

<img width="304" height="134" alt="image" src="https://github.com/user-attachments/assets/e6d27a76-61f1-41d0-a97f-b7fd4a5ea160" />
