### PR TITLE
feat: 동아리 생성 폼 작성 후 description에 대해 XSS 방지 처리

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-intersection-observer": "^9.16.0",
     "react-toastify": "^11.0.5",
     "require-in-the-middle": "^7.5.2",
+    "sanitize-html": "^2.17.6",
     "tailwind-merge": "^3.3.1",
     "to-do-pin": "0.0.41",
     "web-vitals": "^5.1.0"
@@ -90,6 +91,7 @@
     "@types/node": "^20.19.9",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/sanitize-html": "^2.16.1",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",
     "autoprefixer": "^10.4.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       require-in-the-middle:
         specifier: ^7.5.2
         version: 7.5.2
+      sanitize-html:
+        specifier: ^2.17.6
+        version: 2.17.6
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -204,6 +207,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.1.7(@types/react@19.1.9)
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       '@typescript-eslint/eslint-plugin':
         specifier: 7.18.0
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
@@ -3367,6 +3373,9 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
@@ -4403,6 +4412,13 @@ packages:
   dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
+
   domain-browser@4.23.0:
     resolution: {integrity: sha512-ArzcM/II1wCCujdCNyQjXrAFwS4mrLh4C7DZWlaI8mdh7h3BfKdNd3bKXITfl2PT9FtfQqaGvhi1vPRQPimjGA==}
     engines: {node: '>=10'}
@@ -4410,12 +4426,31 @@ packages:
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
 
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
+
   domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
 
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
+
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -4479,6 +4514,18 @@ packages:
 
   entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -5145,6 +5192,13 @@ packages:
       webpack:
         optional: true
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
+  htmlparser2@12.0.0:
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
+
   htmlparser2@6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
 
@@ -5506,6 +5560,9 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  launder@1.7.1:
+    resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -6067,6 +6124,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -6706,6 +6766,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-html@2.17.6:
+    resolution: {integrity: sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==}
+    engines: {node: '>=22.12.0'}
 
   sass-loader@14.2.1:
     resolution: {integrity: sha512-G0VcnMYU18a4N7VoNDegg2OuMjYtxnqzQWARVWCIVSZwJeiL9kg8QMsuIZOplsJgTzZLF6jGxI3AClj8I9nRdQ==}
@@ -10884,6 +10948,10 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@types/semver@7.7.1': {}
 
   '@types/set-cookie-parser@2.4.10':
@@ -12013,19 +12081,53 @@ snapshots:
       domhandler: 4.3.1
       entities: 2.2.0
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  dom-serializer@3.1.1:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
+
   domain-browser@4.23.0: {}
 
   domelementtype@2.3.0: {}
 
+  domelementtype@3.0.0: {}
+
   domhandler@4.3.1:
     dependencies:
       domelementtype: 2.3.0
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
 
   domutils@2.8.0:
     dependencies:
       dom-serializer: 1.4.1
       domelementtype: 2.3.0
       domhandler: 4.3.1
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  domutils@4.0.2:
+    dependencies:
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
 
   dot-case@3.0.4:
     dependencies:
@@ -12088,6 +12190,12 @@ snapshots:
       tapable: 2.2.2
 
   entities@2.2.0: {}
+
+  entities@4.5.0: {}
+
+  entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 
@@ -13010,6 +13118,20 @@ snapshots:
     optionalDependencies:
       webpack: 5.101.0(esbuild@0.25.8)
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
+  htmlparser2@12.0.0:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      entities: 8.0.0
+
   htmlparser2@6.1.0:
     dependencies:
       domelementtype: 2.3.0
@@ -13344,6 +13466,10 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  launder@1.7.1:
+    dependencies:
+      dayjs: 1.11.13
 
   levn@0.4.1:
     dependencies:
@@ -13887,6 +14013,8 @@ snapshots:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse-srcset@1.0.2: {}
 
   parseurl@1.3.3: {}
 
