### PR TITLE
fix: 메인페이지 동아리 카드가 학교 구분 없이 항상 세종대 기준으로 조회되던 문제 수정

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -2,7 +2,12 @@ import HomePage from '@/views/home/ui/home-page';
 import { getUniversityName } from '@/shared/lib/universityMeta';
 
 function Page() {
-  return <HomePage universityName={getUniversityName('SEJONG')} />;
+  return (
+    <HomePage
+      universityName={getUniversityName('SEJONG')}
+      universityCode="SEJONG"
+    />
+  );
 }
 
 export default Page;

--- a/src/app/[universityCode]/(home)/page.tsx
+++ b/src/app/[universityCode]/(home)/page.tsx
@@ -10,9 +10,15 @@ async function Page({
   params: Promise<{ universityCode: string }>;
 }) {
   const { universityCode } = await params;
-  const universityName = getUniversityName(urlCodeToApiCode(universityCode));
+  const apiUniversityCode = urlCodeToApiCode(universityCode);
+  const universityName = getUniversityName(apiUniversityCode);
 
-  return <HomePage universityName={universityName} />;
+  return (
+    <HomePage
+      universityName={universityName}
+      universityCode={apiUniversityCode}
+    />
+  );
 }
 
 export default Page;

--- a/src/views/home/ui/desktop-home-page.tsx
+++ b/src/views/home/ui/desktop-home-page.tsx
@@ -10,9 +10,13 @@ import { Suspense } from 'react';
 
 interface DeskTopHomePageProps {
   universityName: string;
+  universityCode: string;
 }
 
-function DeskTopHomePage({ universityName }: DeskTopHomePageProps) {
+function DeskTopHomePage({
+  universityName,
+  universityCode,
+}: DeskTopHomePageProps) {
   return (
     <>
       <section className="mx-auto mt-4 flex min-h-[calc(100vh-200px)] w-fit flex-col justify-center">
@@ -24,7 +28,10 @@ function DeskTopHomePage({ universityName }: DeskTopHomePageProps) {
       </div>
       <section className="px-[10%]">
         <Suspense fallback={<SharedLoading />}>
-          <ClubCardWidget universityName={universityName} />
+          <ClubCardWidget
+            universityName={universityName}
+            universityCode={universityCode}
+          />
         </Suspense>
       </section>
       <section className="bg-[linear-gradient(to_bottom,_#FFFFFF_0%,_#F8FAFB_5%,_#F8FAFB_95%,_#FFFFFF_100%)] px-[10%]">

--- a/src/views/home/ui/home-page.tsx
+++ b/src/views/home/ui/home-page.tsx
@@ -4,9 +4,10 @@ import MobileHomePage from './mobile-home-page';
 
 interface HomePageProps {
   universityName: string;
+  universityCode: string;
 }
 
-async function HomePage({ universityName }: HomePageProps) {
+async function HomePage({ universityName, universityCode }: HomePageProps) {
   const cookieStore = await cookies();
   const deviceType = cookieStore.get('x-device-type')?.value;
 
@@ -14,7 +15,12 @@ async function HomePage({ universityName }: HomePageProps) {
     return <MobileHomePage universityName={universityName} />;
   }
 
-  return <DeskTopHomePage universityName={universityName} />;
+  return (
+    <DeskTopHomePage
+      universityName={universityName}
+      universityCode={universityCode}
+    />
+  );
 }
 
 export default HomePage;

--- a/src/widgets/club/api/getClubList.ts
+++ b/src/widgets/club/api/getClubList.ts
@@ -16,14 +16,14 @@ async function getClubList({
   category,
   affiliation,
   keyword,
-  universityCode = 'SEJONG',
+  universityCode,
 }: {
   page: number;
   size: number;
   category?: ClubCategory;
   affiliation?: ClubAffiliation;
   keyword?: string;
-  universityCode?: string;
+  universityCode: string;
 }) {
   const session = await getSession();
 

--- a/src/widgets/home/ui/club-card-widget.tsx
+++ b/src/widgets/home/ui/club-card-widget.tsx
@@ -7,12 +7,17 @@ import getClubList from '@/widgets/club/api/getClubList';
 
 interface ClubCardWidgetProps {
   universityName: string;
+  universityCode: string;
 }
 
-async function ClubCardWidget({ universityName }: ClubCardWidgetProps) {
+async function ClubCardWidget({
+  universityName,
+  universityCode,
+}: ClubCardWidgetProps) {
   const clubListResponse = await getClubList({
     page: 1,
     size: 10,
+    universityCode,
   });
   if (!clubListResponse.ok || !clubListResponse.data) {
     return <ErrorBoundaryUi />;


### PR DESCRIPTION
## #️⃣연관된 이슈

#590 

## 📝작업 내용

- ClubCardWidget에서 getClubList 호출 시 universityCode를 전달하지 않아 API 기본값(SEJONG)으로 고정되던 문제 수정
- URL의 [universityCode] 경로 세그먼트를 page → HomePage → DeskTopHomePage → ClubCardWidget까지 전달하도록 변경
- getClubList의 universityCode 기본값 제거하고 필수 파라미터로 변경 (재발 방지)

### 스크린샷 (선택)
- 세종대

<img width="1498" height="757" alt="image" src="https://github.com/user-attachments/assets/bb7139a0-b9b6-4a5e-9909-637a9590dd70" />


- 건국대
<img width="1498" height="757" alt="image" src="https://github.com/user-attachments/assets/3a310581-2e47-4912-94bd-e3336ee2f94a" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
