### PR TITLE
chore: 동아리 로고 이미지가 Next 이미지 최적화 라우트를 거치도록 수정

### DIFF
--- a/src/shared/ui/avatar.tsx
+++ b/src/shared/ui/avatar.tsx
@@ -23,11 +23,18 @@ function Avatar({
 
 function AvatarImage({
   className,
+  src,
   ...props
 }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  const optimizedSrc =
+    typeof src === 'string'
+      ? `/_next/image?url=${encodeURIComponent(src)}&w=128&q=75`
+      : src;
+
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
+      src={optimizedSrc}
       className={cn('aspect-square size-full object-cover', className)}
       {...props}
     />


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #640

## 📝작업 내용

공용 Avatar 컴포넌트(`shared/ui/avatar.tsx`)가 Radix UI의 순정 `<img>`를 사용해서, 실제 표시 크기(24~72px)와 무관하게 S3 원본 이미지(최대 2275x2275, 최대 922KB)를 그대로 다운로드하고 있었습니다. Lighthouse에서 다수의 동아리 로고 이미지에 대해 "표시 크기 대비 이미지가 너무 큼" 경고로 확인됐습니다.

`AvatarImage`에 전달되는 src를 Next.js 내장 이미지 최적화 라우트(`/_next/image?url=...&w=128&q=75`)를 거치도록 수정했습니다. Radix의 로딩/에러 상태에 따른 Fallback 전환 로직은 그대로 유지되며, club-item, favorite-item, card-slider(메인 화면 동아리 슬라이더) 등 이 컴포넌트를 쓰는 13곳 전체에 동일하게 적용됩니다.

실측: 원본 52.3KiB → 최적화 후 943 bytes (로컬 dev 서버 기준, 약 98% 감소)

### 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

`w=128` 고정값으로 잡았는데, 실제 아바타 사용 크기가 24~72px로 다양합니다. 레티나 디스플레이 감안해서 최대 사용처(72px) 기준으로 잡았습니다.