### PR TITLE
refactor: clientApi가 prefixUrl 대신 절대경로로 same-origin 요청하도록 변경 (#643)

### DIFF
--- a/src/shared/api/client-api.ts
+++ b/src/shared/api/client-api.ts
@@ -1,7 +1,7 @@
 import ky from 'ky';
 
 const clientApi = ky.create({
-  prefixUrl: process.env.NEXT_PUBLIC_BASE_URL,
+  prefixUrl: '/',
   hooks: {
     beforeRequest: [
       () => {


### PR DESCRIPTION
* [#642] refactor: clientApi가 prefixUrl 대신 절대경로로 same-origin 요청하도록 변경



* [#642] refactor: clientApi가 절대경로 대신 prefixUrl로 same-origin 요청하도록 변경



---------

## #️⃣연관된 이슈

> ex) closes #이슈번호, closes #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
