### PR TITLE
fix: 승인 후 재로그인 없이 동아리장 페이지 접근되도록 인가 조회 전환

### DIFF
--- a/src/app/[universityCode]/(admin)/admin/(edit)/layout.tsx
+++ b/src/app/[universityCode]/(admin)/admin/(edit)/layout.tsx
@@ -3,7 +3,7 @@ import Footer from '@/shared/ui/Footer';
 import 'to-do-pin/index.css';
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { getSession } from '@/shared/lib/cookie-session';
+import getCurrentUserRole from '@/shared/api/getCurrentUserRole';
 import { UserRole } from '@/shared/model/type';
 import AdminHeader from '@/shared/ui/AdminHeader';
 import {
@@ -44,9 +44,10 @@ export default async function AdminLayout({
   children: React.ReactNode;
   params: Promise<{ universityCode: string }>;
 }) {
-  const session = await getSession();
-  const role = session?.role;
   const { universityCode } = await params;
+
+  const { data } = await getCurrentUserRole();
+  const role = data?.role as UserRole | undefined;
 
   if (!role || !ALLOWED_ROLES.includes(role)) {
     redirect(`/${universityCode}`);

--- a/src/app/[universityCode]/(admin)/admin/(main)/layout.tsx
+++ b/src/app/[universityCode]/(admin)/admin/(main)/layout.tsx
@@ -3,7 +3,7 @@ import Footer from '@/shared/ui/Footer';
 import 'to-do-pin/index.css';
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { getSession } from '@/shared/lib/cookie-session';
+import getCurrentUserRole from '@/shared/api/getCurrentUserRole';
 import { UserRole } from '@/shared/model/type';
 import AdminHeader from '@/shared/ui/AdminHeader';
 import {
@@ -44,9 +44,10 @@ export default async function AdminLayout({
   children: React.ReactNode;
   params: Promise<{ universityCode: string }>;
 }) {
-  const session = await getSession();
-  const role = session?.role;
   const { universityCode } = await params;
+
+  const { data } = await getCurrentUserRole();
+  const role = data?.role as UserRole | undefined;
 
   if (!role || !ALLOWED_ROLES.includes(role)) {
     redirect(`/${universityCode}`);

--- a/src/app/api/users/role/route.ts
+++ b/src/app/api/users/role/route.ts
@@ -1,0 +1,8 @@
+/* eslint-disable import/prefer-default-export */
+import { NextResponse } from 'next/server';
+import getCurrentUserRole from '@/shared/api/getCurrentUserRole';
+
+export async function GET() {
+  const result = await getCurrentUserRole();
+  return NextResponse.json(result);
+}

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -118,7 +118,7 @@ async function MyPage({
           />
           {isAdmin && (
             <div className="mt-6 flex items-center gap-2">
-              <HeaderAdminLink role={userRole} isLoggedIn={!!session} />
+              <HeaderAdminLink isLoggedIn={!!session} />
               <Image src="/nextBlack.svg" alt="" width={8} height={12} />
             </div>
           )}

--- a/src/features/header/ui/header-admin-link.tsx
+++ b/src/features/header/ui/header-admin-link.tsx
@@ -1,30 +1,52 @@
 'use client';
 
-import useUniversityCode from '@/shared/hooks/useUniversityCode';
-
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-
 import { toast } from 'react-toastify';
-import { UserRole } from '@/shared/model/type';
+import useUniversityCode from '@/shared/hooks/useUniversityCode';
+import { ApiResponse, UserRole } from '@/shared/model/type';
 
 interface HeaderAdminLinkProps {
-  role?: UserRole;
   isLoggedIn: boolean;
 }
 
-function HeaderAdminLink({ role, isLoggedIn }: HeaderAdminLinkProps) {
-  const universityCode = useUniversityCode();
+const ALLOWED_ROLES = [
+  UserRole.GREEDY_ADMIN,
+  UserRole.CLUB_ADMIN,
+  UserRole.CLUB_MASTER,
+];
 
-  const handleClick = (e: React.MouseEvent) => {
+function HeaderAdminLink({ isLoggedIn }: HeaderAdminLinkProps) {
+  const universityCode = useUniversityCode();
+  const router = useRouter();
+  const [isChecking, setIsChecking] = useState(false);
+
+  const handleClick = async (e: React.MouseEvent) => {
+    e.preventDefault();
+
     if (!isLoggedIn) {
-      e.preventDefault();
       toast.info('로그인을 먼저 진행해 주세요.');
       return;
     }
 
-    if (role === UserRole.NORMAL) {
-      e.preventDefault();
+    if (isChecking) return;
+
+    setIsChecking(true);
+    try {
+      const response = await fetch('/api/users/role');
+      const body: ApiResponse<{ role: UserRole }> = await response.json();
+      const role = body.data?.role;
+
+      if (role && ALLOWED_ROLES.includes(role)) {
+        router.push(`/${universityCode}/admin`);
+      } else {
+        toast.warning('관리자 전용 페이지입니다!');
+      }
+    } catch {
       toast.warning('관리자 전용 페이지입니다!');
+    } finally {
+      setIsChecking(false);
     }
   };
 

--- a/src/shared/api/getCurrentUserRole.ts
+++ b/src/shared/api/getCurrentUserRole.ts
@@ -1,0 +1,18 @@
+import 'server-only';
+import api from '@/shared/api/auth-api';
+import createErrorResponse from '@/shared/lib/error-message';
+import { ApiResponse } from '@/shared/model/type';
+
+async function getCurrentUserRole() {
+  try {
+    const response = await api
+      .get('users/roles')
+      .json<ApiResponse<{ role: string }>>();
+
+    return { ok: true, message: '성공', data: response.data, status: 200 };
+  } catch (error) {
+    return createErrorResponse(error as Error);
+  }
+}
+
+export default getCurrentUserRole;

--- a/src/widgets/header/ui/header-menu-section.tsx
+++ b/src/widgets/header/ui/header-menu-section.tsx
@@ -16,7 +16,7 @@ interface HeaderMenuSectionProps {
 function HeaderMenuSection({ role, session }: HeaderMenuSectionProps) {
   return (
     <>
-      <HeaderAdminLink role={role} isLoggedIn={!!session} />
+      <HeaderAdminLink isLoggedIn={!!session} />
       <MobileHeader
         sessionRole={role}
         manageClubInfo={session?.manageClubInfo || []}


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #618

## 📝작업 내용

동아리 생성 신청 승인으로 권한이 NORMAL→CLUB_MASTER로 바뀌어도, 로그인 시점에 세션 쿠키에 캐싱된 role이 갱신되지 않아 동아리장(admin) 페이지 접근이 막히던 문제를 수정했습니다.
(QA "로그인 유지 시 동아리 승인에 따른 jwt 토큰 변화 없음", 우선순위: 중간)

백엔드 확인 결과 JWT에는 USER/ADMIN만 담기고 CLUB_MASTER 여부는 DB 조회로 판단하며, 권한 변경 시 accessToken을 재발급하지 않습니다. 따라서 프론트가 인가 시점에 최신 role을 서버에서 조회하도록 전환했습니다.

- **공용 서버 유틸 추가**: `getCurrentUserRole` — auth-api로 `users/roles`를 조회해 최신 role 반환.
- **admin 서버 레이아웃((main)/(edit))**: 캐싱된 `session.role` 대신 최신 조회 role로 인가 → 직접 URL 접근/새로고침 경로 해결.
- **헤더 "동아리 관리" 진입**: 클릭 시점에만 `/api/users/role`로 최신 role을 1회 조회해 인가 → 승인 유저 통과, 일반 유저는 기존 경고 토스트 유지. (페이지마다 조회하는 비용 없음)

> QA 상황상 이번 PR은 실제 차단 지점(admin 서버 레이아웃 + 헤더 클릭)만 조회로 바꾸는 부분 수정입니다. 전역 조회 전환(모바일 헤더 렌더 조건, /api/auth/session 클라 세션 role)은 후속으로 진행합니다.

### 스크린샷 (선택)