### PR TITLE
feat: 관리자 신청 목록 표 정렬 및 한 줄 소개 조회 모달

### DIFF
--- a/src/features/admin/ui/ApplicationCard.tsx
+++ b/src/features/admin/ui/ApplicationCard.tsx
@@ -5,6 +5,7 @@ import type { ApplicationCardItem } from '@/features/admin/model/dashboard-types
 import { ClubCategoryLabel, ClubCategory } from '@/shared/model/type';
 import RejectReasonDialog from './RejectReasonDialog';
 import ApproveCompleteDialog from './ApproveCompleteDialog';
+import DescriptionViewDialog from './DescriptionViewDialog';
 
 interface ApplicationCardProps {
   item: ApplicationCardItem;
@@ -42,90 +43,78 @@ function ApplicationCard({ item, onApprove, onReject }: ApplicationCardProps) {
   return (
     <>
       <div className="flex w-full items-center justify-between border-b border-[#D6D6D6] py-3">
-        <div className="flex items-center gap-20">
-          <div className="flex items-center gap-8">
-            <span className="w-8 shrink-0 text-center text-[12px] leading-[100%] font-normal text-[#474747]">
-              {item.applicantName}
-            </span>
-            <div className="flex items-center gap-6">
-              <div className="h-[52px] w-[52px] shrink-0 overflow-hidden rounded-full bg-[#F8F8F8]">
-                {hasLogo && (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={item.logo}
-                    alt={`${item.clubName} 로고`}
-                    className="h-full w-full object-cover"
-                  />
-                )}
-              </div>
-              <div className="flex flex-col gap-3">
-                <div className="flex w-fit items-center justify-center rounded-[30px] border border-[#22CF64] px-2.5 py-1.5">
-                  <span className="text-[12px] leading-[100%] font-normal text-[#22CF64]">
-                    {item.universityName}
-                  </span>
-                </div>
-                <div className="flex flex-col gap-px">
-                  <div className="flex items-center gap-1.5">
-                    <span className="text-[20px] leading-[140%] font-semibold tracking-[-0.03em] text-[#000000]">
-                      {item.clubName}
-                    </span>
-                    {categoryLabel && (
-                      <span className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#8B95A1]">
-                        {categoryLabel}
-                      </span>
-                    )}
-                    {item.affiliation && (
-                      <>
-                        <span className="h-0.5 w-0.5 rounded-full bg-[#D6D6D6]" />
-                        <span className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#8B95A1]">
-                          {item.affiliation}
-                        </span>
-                      </>
-                    )}
-                  </div>
-                  <span className="text-[12px] leading-[140%] font-normal text-[#8B95A1]">
-                    {formattedDate}
-                  </span>
-                </div>
-              </div>
+        <div className="flex items-center gap-6">
+          <span className="w-12 shrink-0 text-center text-[12px] leading-[100%] font-normal text-[#474747]">
+            {item.applicantName}
+          </span>
+          <div className="h-[52px] w-[52px] shrink-0 overflow-hidden rounded-full bg-[#F8F8F8]">
+            {hasLogo && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={item.logo}
+                alt={`${item.clubName} 로고`}
+                className="h-full w-full object-cover"
+              />
+            )}
+          </div>
+          <div className="flex w-[160px] shrink-0 flex-col gap-3">
+            <div className="flex w-fit items-center justify-center rounded-[30px] border border-[#22CF64] px-2.5 py-1.5">
+              <span className="text-[12px] leading-[100%] font-normal text-[#22CF64]">
+                {item.universityName}
+              </span>
+            </div>
+            <div className="flex flex-col gap-px">
+              <span className="w-full truncate text-[20px] leading-[140%] font-semibold tracking-[-0.03em] text-[#000000]">
+                {item.clubName}
+              </span>
+              <span className="text-[12px] leading-[140%] font-normal text-[#8B95A1]">
+                {formattedDate}
+              </span>
             </div>
           </div>
-
-          {(instagramHref || item.description) && (
-            <div className="flex items-center gap-5">
-              {instagramHref && (
-                <a
-                  href={instagramHref}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-1 rounded-[20px] border border-[#E2E2E2]/70 bg-white py-2 pr-3 pl-2"
-                >
-                  <span className="text-[8px] leading-[10px] text-[#6A6B6B]">
-                    🔗
-                  </span>
-                  <span className="text-[10px] leading-[12px] font-normal tracking-[-0.03em] text-[#6A6B6B]">
-                    {item.instagram}
-                  </span>
-                </a>
-              )}
-              {item.description && (
-                <div className="relative">
-                  <button
-                    type="button"
-                    onClick={() => setDescriptionOpen((previous) => !previous)}
-                    className="cursor-pointer border-b border-[#8B95A1] text-[12px] leading-[100%] font-normal text-[#8B95A1]"
-                  >
-                    한 줄 소개 보기
-                  </button>
-                  {descriptionOpen && (
-                    <div className="absolute top-6 left-0 z-10 w-[240px] rounded-[12px] border border-[#E2E2E2] bg-white p-3 text-[12px] leading-[140%] font-medium text-[#474747] shadow-md">
-                      {item.description}
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
+          <div className="flex w-[220px] shrink-0 items-center gap-1.5 overflow-hidden">
+            {categoryLabel && (
+              <span className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] whitespace-nowrap text-[#8B95A1]">
+                {categoryLabel}
+              </span>
+            )}
+            {item.affiliation && (
+              <>
+                <span className="h-0.5 w-0.5 shrink-0 rounded-full bg-[#D6D6D6]" />
+                <span className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] whitespace-nowrap text-[#8B95A1]">
+                  {item.affiliation}
+                </span>
+              </>
+            )}
+          </div>
+          <div className="flex w-[130px] shrink-0 items-center">
+            {instagramHref && (
+              <a
+                href={instagramHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 rounded-[20px] border border-[#E2E2E2]/70 bg-white py-2 pr-3 pl-2"
+              >
+                <span className="text-[8px] leading-[10px] text-[#6A6B6B]">
+                  🔗
+                </span>
+                <span className="text-[10px] leading-[12px] font-normal tracking-[-0.03em] text-[#6A6B6B]">
+                  instagram
+                </span>
+              </a>
+            )}
+          </div>
+          <div className="w-[110px] shrink-0">
+            {item.description && (
+              <button
+                type="button"
+                onClick={() => setDescriptionOpen(true)}
+                className="cursor-pointer border-b border-[#8B95A1] text-[12px] leading-[100%] font-normal text-[#8B95A1]"
+              >
+                한 줄 소개 보기
+              </button>
+            )}
+          </div>
         </div>
 
         <div className="flex items-center gap-2">
@@ -166,6 +155,15 @@ function ApplicationCard({ item, onApprove, onReject }: ApplicationCardProps) {
         open={approveCompleteDialogOpen}
         onClose={() => setApproveCompleteDialogOpen(false)}
       />
+
+      {item.description && (
+        <DescriptionViewDialog
+          open={descriptionOpen}
+          onClose={() => setDescriptionOpen(false)}
+          clubName={item.clubName}
+          description={item.description}
+        />
+      )}
     </>
   );
 }

--- a/src/features/admin/ui/DescriptionViewDialog.tsx
+++ b/src/features/admin/ui/DescriptionViewDialog.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import * as Dialog from '@radix-ui/react-dialog';
+
+interface DescriptionViewDialogProps {
+  open: boolean;
+  onClose: () => void;
+  clubName: string;
+  description: string;
+}
+
+function DescriptionViewDialog({
+  open,
+  onClose,
+  clubName,
+  description,
+}: DescriptionViewDialogProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
+        <Dialog.Content className="fixed top-1/2 left-1/2 z-50 flex w-[531px] -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center rounded-[20px] bg-white p-7">
+          <div className="flex w-[475px] flex-col gap-6">
+            <div className="flex flex-col gap-1">
+              <Dialog.Title className="text-[20px] leading-[140%] font-semibold tracking-[-0.03em] text-[#000000]">
+                한 줄 소개
+              </Dialog.Title>
+              <Dialog.Description className="text-[16px] leading-[140%] font-medium text-[#8B95A1]">
+                {clubName}
+              </Dialog.Description>
+            </div>
+            <div className="min-h-[120px] w-full rounded-[16px] border border-[#E2E2E2] px-5 py-5 text-[16px] leading-[140%] font-medium break-words whitespace-pre-wrap text-[#474747]">
+              {description}
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex h-[51px] w-full cursor-pointer items-center justify-center rounded-[12px] bg-[#4AF38A] text-[16px] leading-[140%] font-medium text-[#474747] transition-colors hover:bg-[#22CF64]"
+            >
+              확인
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+export default DescriptionViewDialog;

--- a/src/features/admin/ui/DescriptionViewDialog.tsx
+++ b/src/features/admin/ui/DescriptionViewDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as Dialog from '@radix-ui/react-dialog';
+import convertLinkText from '@/entities/club-detail/util/convertLinkText';
 
 interface DescriptionViewDialogProps {
   open: boolean;
@@ -29,9 +30,10 @@ function DescriptionViewDialog({
                 {clubName}
               </Dialog.Description>
             </div>
-            <div className="min-h-[120px] w-full rounded-[16px] border border-[#E2E2E2] px-5 py-5 text-[16px] leading-[140%] font-medium break-words whitespace-pre-wrap text-[#474747]">
-              {description}
-            </div>
+            <div
+              className="min-h-[120px] w-full rounded-[16px] border border-[#E2E2E2] px-5 py-5 text-[16px] leading-[140%] font-medium break-words whitespace-pre-wrap text-[#474747] [&_a]:text-[#20E86C] [&_a]:underline"
+              dangerouslySetInnerHTML={{ __html: convertLinkText(description) }}
+            />
             <button
               type="button"
               onClick={onClose}

--- a/src/views/admin/ui/AdminDashboardView.tsx
+++ b/src/views/admin/ui/AdminDashboardView.tsx
@@ -28,14 +28,16 @@ function AdminDashboardView({
     selectedCode;
 
   return (
-    <div className="flex flex-col gap-8 px-[140px] pt-4 pb-10">
+    <div className="flex flex-col gap-8">
       <div className="flex items-center justify-between">
-        <button
-          type="button"
-          className="flex h-[50px] cursor-pointer items-center justify-center rounded-[30px] bg-[#4AF38A] px-5 text-[16px] leading-[140%] font-medium text-[#000000]"
-        >
-          대시보드
-        </button>
+        <div className="flex flex-col gap-1">
+          <h2 className="text-[20px] leading-[140%] font-semibold tracking-[-0.03em] text-[#000000]">
+            승인 대기 신청
+          </h2>
+          <p className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#8B95A1]">
+            현재 승인 대기 중인 신청을 확인하고 처리할 수 있어요.
+          </p>
+        </div>
         {isMokkojiAdmin ? (
           <AdminUniversitySelectWidget
             universities={universities}
@@ -46,15 +48,6 @@ function AdminDashboardView({
             {selectedUniversityName}
           </span>
         )}
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <h2 className="text-[20px] leading-[140%] font-semibold tracking-[-0.03em] text-[#000000]">
-          승인 대기 신청
-        </h2>
-        <p className="text-[14px] leading-[140%] font-medium tracking-[-0.03em] text-[#8B95A1]">
-          현재 승인 대기 중인 신청을 확인하고 처리할 수 있어요.
-        </p>
       </div>
 
       <ClubMasterApplicationWidget


### PR DESCRIPTION
## #️⃣연관된 이슈

> #600

## 📝작업 내용

관리자 대시보드 '승인 대기 신청' 목록의 정렬/레이아웃을 개선했습니다. (QA: 신청 내역 조회 UI 개선)

- **표 형태 열 정렬**: 신청자·로고·[학교/동아리명/날짜]·카테고리·인스타·한줄소개를 고정폭 열로 재구성. 인스타/한줄소개는 값이 없어도 빈 슬롯을 유지해 모든 행에서 같은 열에 정렬됩니다. (기존: 조건부 인라인이라 인스타 유무에 따라 한줄소개 위치가 어긋남)
- **긴 이름 대비**: 동아리명 고정폭 + 말줄임(…) 처리, 카테고리/소속은 독립 열로 분리.
- **인스타 링크**: raw URL 텍스트 대신 `instagram` 라벨로 표기(기존 pill·링크 이모지 디자인 유지), URL 새 탭 연결.
- **한 줄 소개 조회 모달**: 기존 토글 드롭박스를 반려 사유와 동일한 방식의 공용 다이얼로그(`DescriptionViewDialog`)로 교체.
- **대시보드 레이아웃 정리**: `AdminMainView`와 중복 적용되던 이중 마진(`px-[140px]`) 제거해 동아리 관리 탭과 마진 통일, 중복된 '대시보드' 버튼 제거하고 학교 선택 셀렉터를 '승인 대기 신청' 헤더 오른쪽으로 이동.

### 스크린샷 (선택)
<img width="1917" height="851" alt="image" src="https://github.com/user-attachments/assets/98e22b71-00cb-4abe-bad2-9fe4e6a00b0f" />
<img width="722" height="467" alt="image" src="https://github.com/user-attachments/assets/588b4fbd-5492-4f1f-bdc4-4352500daef1" />


## 💬리뷰 요구사항(선택)
