### PR TITLE
[no-issue] chore: 디스코드 알림 봇 댓글 필터링

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -106,10 +106,10 @@ jobs:
 
   pr-comment:
     if: >
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       github.actor != 'github-actions[bot]') ||
-      github.event_name == 'pull_request_review_comment'
+      !endsWith(github.actor, '[bot]') &&
+      ((github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request) ||
+      github.event_name == 'pull_request_review_comment')
     runs-on: ubuntu-latest
     steps:
       - name: Send comment to PR thread
@@ -122,7 +122,7 @@ jobs:
           REPO="$GITHUB_REPOSITORY"
           AUTHOR=$(jq -r '.comment.user.login' "$GITHUB_EVENT_PATH")
 
-          if [ "$AUTHOR" = "github-actions[bot]" ]; then
+          if [[ "$AUTHOR" == *"[bot]" ]]; then
             exit 0
           fi
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> 없음

## 📝작업 내용
- 디스코드 PR 코멘트 알림에서 `[bot]`으로 끝나는 모든 봇 계정 필터링
- 기존: `github-actions[bot]`만 필터링
- 변경: Vercel, Codecov 등 모든 봇 댓글 무시 (job-level `if` + shell-level 이중 방어)