### PR TITLE
refactor: 피드백 모달 데탑 버전에서는 하단 여백 줄이기

### DIFF
--- a/src/shared/ui/scroll-top-button.tsx
+++ b/src/shared/ui/scroll-top-button.tsx
@@ -10,7 +10,7 @@ export default function ScrollTopButton() {
   return isVisible ? (
     <Link
       href="#top"
-      className="fixed right-6 bottom-25 z-50 flex h-[50px] w-[50px] cursor-pointer items-center justify-center rounded-full bg-white shadow-lg"
+      className="fixed right-6 bottom-25 z-50 flex h-[50px] w-[50px] cursor-pointer items-center justify-center rounded-full bg-white shadow-lg lg:bottom-10"
     >
       <Image src="/recruit/up.svg" alt="Scroll to top" width={20} height={20} />
     </Link>

--- a/src/widgets/feedback/ui/feedback-modal.tsx
+++ b/src/widgets/feedback/ui/feedback-modal.tsx
@@ -88,7 +88,7 @@ function FeedbackModal() {
         </div>
       )}
       {isOpen && isVisible && (
-        <div className="fixed right-23 bottom-25 z-50 hidden w-85 sm:block">
+        <div className="fixed right-23 bottom-25 z-50 hidden w-85 sm:block lg:bottom-10">
           {content}
         </div>
       )}


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #632 

## 📝작업 내용

- 피드백 모달과 스크롤탑버튼 두개 모두 기존에는 bottom-25만 있었는데 lg:bottom-10을 추가하여 여백을 줄였습니다.

### 스크린샷 (선택)
<img width="1485" height="762" alt="image" src="https://github.com/user-attachments/assets/b8491142-f6a2-4587-9c73-6436fd97c33b" />
-> 이제 살짝 버튼 보입니다~


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
