### PR TITLE
[no-issue] chore: CODEOWNERS 파일 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @greedy-team/mokkoji-frontend


### PR DESCRIPTION
## #️⃣연관된 이슈
> no-issue

## 📝작업 내용
- `.github/CODEOWNERS` 파일 추가
- `@greedy-team/mokkoji-frontend` 팀을 전체 파일 리뷰어로 지정
- PR 생성 시 자동으로 리뷰어가 할당됩니다