### PR TITLE
fix: 동아리 상세 페이지 모집 이력 API 실패 시 모집공고 content 미노출

### DIFF
--- a/src/views/club/ui/club-detail-page.tsx
+++ b/src/views/club/ui/club-detail-page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation';
 import RecruitDetailHeader from '@/entities/club-detail/ui/recruit-detail-header';
+import RecruitHistorySection from '@/entities/club-detail/ui/recruit-history-section';
 import ErrorBoundaryUi from '@/shared/ui/error-boundary-ui';
 import ClubDetailTabs from '@/widgets/club-detail/ui/club-detail-tabs';
 import getRecentRecruitDetail from '@/views/club/api/getRecentRecruitDetail';
@@ -16,20 +17,31 @@ async function ClubDetailPage({ params, searchParams }: ClubDetailPageProps) {
   const { id, universityCode } = await params;
   const { tab = 'recruit', recruit } = await searchParams;
 
-  const [recent, recruitHistories] = await Promise.all([
+  const [recentResult, recruitHistoriesResult] = await Promise.allSettled([
     getRecentRecruitDetail(Number(id)),
     getClubRecruitments(Number(id)),
   ]);
 
+  if (recentResult.status === 'rejected') return <ErrorBoundaryUi />;
+  const recent = recentResult.value;
+
   if (recent?.status === 404 || !recent.data) notFound();
   if (!recent.ok) return <ErrorBoundaryUi />;
 
-  const historiesArray = recruitHistories.ok
-    ? (recruitHistories.data?.recruitments ?? [])
-    : [];
-
   const recruitmentId = Number(recruit) || recent.data.id;
   const selected = await getRecruitDetail(recruitmentId);
+
+  const historySlot =
+    recruitHistoriesResult.status === 'rejected' ||
+    !recruitHistoriesResult.value.ok ? (
+      <ErrorBoundaryUi message="모집 이력을 불러오지 못했습니다." />
+    ) : (
+      <RecruitHistorySection
+        clubId={Number(id)}
+        recruitHistories={recruitHistoriesResult.value.data?.recruitments ?? []}
+        selectedRecruitId={recruitmentId}
+      />
+    );
 
   return (
     <>
@@ -49,22 +61,14 @@ async function ClubDetailPage({ params, searchParams }: ClubDetailPageProps) {
           isAlwaysRecruiting={recent.data.isAlwaysRecruiting}
         />
 
-        {historiesArray.length > 0 ? (
-          <ClubDetailTabs
-            activeTab={tab}
-            recruitData={selected.data}
-            recruitHistories={historiesArray}
-            clubId={Number(id)}
-            selectedRecruitmentId={recruitmentId}
-            universityCode={universityCode}
-          />
-        ) : (
-          <ClubDetailTabs
-            activeTab={tab}
-            clubId={Number(id)}
-            universityCode={universityCode}
-          />
-        )}
+        <ClubDetailTabs
+          activeTab={tab}
+          recruitData={selected.ok ? selected.data : undefined}
+          clubId={Number(id)}
+          selectedRecruitmentId={recruitmentId}
+          universityCode={universityCode}
+          historySlot={historySlot}
+        />
       </div>
     </>
   );

--- a/src/widgets/club-detail/ui/club-detail-tabs.tsx
+++ b/src/widgets/club-detail/ui/club-detail-tabs.tsx
@@ -1,8 +1,8 @@
+import { type ReactNode } from 'react';
 import Link from 'next/link';
 import ClubRecruitWidget from '@/widgets/club-detail/ui/club-recruit-widget';
 import ClubDescriptionWidget from '@/widgets/club-detail/ui/club-description-widget';
 import ClubCommentsWidget from '@/widgets/club-detail/ui/club-comments-widget';
-import { ClubRecruitments } from '@/entities/club-detail/model/type';
 import { RecruitStatus } from '@/shared/model/type';
 
 interface ActiveRecruitmentData {
@@ -22,10 +22,10 @@ interface ActiveRecruitmentData {
 interface ClubDetailTabsProps {
   activeTab: string;
   recruitData?: ActiveRecruitmentData;
-  recruitHistories?: ClubRecruitments[];
   clubId: number;
   selectedRecruitmentId?: number;
   universityCode: string;
+  historySlot?: ReactNode;
 }
 
 const TABS = [
@@ -37,10 +37,10 @@ const TABS = [
 function ClubDetailTabs({
   activeTab,
   recruitData,
-  recruitHistories,
   clubId,
   selectedRecruitmentId,
   universityCode,
+  historySlot,
 }: ClubDetailTabsProps) {
   const getHref = (key: string) => {
     const queryString = new URLSearchParams();
@@ -51,12 +51,7 @@ function ClubDetailTabs({
 
   const renderContent = () => {
     if (activeTab === 'recruit') {
-      if (
-        !recruitData ||
-        !recruitHistories ||
-        recruitHistories.length < 0 ||
-        !selectedRecruitmentId
-      ) {
+      if (!recruitData || !selectedRecruitmentId) {
         return (
           <p className="text-primary-500 py-20 text-center">
             모집공고가 없습니다.
@@ -66,8 +61,6 @@ function ClubDetailTabs({
 
       return (
         <ClubRecruitWidget
-          clubId={clubId}
-          recruitHistories={recruitHistories}
           selectedRecruitmentId={selectedRecruitmentId}
           recruitDetail={{
             title: recruitData.title,
@@ -80,6 +73,7 @@ function ClubDetailTabs({
             recruitEnd: recruitData.recruitEnd,
             status: recruitData.status,
           }}
+          historySlot={historySlot}
         />
       );
     }

--- a/src/widgets/club-detail/ui/club-recruit-widget.tsx
+++ b/src/widgets/club-detail/ui/club-recruit-widget.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
 import RecruitDetailView from '@/entities/club-detail/ui/recruit-detail-view';
-import RecruitHistorySection from '@/entities/club-detail/ui/recruit-history-section';
-import { ClubRecruitments } from '@/entities/club-detail/model/type';
 import NavigateRecruitForm from '@/features/club-detail/ui/navigate-recruit-form';
 import { RecruitStatus } from '@/shared/model/type';
 
@@ -19,17 +17,15 @@ interface RecruitDetail {
   status: RecruitStatus;
 }
 interface ClubRecruitWidgetProps {
-  clubId: number;
-  recruitHistories: ClubRecruitments[];
   selectedRecruitmentId: number;
   recruitDetail: RecruitDetail;
+  historySlot?: ReactNode;
 }
 
 function ClubRecruitWidget({
-  clubId,
-  recruitHistories,
   selectedRecruitmentId,
   recruitDetail,
+  historySlot,
 }: ClubRecruitWidgetProps) {
   const recruitHistoryRef = useRef<HTMLDivElement>(null);
   const fadeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -69,15 +65,9 @@ function ClubRecruitWidget({
         content={recruitDetail.content}
         recruitForm={recruitDetail.recruitForm}
         imageUrls={recruitDetail.imageUrls}
-        recentRecruitId={recruitHistories[0]?.id ?? selectedRecruitmentId}
+        recentRecruitId={selectedRecruitmentId}
       />
-      <div ref={recruitHistoryRef}>
-        <RecruitHistorySection
-          clubId={clubId}
-          recruitHistories={recruitHistories}
-          selectedRecruitId={selectedRecruitmentId}
-        />
-      </div>
+      <div ref={recruitHistoryRef}>{historySlot}</div>
       {mounted && (
         <div
           className="fixed right-2 bottom-5 z-50 transition-opacity duration-150 lg:right-[calc((100vw-60vw)/2+24px)] lg:bottom-14"


### PR DESCRIPTION
## #️⃣연관된 이슈
> closes #620

## 📝작업 내용
- `GET recruitments/club/{id}` API 500 에러 시 모집공고 content까지 미노출되던 문제 수정
- `Promise.allSettled`로 병렬 fetch하여 각 API 실패를 독립적으로 처리
- 모집 이력 실패 시 해당 섹션만 `ErrorBoundaryUi` 표시, 모집공고 content는 정상 렌더링
- `historySlot` 패턴으로 모집 이력 섹션 컴포넌트 합성 구조 개선
- `ClubDetailTabs` 가드 조건의 `recruitHistories.length < 0` 버그 제거

## 💬리뷰 요구사항(선택)
- 백엔드 `recruitments/club/{id}` API의 NPE 버그는 별도 수정 필요 (날짜 null인 모집 데이터)