### PR TITLE
feat: 총동연 반려 사유 조회 기능 추가

### DIFF
--- a/src/features/admin/model/dashboard-types.ts
+++ b/src/features/admin/model/dashboard-types.ts
@@ -57,6 +57,7 @@ export interface ApplicationCardItem {
   universityName: string;
   applicantName: string;
   status: ApplicationStatus;
+  rejectReason: string | null;
   createdAt: string;
   category?: string;
   affiliation?: string;

--- a/src/features/admin/ui/ApplicationCard.tsx
+++ b/src/features/admin/ui/ApplicationCard.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import type { ApplicationCardItem } from '@/features/admin/model/dashboard-types';
 import { ClubCategoryLabel, ClubCategory } from '@/shared/model/type';
+import RejectReasonViewDialog from '@/shared/ui/RejectReasonViewDialog';
 import RejectReasonDialog from './RejectReasonDialog';
 import ApproveCompleteDialog from './ApproveCompleteDialog';
 
@@ -147,11 +148,16 @@ function ApplicationCard({ item, onApprove, onReject }: ApplicationCardProps) {
               </button>
             </>
           ) : (
-            <span
-              className={`text-[14px] leading-[140%] font-medium tracking-[-0.03em] ${item.status === 'APPROVED' ? 'text-[#22CF64]' : 'text-[#8B95A1]'}`}
-            >
-              {item.status === 'APPROVED' ? '승인됨' : '반려됨'}
-            </span>
+            <div className="flex items-center gap-2">
+              <span
+                className={`text-[14px] leading-[140%] font-medium tracking-[-0.03em] ${item.status === 'APPROVED' ? 'text-[#22CF64]' : 'text-[#8B95A1]'}`}
+              >
+                {item.status === 'APPROVED' ? '승인됨' : '반려됨'}
+              </span>
+              {item.status === 'REJECTED' && (
+                <RejectReasonViewDialog rejectReason={item.rejectReason} />
+              )}
+            </div>
           )}
         </div>
       </div>

--- a/src/features/admin/ui/ApplicationTableRow.tsx
+++ b/src/features/admin/ui/ApplicationTableRow.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import type { ApplicationStatus } from '@/features/admin/model/dashboard-types';
 import { ClubCategoryLabel, ClubCategory } from '@/shared/model/type';
+import RejectReasonViewDialog from '@/shared/ui/RejectReasonViewDialog';
 import TableDataCell from './TableDataCell';
 import RejectReasonDialog from './RejectReasonDialog';
 import ApproveCompleteDialog from './ApproveCompleteDialog';
