### PR TITLE
refactor: 대시보드에서 버튼의 네이밍을 단순화하고 안내문구를 추가하여 이해를 돕도록 수정

### DIFF
--- a/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
+++ b/src/widgets/admin/ui/ClubMasterApplicationWidget.tsx
@@ -145,8 +145,9 @@ function ClubMasterApplicationWidget({
           isActive={kindFilter === 'clubApplication'}
           onClick={() => setKindFilter('clubApplication')}
         >
-          동아리 생성 &amp; 동아리장
+          동아리 생성
         </SubTabButton>
+
         <SubTabButton
           isActive={kindFilter === 'clubMaster'}
           onClick={() => setKindFilter('clubMaster')}
@@ -154,6 +155,12 @@ function ClubMasterApplicationWidget({
           동아리장
         </SubTabButton>
       </div>
+
+      <p className="text-text-tertiary -mt-2 mb-5 text-sm">
+        {kindFilter === 'clubApplication'
+          ? '동아리의 기본정보를 확인하고 생성 승인을 해주세요. 생성 승인을 하면 신청자에게 동아리장 권한이 바로 부여됩니다.'
+          : '동아리 이름과 동아리장 신청자 이름을 확인하고 동아리장 승인을 해주세요. 승인을 하면 신청자에게 동아리장 권한이 바로 부여됩니다.'}
+      </p>
 
       <div className="flex flex-col gap-6">
         <div className="flex">


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes 627

## 📝작업 내용

- 대시보드에서 버튼의 네이밍을 단순화하고 안내문구를 추가하여 이해를 돕도록 수정

### 스크린샷 (선택)

<img width="1485" height="762" alt="image" src="https://github.com/user-attachments/assets/7c5b10d4-51b7-4528-b365-36047015a47d" />

<img width="1485" height="762" alt="image" src="https://github.com/user-attachments/assets/c08313fc-0fe5-4294-8089-09eff58b815a" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
