### PR TITLE
refactor: ClubDetailTabs 탭 키 타입 안전성 개선

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ CSS tokens: `src/app/theme.css` / Animations: `src/app/globals.css`
 7. **No abbreviated naming**: Use full words. (`btn` → `button`, `idx` → `index`)
 8. **Server/Client separation**: Default to Server Component if no interaction. Use `'use client'` if `useState`/`useEffect`/event handlers exist.
 9. **No raw fetch**: Always use ky for HTTP requests. Never use fetch directly.
+10. **No magic strings for fixed value sets**: When a value can only be one of a known fixed set (tab keys, status values, etc.), define it as an `as const` array/object and derive a union type from it, instead of typing the field as plain `string`. Prevents typos from silently passing type checks.
 
 ## Commit Rules
 

--- a/src/widgets/club-detail/ui/club-detail-tabs.tsx
+++ b/src/widgets/club-detail/ui/club-detail-tabs.tsx
@@ -19,6 +19,18 @@ interface ActiveRecruitmentData {
   status: RecruitStatus;
 }
 
+const TABS = [
+  { key: 'recruit', label: '모집공고' },
+  { key: 'about', label: '동아리 소개' },
+  { key: 'comments', label: '댓글' },
+] as const;
+
+type TabKey = (typeof TABS)[number]['key'];
+
+function isTabKey(value: string): value is TabKey {
+  return TABS.some((tab) => tab.key === value);
+}
+
 interface ClubDetailTabsProps {
   activeTab: string;
   recruitData?: ActiveRecruitmentData;
@@ -28,12 +40,6 @@ interface ClubDetailTabsProps {
   historySlot?: ReactNode;
 }
 
-const TABS = [
-  { key: 'recruit', label: '모집공고' },
-  { key: 'about', label: '동아리 소개' },
-  { key: 'comments', label: '댓글' },
-];
-
 function ClubDetailTabs({
   activeTab,
   recruitData,
@@ -42,7 +48,9 @@ function ClubDetailTabs({
   universityCode,
   historySlot,
 }: ClubDetailTabsProps) {
-  const getHref = (key: string) => {
+  const currentTab: TabKey = isTabKey(activeTab) ? activeTab : 'recruit';
+
+  const buildTabHref = (key: TabKey) => {
     const queryString = new URLSearchParams();
     queryString.set('recruit', String(selectedRecruitmentId));
     if (key !== 'recruit') queryString.set('tab', key);
@@ -50,56 +58,58 @@ function ClubDetailTabs({
   };
 
   const renderContent = () => {
-    if (activeTab === 'recruit') {
-      if (!recruitData || !selectedRecruitmentId) {
+    switch (currentTab) {
+      case 'recruit': {
+        if (!recruitData || !selectedRecruitmentId) {
+          return (
+            <p className="text-primary-500 py-20 text-center">
+              모집공고가 없습니다.
+            </p>
+          );
+        }
+
         return (
-          <p className="text-primary-500 py-20 text-center">
-            모집공고가 없습니다.
-          </p>
+          <ClubRecruitWidget
+            selectedRecruitmentId={selectedRecruitmentId}
+            recruitDetail={{
+              title: recruitData.title,
+              clubName: recruitData.clubName,
+              category: recruitData.category,
+              content: recruitData.content,
+              recruitForm: recruitData.recruitForm,
+              imageUrls: recruitData.imageUrls,
+              recruitStart: recruitData.recruitStart,
+              recruitEnd: recruitData.recruitEnd,
+              status: recruitData.status,
+            }}
+            historySlot={historySlot}
+          />
         );
       }
 
-      return (
-        <ClubRecruitWidget
-          selectedRecruitmentId={selectedRecruitmentId}
-          recruitDetail={{
-            title: recruitData.title,
-            clubName: recruitData.clubName,
-            category: recruitData.category,
-            content: recruitData.content,
-            recruitForm: recruitData.recruitForm,
-            imageUrls: recruitData.imageUrls,
-            recruitStart: recruitData.recruitStart,
-            recruitEnd: recruitData.recruitEnd,
-            status: recruitData.status,
-          }}
-          historySlot={historySlot}
-        />
-      );
-    }
+      case 'about':
+        return <ClubDescriptionWidget clubId={clubId} />;
 
-    if (activeTab === 'about') {
-      return <ClubDescriptionWidget clubId={clubId} />;
-    }
+      case 'comments':
+        return <ClubCommentsWidget clubId={clubId} />;
 
-    if (activeTab === 'comments') {
-      return <ClubCommentsWidget clubId={clubId} />;
+      default: {
+        const exhaustiveCheck: never = currentTab;
+        return exhaustiveCheck;
+      }
     }
-
-    return null;
   };
 
   return (
     <div className="mt-8 lg:mt-12">
       <div className="sticky top-0 z-30 mb-8 flex justify-center border-b border-b-[#D6D6D6] bg-white py-5 pb-3 lg:mb-12">
         {TABS.map((tab) => {
-          const isSelected = tab.key === activeTab;
+          const isSelected = tab.key === currentTab;
 
           return (
             <Link
               key={tab.key}
-              href={getHref(tab.key)}
-              prefetch={false}
+              href={buildTabHref(tab.key)}
               className="data-[selected=true]:text-primary-500 relative flex-1 text-center text-sm font-medium text-[#9C9C9C] lg:text-lg"
               data-selected={isSelected}
             >


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #648

## 📝작업 내용

`ClubDetailTabs`의 `activeTab`이 단순 `string`이라 오타나 잘못된 쿼리파라미터(`?tab=`)가 와도 컴파일 타임에 잡히지 않고 조용히 빈 화면을 렌더링하던 문제를 개선했습니다. 또한 `renderContent`가 if 체인이라 탭이 추가돼도 케이스 누락을 잡아주지 못하던 부분도 함께 고쳤습니다.

- `TABS`를 `as const`로 고정하고 `TabKey` 유니언 타입 추출
- `isTabKey` 타입가드로 URL에서 온 raw `activeTab` 문자열을 런타임 검증 후 안전하게 좁힘 (잘못된 값은 `'recruit'`로 폴백)
- `renderContent`를 `switch` + exhaustive check(`never`)로 변경해, 탭이 추가됐는데 케이스 처리를 빠뜨리면 컴파일 에러로 감지되도록 함
- `getHref` → `buildTabHref`로 함수명 변경 (역할이 더 명확하게)
- `CLAUDE.md`에 "고정된 값 집합은 `as const` + 유니언 타입으로 정의" 컨벤션 추가

### 스크린샷 (선택)

UI 변경 없음 (타입/로직 개선)

## 💬리뷰 요구사항(선택)

`isTabKey` 폴백 처리(잘못된 tab 값이면 `'recruit'`로 대체)가 UX상 적절한지 봐주시면 좋겠습니다.