### PR TITLE
refactor: 동아리 생성, 신청 폼 수정

### DIFF
--- a/src/app/[universityCode]/club-application/layout.tsx
+++ b/src/app/[universityCode]/club-application/layout.tsx
@@ -24,7 +24,7 @@ export default async function Layout({
   return (
     <div className="flex flex-col">
       <Header universityCode={universityCode} />
-      <main className="flex px-4 py-7 pb-[calc(1.75rem+85px)] lg:pb-7">
+      <main className="flex justify-center px-4 py-7 pb-[calc(1.75rem+85px)] lg:pb-7">
         {children}
       </main>
       <BottomNav />

--- a/src/features/club-create/ui/club-create-basic-step.tsx
+++ b/src/features/club-create/ui/club-create-basic-step.tsx
@@ -205,7 +205,7 @@ function ClubCreateBasicStep({
         <Input
           className="rounded-lg border border-[#D6D6D6] bg-white px-4 py-3 text-sm placeholder:text-[#C0C0C0]"
           id="club-instagram"
-          placeholder="@mokkoji"
+          placeholder="https://www.instagram.com/mokkoji"
           value={formData.instagram}
           onChange={(e) =>
             setFormData((prev) => ({ ...prev, instagram: e.target.value }))

--- a/src/widgets/club-application/ui/club-application-tab.tsx
+++ b/src/widgets/club-application/ui/club-application-tab.tsx
@@ -20,7 +20,7 @@ function ClubApplicationTabs({ universities }: ClubApplicationTabsProps) {
   const [activeTab, setActiveTab] = useState<TabKey>('club-create');
 
   return (
-    <div className="w-full sm:px-8 lg:px-[150px]">
+    <div className="w-[95vw] lg:w-[60%] lg:max-w-[60%] lg:min-w-[60%]">
       <div className="sticky top-0 z-30 flex w-full justify-start border-b border-b-[#D6D6D6] bg-white pb-3 lg:mb-12">
         {TABS.map((tab) => {
           const isSelected = tab.key === activeTab;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #587 

## 📝작업 내용

- 동아리 생성, 신청 폼의 데스크탑 버전일때 너비를 상세페이지와 동일하게 수정
- 동아리 생성 폼에서 인스타그램의 placeholder값을 올바른 예시로 수정 (https:/~)

### 스크린샷 (선택)
<img width="1498" height="757" alt="image" src="https://github.com/user-attachments/assets/467bc43f-db38-4983-8296-a2b877f1b2d8" />


## 💬리뷰 요구사항(선택)

- 너비가 넓다는 피드백을 받아서 동아리 상세페이지와 동일한 너비로 수정을 했는데 더 줄여야할지, 지금 정도도 괜찮을지 질문 드립니다 !
- placeholder값에 예시로 https://www.instagram.com/mokkoji 라고 작성을 했는데 실제 유효한 값은 https://www.instagram.com/sejong_mokkoji 이긴합니다 ! 다만 저희가 세종대만 하는게 아니라 sejong을 뺀 상태로 넣어뒀는데 제출 형식만 보이면 되는거니까 괜찮겠죠?
