### PR TITLE
refactor: 동아리카드에 대해 동아리명이 길어지면 말줄임표

### DIFF
--- a/src/entities/club/ui/club-item.tsx
+++ b/src/entities/club/ui/club-item.tsx
@@ -40,14 +40,14 @@ function ClubItem({
     >
       <div className="flex w-full">
         <div className="flex w-full items-center gap-4">
-          <Avatar className="h-[54px] w-[54px]">
+          <Avatar className="h-[54px] w-[54px] shrink-0">
             <AvatarImage src={logo} alt={logo} />
             <AvatarFallback />
           </Avatar>
 
-          <div className="flex flex-1 flex-col gap-1">
-            <div className="flex items-center gap-2">
-              <h1 className="text-text-primary text-[20px] leading-none font-bold whitespace-nowrap">
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="flex min-w-0 items-center gap-2">
+              <h1 className="text-text-primary min-w-0 flex-1 truncate text-[20px] leading-none font-bold">
                 {name}
               </h1>
 
@@ -56,12 +56,13 @@ function ClubItem({
                   isFavorite={isFavorite}
                   clubId={id}
                   customClass="scale-100 mt-1"
+                  wrapperClass="shrink-0"
                 />
               )}
               {recruitStatus && (
                 <RadiusTag
                   recruitStatus={recruitStatus}
-                  className="absolute top-8 right-5 shrink-0 px-3 py-2 text-xs"
+                  className="shrink-0 px-3 py-2 text-xs"
                 />
               )}
             </div>

--- a/src/entities/club/ui/club-item.tsx
+++ b/src/entities/club/ui/club-item.tsx
@@ -45,7 +45,7 @@ function ClubItem({
             <AvatarFallback />
           </Avatar>
 
-          <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex min-w-0 flex-1 flex-col">
             <div className="flex min-w-0 items-center gap-2">
               <h1 className="text-text-primary min-w-0 flex-1 truncate text-[20px] leading-none font-bold">
                 {name}


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #630 

## 📝작업 내용

- 동아리명이 길 경우 카드 밖으로 넘치지 않고 말줄임표(...)로 잘리도록 처리
- 모집 상태 배지가 absolute 포지셔닝으로 고정돼 있어, 이름이 길어지면 하트 아이콘 위에 겹쳐 보이던 문제 발견 및 수정
-> 배지를 절대 위치에서 flex 레이아웃 안의 일반 요소로 변경
-> 아바타 · 하트 · 배지는 shrink-0으로 크기 고정, 이름만 남은 공간을 채우다가 줄어들도록 처리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