@@ -13,6 +14,7 @@ interface ApplicationTableRowProps {
   applicantName: string;
   category?: string;
   status: ApplicationStatus;
+  rejectReason: string | null;
   createdAt: string;
   onApprove: (applicationId: number) => void;
   onReject: (applicationId: number, rejectReason?: string) => void;
@@ -24,6 +26,7 @@ function ApplicationTableRow({
   applicantName,
   category,
   status,
+  rejectReason,
   createdAt,
   onApprove,
   onReject,
@@ -74,11 +77,16 @@ function ApplicationTableRow({
               </button>
             </>
           ) : (
-            <span
-              className={`text-[14px] leading-[140%] font-medium tracking-[-0.03em] ${status === 'APPROVED' ? 'text-[#22CF64]' : 'text-[#8B95A1]'}`}
-            >
-              {status === 'APPROVED' ? '승인됨' : '반려됨'}
-            </span>
+            <div className="flex items-center gap-2">
+              <span
+                className={`text-[14px] leading-[140%] font-medium tracking-[-0.03em] ${status === 'APPROVED' ? 'text-[#22CF64]' : 'text-[#8B95A1]'}`}
+              >
+                {status === 'APPROVED' ? '승인됨' : '반려됨'}
+              </span>
+              {status === 'REJECTED' && (
+                <RejectReasonViewDialog rejectReason={rejectReason} />
+              )}
+            </div>
           )}
         </div>
       </div>

--- a/src/features/my/ui/club-application-card.tsx
+++ b/src/features/my/ui/club-application-card.tsx
@@ -1,17 +1,7 @@
 'use client';
 
 import dayjs from 'dayjs';
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/shared/ui/dialog';
-import { Button } from '@/shared/ui/button';
+import RejectReasonViewDialog from '@/shared/ui/RejectReasonViewDialog';
 import { ApplicationCardItem } from '@/entities/my/model/type';
 
 type ClubApplicationCardProps = {
@@ -65,43 +55,7 @@ function ClubApplicationCard({ item }: ClubApplicationCardProps) {
             <span className="text-alert-500 border-alert-500 rounded-full border px-3 py-1 text-xs">
               반려
             </span>
-            <Dialog>
-              <DialogTrigger asChild>
-                <button
-                  type="button"
-                  className="text-text-tertiary text-xs underline"
-                >
-                  반려 사유 확인
-                </button>
-              </DialogTrigger>
-              <DialogContent
-                aria-describedby="reject-reason-description"
-                className="w-[400px] rounded-2xl"
-              >
-                <DialogHeader>
-                  <DialogTitle className="flex items-start font-semibold">
-                    반려 사유
-                  </DialogTitle>
-                </DialogHeader>
-                <DialogDescription
-                  id="reject-reason-description"
-                  className="text-text-secondary text-sm"
-                >
-                  {rejectReason}
-                </DialogDescription>
-                <DialogFooter>
-                  <DialogClose asChild>
-                    <Button
-                      type="button"
-                      variant="submit-default"
-                      className="mt-2 rounded-xl bg-[#4AF38A] py-6 font-normal text-[#474747] disabled:text-white"
-                    >
-                      확인
-                    </Button>
-                  </DialogClose>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
+            <RejectReasonViewDialog rejectReason={rejectReason} />
           </div>
         )}
       </div>

--- a/src/features/my/ui/club-application-card.tsx
+++ b/src/features/my/ui/club-application-card.tsx
@@ -52,10 +52,10 @@ function ClubApplicationCard({ item }: ClubApplicationCardProps) {
 
         {status === 'REJECTED' && (
           <div className="flex items-center gap-2">
+            <RejectReasonViewDialog rejectReason={rejectReason} />
             <span className="text-alert-500 border-alert-500 rounded-full border px-3 py-1 text-xs">
               반려
             </span>
-            <RejectReasonViewDialog rejectReason={rejectReason} />
           </div>
         )}
       </div>

--- a/src/shared/ui/RejectReasonViewDialog.tsx
+++ b/src/shared/ui/RejectReasonViewDialog.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/shared/ui/dialog';
+import { Button } from '@/shared/ui/button';
+
+interface RejectReasonViewDialogProps {
+  rejectReason: string | null;
+  triggerLabel?: string;
+  triggerClassName?: string;
+}
+
+function RejectReasonViewDialog({
+  rejectReason,
+  triggerLabel = '반려 사유 확인',
+  triggerClassName = 'text-text-tertiary text-xs underline',
+}: RejectReasonViewDialogProps) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button type="button" className={triggerClassName}>
+          {triggerLabel}
+        </button>
+      </DialogTrigger>
+      <DialogContent
+        aria-describedby="reject-reason-description"
+        className="w-[400px] rounded-2xl"
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-start font-semibold">
+            반려 사유
+          </DialogTitle>
+        </DialogHeader>
+        <DialogDescription
+          id="reject-reason-description"
+          className="text-text-secondary text-sm"
+        >
+          {rejectReason}
+        </DialogDescription>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button
+              type="button"
+              variant="submit-default"
+              className="mt-2 rounded-xl bg-[#4AF38A] py-6 font-normal text-[#474747] disabled:text-white"
+            >
+              확인
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default RejectReasonViewDialog;

--- a/src/widgets/admin/ui/ClubApplicationWidget.tsx
+++ b/src/widgets/admin/ui/ClubApplicationWidget.tsx
@@ -113,6 +113,7 @@ function ClubApplicationWidget({
               applicantName={application.applicantName}
               category={application.category}
               status={application.status}
+              rejectReason={application.rejectReason}
               createdAt={application.createdAt}
               onApprove={handleApprove}
               onReject={handleReject}

--- a/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
+++ b/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
@@ -52,6 +52,7 @@ function ClubMasterApplicationWidget({
         universityName: application.universityName,
         applicantName: application.userName,
         status: application.status,
+        rejectReason: application.rejectReason,
         createdAt: application.createdAt,
       }));
     }
@@ -64,6 +65,7 @@ function ClubMasterApplicationWidget({
       universityName: application.universityName,
       applicantName: application.applicantName,
       status: application.status,
+      rejectReason: application.rejectReason,
       createdAt: application.createdAt,
       category: application.category,
       affiliation: application.affiliation,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #598

## 📝작업 내용

총동연(관리자)이 반려된 동아리/동아리장 신청의 반려 사유를 확인할 수 있도록 구현했습니다.
백엔드 응답에 이미 포함된 `rejectReason`을 화면까지 연결했습니다.

- 마이페이지에 있던 반려 사유 조회 모달을 공용 컴포넌트 `shared/ui/RejectReasonViewDialog`로 추출해 마이페이지·관리자 양쪽에서 재사용
- 관리자 대시보드 신청 목록(카드형 `ApplicationCard`, 테이블형 `ApplicationTableRow`)의 반려 항목에 "반려 사유 확인" 버튼 추가
- `ApplicationCardItem` 타입에 `rejectReason` 추가 및 위젯 매핑/전달 연결
- 마이페이지 카드의 "반려 사유 확인" ↔ "반려" 뱃지 순서 조정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 반려 사유 조회 모달을 `shared/ui`로 추출해 공용화했는데, 트리거 스타일을 `triggerClassName` prop으로 주입하는 방식이 적절한지 봐주시면 좋겠습니다.