### PR TITLE
refactor: 다른 학교 동아리 즐겨찾기 시도 시 알림 처리

### DIFF
--- a/src/shared/ui/favorite-button.tsx
+++ b/src/shared/ui/favorite-button.tsx
@@ -5,6 +5,7 @@ import { toast } from 'react-toastify';
 import throttle from 'lodash/throttle';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSession } from '@/shared/lib/session-context';
+import useUniversityCode from '@/shared/hooks/useUniversityCode';
 import FavoriteThread from './favorite-thread';
 import postFavorite from '../api/post-favorite';
 import deleteFavorite from '../api/delete-favorite';
@@ -25,12 +26,17 @@ function FavoriteButton({
   const [favorite, setFavorite] = useState(isFavorite);
   const { session } = useSession();
   const queryClient = useQueryClient();
+  const universityCode = useUniversityCode();
 
   const handleToggle = useMemo(
     () =>
       throttle(async () => {
         if (!session) {
           toast.error('로그인 후 이용하실 수 있습니다.');
+          return;
+        }
+        if (!favorite && session.universityCode !== universityCode) {
+          toast.error('다른 학교의 동아리는 즐겨찾기할 수 없습니다.');
           return;
         }
         const result = favorite
@@ -43,7 +49,7 @@ function FavoriteButton({
         setFavorite((prev) => !prev);
         queryClient.invalidateQueries({ queryKey: ['favorites'] });
       }, 600),
-    [favorite, session, clubId, queryClient],
+    [favorite, session, clubId, queryClient, universityCode],
   );
 
   return (


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #625 

## 📝작업 내용

- 로그인 유저의 학교 코드(session.universityCode)와 현재 URL의 학교 코드(useUniversityCode())를 비교해서, 즐겨찾기를 추가하려는 시점에 두 값이 다르면 API 호출 없이 "다른 학교의 동아리는 즐겨찾기할 수 없습니다." 토스트만 띄우고 막음. 
- 이미 즐겨찾기된 항목을 해제하는 경우는 이 체크를 타지 않아서 기존 즐겨찾기 목록 페이지 동작에는 영향 없음.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
