### PR TITLE
fix: 즐겨찾기 달력 UI 개선

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -490,6 +490,11 @@ html::-webkit-scrollbar {
   color: #1f2937 !important;
 }
 
+.react-calendar__month-view__days__day--neighboringMonth,
+.react-calendar__month-view__days__day--neighboringMonth abbr {
+  color: #757575 !important;
+}
+
 .react-calendar__month-view__weekdays {
   text-align: center;
   text-decoration: none !important;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -385,6 +385,8 @@ html::-webkit-scrollbar {
   }
   body {
     @apply bg-background text-foreground;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 }
 .react-calendar__month-view__weekdays__weekday abbr {

--- a/src/features/favorite/ui/custom-calendar.tsx
+++ b/src/features/favorite/ui/custom-calendar.tsx
@@ -18,10 +18,18 @@ const Calendar = dynamic(() => import('react-calendar'), {
 interface CustomCalendarProps {
   value: Date;
   setValue: (value: Date) => void;
+  activeStartDate: Date;
+  setActiveStartDate: (value: Date) => void;
   data: FavoriteDateItem[];
 }
 
-function CustomCalendar({ value, setValue, data }: CustomCalendarProps) {
+function CustomCalendar({
+  value,
+  setValue,
+  activeStartDate,
+  setActiveStartDate,
+  data,
+}: CustomCalendarProps) {
   const {
     isModalOpen,
     setIsModalOpen,
@@ -34,9 +42,10 @@ function CustomCalendar({ value, setValue, data }: CustomCalendarProps) {
     <>
       <Calendar
         onChange={(val) => handleDateClick(val as Date)}
-        onActiveStartDateChange={({ activeStartDate }) => {
-          if (activeStartDate) {
-            setValue(activeStartDate);
+        activeStartDate={activeStartDate}
+        onActiveStartDateChange={({ activeStartDate: nextActiveStartDate }) => {
+          if (nextActiveStartDate) {
+            setActiveStartDate(nextActiveStartDate);
           }
         }}
         value={value}

--- a/src/features/favorite/ui/custom-calendar.tsx
+++ b/src/features/favorite/ui/custom-calendar.tsx
@@ -2,13 +2,17 @@
 
 import 'react-calendar/dist/Calendar.css';
 import dynamic from 'next/dynamic';
+import { useState } from 'react';
 import { FavoriteDateItem } from '@/entities/favorite/model/type';
 import RecruitEndModal from '@/entities/favorite/ui/recruit-end-modal';
 import DateNavigation from '@/entities/favorite/ui/format-navigation';
 import SharedLoading from '@/shared/ui/loading';
+import cn from '@/shared/lib/utils';
 import Image from 'next/image';
 import getWeekdays from '../util/get-week-days';
 import useCalendarDeadline from '../model/useCalendarDeadline';
+
+const getMonthIndex = (date: Date) => date.getFullYear() * 12 + date.getMonth();
 
 const Calendar = dynamic(() => import('react-calendar'), {
   ssr: false,
@@ -30,6 +34,7 @@ function CustomCalendar({
   setActiveStartDate,
   data,
 }: CustomCalendarProps) {
+  const [direction, setDirection] = useState<'left' | 'right' | null>(null);
   const {
     isModalOpen,
     setIsModalOpen,
@@ -38,64 +43,80 @@ function CustomCalendar({
     deadlineMap,
   } = useCalendarDeadline(data, setValue);
 
+  const handleActiveStartDateChange = (nextActiveStartDate: Date | null) => {
+    if (!nextActiveStartDate) return;
+    setDirection(
+      getMonthIndex(nextActiveStartDate) > getMonthIndex(activeStartDate)
+        ? 'right'
+        : 'left',
+    );
+    setActiveStartDate(nextActiveStartDate);
+  };
+
   return (
     <>
-      <Calendar
-        onChange={(val) => handleDateClick(val as Date)}
-        activeStartDate={activeStartDate}
-        onActiveStartDateChange={({ activeStartDate: nextActiveStartDate }) => {
-          if (nextActiveStartDate) {
-            setActiveStartDate(nextActiveStartDate);
-          }
-        }}
-        value={value}
-        locale="ko-KR"
-        className="!w-full rounded-xl !border-none !bg-[#FBFBFB] !p-3 text-gray-800 lg:!w-[700px]"
-        nextLabel={
-          <div className="flex items-center justify-center">
-            <Image
-              src="/favorite/next.svg"
-              alt="다음달"
-              width={12}
-              height={23}
-              className="h-[12px] w-[6px] lg:h-[23px] lg:w-[12px]"
-            />
-          </div>
-        }
-        prevLabel={
-          <div className="flex items-center justify-center">
-            <Image
-              src="/favorite/prev.svg"
-              alt="저번달"
-              width={12}
-              height={23}
-              className="h-[12px] w-[6px] lg:h-[23px] lg:w-[12px]"
-            />
-          </div>
-        }
-        navigationLabel={DateNavigation}
-        formatShortWeekday={(locale, date) => getWeekdays(date)}
-        formatDay={(locale, date) => date.getDate().toString()}
-        next2Label={null}
-        prev2Label={null}
-        tileClassName={({ date, view }) => {
-          if (view !== 'month') return '';
+      <div className="w-full overflow-hidden rounded-xl bg-[#FBFBFB] p-3 lg:w-[700px]">
+        <div
+          key={`${activeStartDate.getFullYear()}-${activeStartDate.getMonth()}`}
+          className={cn(
+            direction === 'left' && 'animate-slide-in-left',
+            direction === 'right' && 'animate-slide-in-right',
+          )}
+        >
+          <Calendar
+            onChange={(val) => handleDateClick(val as Date)}
+            activeStartDate={activeStartDate}
+            onActiveStartDateChange={({
+              activeStartDate: nextActiveStartDate,
+            }) => handleActiveStartDateChange(nextActiveStartDate)}
+            value={value}
+            locale="ko-KR"
+            className="!w-full !border-none !bg-transparent text-gray-800"
+            nextLabel={
+              <div className="flex items-center justify-center">
+                <Image
+                  src="/favorite/next.svg"
+                  alt="다음달"
+                  width={12}
+                  height={23}
+                  className="h-[12px] w-[6px] lg:h-[23px] lg:w-[12px]"
+                />
+              </div>
+            }
+            prevLabel={
+              <div className="flex items-center justify-center">
+                <Image
+                  src="/favorite/prev.svg"
+                  alt="저번달"
+                  width={12}
+                  height={23}
+                  className="h-[12px] w-[6px] lg:h-[23px] lg:w-[12px]"
+                />
+              </div>
+            }
+            navigationLabel={DateNavigation}
+            formatShortWeekday={(locale, date) => getWeekdays(date)}
+            formatDay={(locale, date) => date.getDate().toString()}
+            next2Label={null}
+            prev2Label={null}
+            tileClassName={({ date, view }) => {
+              if (view !== 'month') return '';
 
-          const dateKey = date.toDateString();
-          const isSelected = value.toDateString() === dateKey;
-          const isDeadline = deadlineMap.has(dateKey);
+              const dateKey = date.toDateString();
+              const isSelected = value.toDateString() === dateKey;
+              const isDeadline = deadlineMap.has(dateKey);
 
-          let textClass = '!text-sm lg:!text-xl';
-          let selectedClass = '';
+              let textClass = '!text-sm lg:!text-xl';
+              let selectedClass = '';
 
-          if (isSelected) {
-            textClass = '!text-[#00E457] lg:!text-xl';
-            selectedClass = 'selected-date';
-          } else if (isDeadline) {
-            textClass = '!text-[#00E457] lg:!text-xl';
-          }
+              if (isSelected) {
+                textClass = '!text-[#00E457] lg:!text-xl';
+                selectedClass = 'selected-date';
+              } else if (isDeadline) {
+                textClass = '!text-[#00E457] lg:!text-xl';
+              }
 
-          return `
+              return `
             ${textClass}
             !bg-transparent
             hover:!bg-blue-100
@@ -105,8 +126,10 @@ function CustomCalendar({
             lg:!mb-3
             ${selectedClass}
           `;
-        }}
-      />
+            }}
+          />
+        </div>
+      </div>
       <RecruitEndModal
         modalOpen={isModalOpen}
         setModalOpen={setIsModalOpen}

--- a/src/features/favorite/ui/custom-calendar.tsx
+++ b/src/features/favorite/ui/custom-calendar.tsx
@@ -41,7 +41,7 @@ function CustomCalendar({ value, setValue, data }: CustomCalendarProps) {
         }}
         value={value}
         locale="ko-KR"
-        className="h-[574px] !w-full rounded-xl !border-none !bg-[#FBFBFB] !p-3 text-gray-800 lg:!w-[700px]"
+        className="!w-full rounded-xl !border-none !bg-[#FBFBFB] !p-3 text-gray-800 lg:!w-[700px]"
         nextLabel={
           <div className="flex items-center justify-center">
             <Image

--- a/src/views/favorite/ui/favorite-page.tsx
+++ b/src/views/favorite/ui/favorite-page.tsx
@@ -18,7 +18,7 @@ async function FavoritePage() {
   return (
     <>
       <ScrollProgressBar />
-      <div className="mx-auto w-full px-4 sm:w-4xl sm:px-5 lg:w-6xl">
+      <div className="mx-auto w-full px-4 pb-16 sm:w-4xl sm:px-5 lg:w-6xl">
         <AsyncBoundaryWithQuery
           pendingFallback={<FavoriteListSkeletonLoading />}
           rejectedFallback={<ErrorBoundaryUi />}

--- a/src/widgets/favorite/ui/favorite-dynamic-section.tsx
+++ b/src/widgets/favorite/ui/favorite-dynamic-section.tsx
@@ -9,12 +9,13 @@ import favoriteQueries from '../api/queries';
 
 function FavoriteDynamicSection() {
   const [value, setValue] = useState<Date>(new Date());
+  const [activeStartDate, setActiveStartDate] = useState<Date>(new Date());
 
   const yearMonth = useMemo(() => {
-    const year = value.getFullYear();
-    const month = String(value.getMonth() + 1).padStart(2, '0');
+    const year = activeStartDate.getFullYear();
+    const month = String(activeStartDate.getMonth() + 1).padStart(2, '0');
     return `${year}-${month}`;
-  }, [value]);
+  }, [activeStartDate]);
 
   const { data: favoriteRecruitments = [] } = useQuery(
     favoriteQueries.recruit(yearMonth),
@@ -25,6 +26,8 @@ function FavoriteDynamicSection() {
       <CustomCalendar
         value={value}
         setValue={setValue}
+        activeStartDate={activeStartDate}
+        setActiveStartDate={setActiveStartDate}
         data={favoriteRecruitments}
       />
       <div className="flex flex-col gap-4 lg:ml-4 lg:w-[400px]">


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #612

## 📝작업 내용

QA "달력 밤티 현상"(우선순위 중하) 대응 및 즐겨찾기 달력 UX 개선입니다.

- **회색 박스 높이 고정 해제**: `h-[574px]` 고정을 제거해 달력 줄 수(5·6줄)에 맞춰 높이가 가변적으로 조정됩니다.
- **이웃 달 날짜 색상 통일**: 주말 색상 `!important`가 react-calendar의 이웃 달 회색을 덮어 다음 달 주말만 진하게 보이던 문제를 수정, 이웃 달 날짜를 모두 회색으로 통일했습니다.
- **맥 폰트 렌더링 개선**: `body`에 `-webkit-font-smoothing: antialiased` 등을 적용해 맥 환경에서 글씨가 과하게 두꺼워지는 현상을 완화했습니다.
- **월 이동 하이라이팅 버그 수정**: 달을 넘길 때 매월 1일이 하이라이팅되던 문제를, "보는 달"(activeStartDate)과 "선택 날짜"(value)를 분리해 해결했습니다. 이제 선택 날짜 또는 오늘만 하이라이팅됩니다.
- **월 이동 슬라이드 애니메이션**: 회색 배경은 고정한 채, 달력 내용만 이동 방향에 따라 좌우로 슬라이드+페이드되도록 추가했습니다.
- **달력·광고 간격 추가**: 달력과 하단 광고가 붙어 있던 부분에 여백을 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> - `body`의 폰트 안티앨리어싱은 **전역 적용**이라 develop 병합 전 맥 환경에서 확인이 필요합니다. (윈도우 환경에서는 검증이 불가능한 부분)