### PR TITLE
feat: 클럽 목록 페이지네이션 prefetch 적용

### DIFF
--- a/src/shared/hooks/useNumberPagination.ts
+++ b/src/shared/hooks/useNumberPagination.ts
@@ -1,0 +1,87 @@
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+type PaginationPage = number | 'ellipsis-start' | 'ellipsis-end';
+
+function getPaginationPages(
+  currentPage: number,
+  totalPages: number,
+  pageRange: number,
+): PaginationPage[] {
+  const pages: PaginationPage[] = [];
+  if (totalPages <= pageRange) {
+    for (let page = 1; page <= totalPages; page += 1) pages.push(page);
+    return pages;
+  }
+
+  const halfRange = Math.floor(pageRange / 2);
+  let startPage = currentPage - halfRange;
+  let endPage = currentPage + halfRange;
+
+  if (startPage < 1) {
+    startPage = 1;
+    endPage = pageRange;
+  }
+  if (endPage > totalPages) {
+    endPage = totalPages;
+    startPage = totalPages - pageRange + 1;
+  }
+
+  if (startPage > 1) pages.push(1);
+  if (startPage > 2) pages.push('ellipsis-start');
+
+  for (let page = startPage; page <= endPage; page += 1) pages.push(page);
+
+  if (endPage < totalPages - 1) pages.push('ellipsis-end');
+  if (endPage < totalPages) pages.push(totalPages);
+
+  return pages;
+}
+
+interface Params {
+  page: number;
+  totalPages: number;
+  pageRange?: number;
+  prefetchNext?: boolean;
+}
+
+function useNumberPagination({
+  page,
+  totalPages,
+  pageRange = 5,
+  prefetchNext = true,
+}: Params) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const safeTotalPages = Math.max(1, totalPages);
+  const safePage = Math.min(Math.max(1, page), safeTotalPages);
+  const pages = getPaginationPages(safePage, safeTotalPages, pageRange);
+
+  const canGoPrev = safePage > 1;
+  const canGoNext = safePage < safeTotalPages;
+
+  const buildPageUrl = (nextPage: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.delete('page');
+    params.set('page', String(nextPage));
+    return `?${params.toString()}`;
+  };
+
+  const moveToPage = (nextPage: number) => {
+    router.push(buildPageUrl(nextPage), { scroll: true });
+  };
+
+  useEffect(() => {
+    if (prefetchNext && canGoNext) {
+      router.prefetch(buildPageUrl(safePage + 1));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [safePage, canGoNext, prefetchNext]);
+
+  return { pages, safePage, canGoPrev, canGoNext, moveToPage };
+}
+
+export default useNumberPagination;
+export type { PaginationPage };

--- a/src/shared/hooks/useNumberPagination.ts
+++ b/src/shared/hooks/useNumberPagination.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 type PaginationPage = number | 'ellipsis-start' | 'ellipsis-end';
@@ -53,6 +53,7 @@ function useNumberPagination({
 }: Params) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const searchParamsString = searchParams.toString();
 
   const safeTotalPages = Math.max(1, totalPages);
   const safePage = Math.min(Math.max(1, page), safeTotalPages);
@@ -61,13 +62,16 @@ function useNumberPagination({
   const canGoPrev = safePage > 1;
   const canGoNext = safePage < safeTotalPages;
 
-  const buildPageUrl = (nextPage: number) => {
-    const params = new URLSearchParams(searchParams.toString());
+  const buildPageUrl = useCallback(
+    (nextPage: number) => {
+      const params = new URLSearchParams(searchParamsString);
 
-    params.delete('page');
-    params.set('page', String(nextPage));
-    return `?${params.toString()}`;
-  };
+      params.delete('page');
+      params.set('page', String(nextPage));
+      return `?${params.toString()}`;
+    },
+    [searchParamsString],
+  );
 
   const moveToPage = (nextPage: number) => {
     router.push(buildPageUrl(nextPage), { scroll: true });
@@ -77,8 +81,7 @@ function useNumberPagination({
     if (prefetchNext && canGoNext) {
       router.prefetch(buildPageUrl(safePage + 1));
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [safePage, canGoNext, prefetchNext]);
+  }, [safePage, canGoNext, prefetchNext, buildPageUrl, router]);
 
   return { pages, safePage, canGoPrev, canGoNext, moveToPage };
 }

--- a/src/shared/ui/numberPagination.tsx
+++ b/src/shared/ui/numberPagination.tsx
@@ -1,45 +1,8 @@
 'use client';
 
 import React from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
 import cn from '@/shared/lib/utils';
-
-type PaginationPage = number | 'ellipsis';
-
-function getPaginationPages(
-  currentPage: number,
-  totalPages: number,
-  pageRange = 5,
-): PaginationPage[] {
-  const pages: PaginationPage[] = [];
-  if (totalPages <= pageRange) {
-    for (let page = 1; page <= totalPages; page += 1) pages.push(page);
-    return pages;
-  }
-
-  const halfRange = Math.floor(pageRange / 2);
-  let startPage = currentPage - halfRange;
-  let endPage = currentPage + halfRange;
-
-  if (startPage < 1) {
-    startPage = 1;
-    endPage = pageRange;
-  }
-  if (endPage > totalPages) {
-    endPage = totalPages;
-    startPage = totalPages - pageRange + 1;
-  }
-
-  if (startPage > 1) pages.push(1);
-  if (startPage > 2) pages.push('ellipsis');
-
-  for (let page = startPage; page <= endPage; page += 1) pages.push(page);
-
-  if (endPage < totalPages - 1) pages.push('ellipsis');
-  if (endPage < totalPages) pages.push(totalPages);
-
-  return pages;
-}
+import useNumberPagination from '@/shared/hooks/useNumberPagination';
 
 type Props = {
   page: number;
@@ -52,25 +15,8 @@ export default function NumberPagination({
   totalPages,
   pageRange = 5,
 }: Props) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  const safeTotalPages = Math.max(1, totalPages);
-  const safePage = Math.min(Math.max(1, page), safeTotalPages);
-  const pages = getPaginationPages(safePage, safeTotalPages, pageRange);
-
-  const moveToPage = (nextPage: number) => {
-    const params = new URLSearchParams(searchParams.toString());
-
-    params.delete('page');
-    params.set('page', String(nextPage));
-    router.push(`?${params.toString()}`, { scroll: true });
-  };
-
-  const canGoPrev = safePage > 1;
-  const canGoNext = safePage < safeTotalPages;
-
-  let ellipsisIndex = 0;
+  const { pages, safePage, canGoPrev, canGoNext, moveToPage } =
+    useNumberPagination({ page, totalPages, pageRange });
 
   return (
     <nav
@@ -93,13 +39,9 @@ export default function NumberPagination({
 
       <div className="flex items-center gap-4 text-3xl">
         {pages.map((pageItem) => {
-          if (pageItem === 'ellipsis') {
-            ellipsisIndex += 1;
+          if (pageItem === 'ellipsis-start' || pageItem === 'ellipsis-end') {
             return (
-              <span
-                key={`ellipsis-${ellipsisIndex}`}
-                className="text-base text-[#BDBDBD]"
-              >
+              <span key={pageItem} className="text-base text-[#BDBDBD]">
                 <img src="/pagination/ellipses.svg" alt="말줄임" />
               </span>
             );


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #646

## 📝작업 내용

클럽 목록 페이지네이션 클릭 시 체감 전환 속도를 개선하기 위해 다음 페이지를 미리 `router.prefetch()`로 받아오도록 했습니다. 또한 `NumberPagination` 컴포넌트에 섞여있던 페이지 계산/이동/prefetch 로직을 `useNumberPagination` 훅으로 분리해, 컴포넌트는 마크업 조립만 담당하도록 정리했습니다.

- `router.prefetch()`로 다음 페이지(있을 경우) prefetch — 이전 페이지는 이미 방문 이력으로 캐시되어 있어 제외
- `prefetchNext` 옵션으로 prefetch on/off 제어 가능
- ellipsis 렌더링 key를 `ellipsis-start`/`ellipsis-end`로 구분해 유일성 문제 해결 (기존엔 mutable 카운터로 처리)

### 스크린샷 (선택)

동작 자체는 페이지네이션 UI 변경 없음 (내부 로직/성능 개선)

## 💬리뷰 요구사항(선택)

`useNumberPagination` 훅의 prefetch 시점(페이지 렌더 시 다음 페이지 prefetch)이 적절한지, 그리고 prefetch로 인한 불필요한 요청 증가가 우려되는 부분이 있는지 봐주시면 좋겠습니다.