### PR TITLE
[#624] fix: 검색 폼 action에 대학코드 삽입

### DIFF
--- a/src/entities/home/ui/home-body.tsx
+++ b/src/entities/home/ui/home-body.tsx
@@ -1,11 +1,16 @@
+'use client';
+
 import Image from 'next/image';
+import useUniversityCode from '@/shared/hooks/useUniversityCode';
 
 function HomeSearchBar() {
+  const universityCode = useUniversityCode();
+
   return (
     <div className="mb-5 flex flex-col items-center py-5 lg:mb-[15px]">
       <div className="group relative w-[65%] lg:w-[80%]">
         <form
-          action="/search"
+          action={`/${universityCode}/search`}
           method="GET"
           className="flex items-center justify-between gap-1 pb-2 text-xs lg:text-xl"
         >

--- a/src/features/search/ui/search-input.tsx
+++ b/src/features/search/ui/search-input.tsx
@@ -1,13 +1,18 @@
+'use client';
+
 import Image from 'next/image';
+import useUniversityCode from '@/shared/hooks/useUniversityCode';
 import SaveClientInput from './save-client-input';
 
 function SearchInput() {
+  const universityCode = useUniversityCode();
+
   return (
     <div className="mt-10 flex w-[85%] justify-center lg:w-full">
       <div className="w-full lg:w-[43%]">
         <h1 className="mb-8 ml-2 text-3xl font-bold lg:ml-0">동아리 검색</h1>
         <form
-          action="/search"
+          action={`/${universityCode}/search`}
           method="GET"
           className="relative mx-auto w-[95%] lg:w-[80%]"
         >


### PR DESCRIPTION
## #️⃣연관된 이슈
> closes #624

## 📝작업 내용
- 메인 페이지(`home-body.tsx`) 및 검색 페이지(`search-input.tsx`)의 검색 폼 `action`이 `/search`로 하드코딩되어 있어 대학코드 없이 이동, notFound 페이지로 빠지는 버그 수정
- `useUniversityCode()` 훅을 사용하여 `action`을 `/{universityCode}/search`로 동적 생성하도록 변경