### PR TITLE
[#634] fix: 즐겨찾기 시 학교 코드 비교 오류 수정

### DIFF
--- a/src/shared/ui/favorite-button.tsx
+++ b/src/shared/ui/favorite-button.tsx
@@ -6,6 +6,7 @@ import throttle from 'lodash/throttle';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSession } from '@/shared/lib/session-context';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
+import { urlCodeToApiCode } from '@/shared/lib/universityMeta';
 import FavoriteThread from './favorite-thread';
 import postFavorite from '../api/post-favorite';
 import deleteFavorite from '../api/delete-favorite';
@@ -35,7 +36,10 @@ function FavoriteButton({
           toast.error('로그인 후 이용하실 수 있습니다.');
           return;
         }
-        if (!favorite && session.universityCode !== universityCode) {
+        if (
+          !favorite &&
+          session.universityCode !== urlCodeToApiCode(universityCode)
+        ) {
           toast.error('다른 학교의 동아리는 즐겨찾기할 수 없습니다.');
           return;
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #634 

## 📝작업 내용
- URL의 학교 코드(소문자)와 세션의 학교 코드(대문자)를 그대로 비교해 같은 학교여도 다른 학교로 판정되어 즐겨찾기가 전부 막히던 문제 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