@@ -14568,6 +14696,16 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  sanitize-html@2.17.6:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 12.0.0
+      is-plain-object: 5.0.0
+      launder: 1.7.1
+      parse-srcset: 1.0.2
+      postcss: 8.5.6
 
   sass-loader@14.2.1(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:

--- a/src/features/admin/ui/DescriptionViewDialog.tsx
+++ b/src/features/admin/ui/DescriptionViewDialog.tsx
@@ -20,7 +20,7 @@ function DescriptionViewDialog({
     <Dialog.Root open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
-        <Dialog.Content className="fixed top-1/2 left-1/2 z-50 flex w-[531px] -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center rounded-[20px] bg-white p-7">
+        <Dialog.Content className="fixed top-1/2 left-1/2 z-50 flex max-h-[85vh] w-[531px] -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center rounded-[20px] bg-white p-7">
           <div className="flex w-[475px] flex-col gap-6">
             <div className="flex flex-col gap-1">
               <Dialog.Title className="text-[20px] leading-[140%] font-semibold tracking-[-0.03em] text-[#000000]">
@@ -31,7 +31,7 @@ function DescriptionViewDialog({
               </Dialog.Description>
             </div>
             <div
-              className="min-h-[120px] w-full rounded-[16px] border border-[#E2E2E2] px-5 py-5 text-[16px] leading-[140%] font-medium break-words whitespace-pre-wrap text-[#474747] [&_a]:text-[#20E86C] [&_a]:underline"
+              className="max-h-[45vh] min-h-[120px] w-full overflow-y-auto rounded-[16px] border border-[#E2E2E2] px-5 py-5 text-[16px] leading-[140%] font-medium break-words whitespace-pre-wrap text-[#474747] [&_a]:text-[#20E86C] [&_a]:underline"
               dangerouslySetInnerHTML={{ __html: convertLinkText(description) }}
             />
             <button

--- a/src/features/club-create/api/postCreateClubApplication.ts
+++ b/src/features/club-create/api/postCreateClubApplication.ts
@@ -2,13 +2,19 @@
 
 import api from '@/shared/api/auth-api';
 import createErrorResponse from '@/shared/lib/error-message';
+import sanitizeDescriptionHtml from '@/shared/lib/sanitizeDescriptionHtml';
 import type { ClubCreateFormData } from '../model/type';
 
 async function postCreateClubApplication(
   data: ClubCreateFormData & { applicantName: string },
 ) {
   try {
-    await api.post('club-applications', { json: data });
+    await api.post('club-applications', {
+      json: {
+        ...data,
+        description: sanitizeDescriptionHtml(data.description),
+      },
+    });
     return { ok: true, message: '동아리 생성 신청이 완료되었습니다.' };
   } catch (error) {
     return createErrorResponse(error as Error, [

--- a/src/features/club-create/ui/club-create-description-step.tsx
+++ b/src/features/club-create/ui/club-create-description-step.tsx
@@ -15,7 +15,7 @@ function ClubCreateDescriptionStep({ onSubmit, isSubmitting }: Props) {
 
   return (
     <div className="flex flex-col gap-6 py-8">
-      <h2 className="text-base font-bold">동아리 한줄 소개</h2>
+      <h2 className="text-base font-bold">동아리 소개</h2>
 
       <ClubDescriptionEditor
         onChange={(html, empty) => {

--- a/src/shared/lib/sanitizeDescriptionHtml.ts
+++ b/src/shared/lib/sanitizeDescriptionHtml.ts
@@ -2,7 +2,24 @@ import sanitizeHtml from 'sanitize-html';
 
 function sanitizeDescriptionHtml(html: string): string {
   return sanitizeHtml(html, {
-    allowedTags: ['p', 'br', 'strong', 'b', 'em', 'i', 'u', 'span'],
+    allowedTags: [
+      'p',
+      'br',
+      'strong',
+      'b',
+      'em',
+      'i',
+      'u',
+      'span',
+      's',
+      'blockquote',
+      'code',
+      'pre',
+      'hr',
+      'ul',
+      'ol',
+      'li',
+    ],
     allowedAttributes: {
       p: ['style'],
       span: ['style'],

--- a/src/shared/lib/sanitizeDescriptionHtml.ts
+++ b/src/shared/lib/sanitizeDescriptionHtml.ts
@@ -1,0 +1,22 @@
+import sanitizeHtml from 'sanitize-html';
+
+function sanitizeDescriptionHtml(html: string): string {
+  return sanitizeHtml(html, {
+    allowedTags: ['p', 'br', 'strong', 'b', 'em', 'i', 'u', 'span'],
+    allowedAttributes: {
+      p: ['style'],
+      span: ['style'],
+    },
+    allowedStyles: {
+      p: {
+        'text-align': [/^left$|^center$|^right$/],
+      },
+      span: {
+        'font-size': [/^[\d.]+(px|rem)$/],
+        'font-weight': [/^bold$/],
+      },
+    },
+  });
+}
+
+export default sanitizeDescriptionHtml;


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #606 

## 📝작업 내용

### 문제점

동아리 신청서의 소개글(description)은 `ClubDescriptionEditor`에서 작성된 `HTML`을 그대로 저장하고, 이후 `club-description-widget.tsx(동아리 상세 페이지)`, `DescriptionViewDialog.tsx`(관리자 검토 화면)에서 `dangerouslySetInnerHTML`로 그대로 렌더링됩니다.

`dangerouslySetInnerHTML`은 `React`가 해당 문자열을 이스케이프 없이 그대로 DOM에 주입하는 API라, 만약 저장된 `description`에 <script>, onerror, javascript: 링크 같은 악성 마크업이 섞여 있으면 그 내용을 렌더링하는 모든 사용자(공개 페이지 방문자, 관리자)의 브라우저에서 스크립트가 실행될 수 있는 저장형 XSS 위험이 있었습니다.

이를 막기 위해 신청서 제출(`postCreateClubApplication`) 시점에 `description`을 서식 태그 화이트리스트 기반으로 `sanitize`하는 처리를 추가했습니다.

### 라이브러리 선택

sanitize 구현체로 아래 후보들을 검토했습니다.

- DOMPurify: 가장 널리 쓰이는 sanitize 라이브러리지만, 브라우저 DOM(window)에 의존합니다. `postCreateClubApplication`은 'use server'로 선언된 `Server Action`이라 `Node` 환경에서 실행되는데, `DOMPurify`를 여기서 쓰려면 jsdom으로 가짜 DOM을 만들어 주입해야 해서 (혹은 isomorphic-dompurify) 불필요하게 무거워집니다.
- xss (js-xss): `Node` 환경에서 동작하지만, 옵션 구성이 `DOMPurify`/`sanitize-html`에 비해 화이트리스트 세부 제어(style 속성 값 단위 제한 등)가 덜 직관적입니다.
- sanitize-html (채택): 처음부터 `Node` 서버 사이드에서 쓰도록 설계된 라이브러리로, `DOM` 없이 파서(`htmlparser2`) 기반으로 동작합니다. `allowedTags` / `allowedAttributes` / `allowedStyles` 옵션으로 태그·속성·CSS 값까지 화이트리스트를 세밀하게 지정할 수 있어 요구사항과 가장 잘 맞았습니다.

### 화이트리스트 설계
에디터 툴바에 노출된 서식(굵게, 밑줄, 기울임, 정렬, 폰트 크기)뿐 아니라, `ClubDescriptionEditor`가 내부적으로 쓰는 `StarterKit`이 툴바 버튼 없이도 마크다운 단축 입력(- → 목록, > → 인용, ``` → 코드블록, --- → 구분선 등)으로 만들어낼 수 있는 서식까지 함께 조사해서 `sanitizeDescriptionHtml.ts`의 화이트리스트에 반영했습니다.

- 허용 태그: p, br, strong, b, em, i, u, span, s, blockquote, code, pre, hr, ul, ol, li
- 허용 속성/스타일: p, span의 style 중 text-align(정렬), font-size/font-weight(제목 크기) 값만 정규식으로 제한 — 그 외 속성(onclick 등 이벤트 핸들러, style의 background:url() 등)은 전부 제거
- 화이트리스트 밖 CSS 값이 모두 제거되고 정상 서식은 유지되는 것을 로컬에서 확인했습니다.


### 대시보드 소개 모달에 스크롤 달기

동아리 소개에 대해서 툴바에 존재하는 모든 마크업이 삭제 되지 않고 잘 반영되는지 확인하고자 전부 다 걸어서 테스트를 해보며 소개가 길어졌는데 대시보드에서 스크롤이 안되는 이슈를 확인했습니다.스크롤 달아서 해결했습니다.



## 스크린샷 (선택)


수정 전 

<img width="3024" height="1538" alt="image" src="https://github.com/user-attachments/assets/fdc0ef58-c57f-4bfd-b6a4-6285d897cbb1" />


수정 후

<img width="1512" height="769" alt="image" src="https://github.com/user-attachments/assets/2999623a-cbce-4e0d-9a60-a08f039053b2" />


## 💬리뷰 요구사항(선택)

pnpm i 하고 확인하시길 바랍니다 !
