### PR TITLE
[#583] fix: 동아리 정보 수정 후 리다이렉트 경로에 universityCode 추가

### DIFF
--- a/src/features/admin-club-description/ui/edit/edit-flow-container.tsx
+++ b/src/features/admin-club-description/ui/edit/edit-flow-container.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import ky from 'ky';
 import { ClubInfoType } from '@/shared/model/type';
+import useUniversityCode from '@/shared/hooks/useUniversityCode';
 import { Button } from '@/shared/ui/button';
 import DotsPulseLoader from '@/shared/ui/DotsPulseLoader';
 import SharedLoading from '@/shared/ui/loading';
@@ -22,6 +23,7 @@ interface ClubEditFlowContainerProps {
 
 function EditFlowContent({ clubInfo, clubId }: ClubEditFlowContainerProps) {
   const router = useRouter();
+  const universityCode = useUniversityCode();
   const flow = useEditFlow();
   const initialFormData = {
     name: clubInfo.name,
@@ -135,7 +137,11 @@ function EditFlowContent({ clubInfo, clubId }: ClubEditFlowContainerProps) {
         </p>
         <Button
           onClick={() =>
-            router.push(completedClubId ? `/club/${completedClubId}` : '/club')
+            router.push(
+              completedClubId
+                ? `/${universityCode}/club/${completedClubId}`
+                : `/${universityCode}/club`,
+            )
           }
         >
           동아리 확인하기


### PR DESCRIPTION
## #️⃣연관된 이슈
> #583

## 📝작업 내용
- 동아리 정보 수정 완료 후 `router.push`에 `universityCode`가 누락되어 잘못된 경로로 이동되던 문제 수정
- `useUniversityCode()` hook을 사용하여 `/{universityCode}/club/{clubId}`로 정상 이동하도록 변경

## 💬리뷰 요구사항(선택)
- `create-flow-container.tsx`는 이미 `useUniversityCode()`를 사용하고 있었으나 `edit-flow-container.tsx`에만 누락되어 있었습니다


https://github.com/user-attachments/assets/948a4241-366d-4f21-b53a-0378dec66819

