### PR TITLE
refactor: 클라이언트 URL 쿼리 파라미터를 nuqs로 통일

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { ToDoPinProvider } from 'to-do-pin';
 import { AppSessionProvider } from '@/shared/lib/session-context';
 import { ToastContainer } from 'react-toastify';
 import MSWProvider from '@/_providers/msw-provider';
+import { NuqsAdapter } from 'nuqs/adapters/next/app';
 
 const pretendard = localFont({
   src: [
@@ -78,22 +79,24 @@ export default function RootLayout({
         <ClarityProvider />
       </head>
       <body className={`${pretendard.className} scrollbar-hide`}>
-        <MSWProvider>
-          <AppSessionProvider>
-            <ToDoPinProvider>
-              <WebVitalProvider />
-              <ToastContainer
-                autoClose={2000}
-                hideProgressBar
-                closeOnClick
-                pauseOnHover={false}
-                newestOnTop
-                limit={1}
-              />
-              {children}
-            </ToDoPinProvider>
-          </AppSessionProvider>
-        </MSWProvider>
+        <NuqsAdapter>
+          <MSWProvider>
+            <AppSessionProvider>
+              <ToDoPinProvider>
+                <WebVitalProvider />
+                <ToastContainer
+                  autoClose={2000}
+                  hideProgressBar
+                  closeOnClick
+                  pauseOnHover={false}
+                  newestOnTop
+                  limit={1}
+                />
+                {children}
+              </ToDoPinProvider>
+            </AppSessionProvider>
+          </MSWProvider>
+        </NuqsAdapter>
       </body>
     </html>
   );

--- a/src/entities/club/ui/club-category-button-section.tsx
+++ b/src/entities/club/ui/club-category-button-section.tsx
@@ -8,7 +8,7 @@ import {
 import Image from 'next/image';
 import { Button } from '@/shared/ui/button';
 import cn from '@/shared/lib/utils';
-import { useRouter, useSearchParams } from 'next/navigation';
+import useUrlParams from '@/shared/model/useUrlParams';
 
 const categories: ClubCategory[] = [
   ClubCategory.CULTURAL_ART,
@@ -20,23 +20,7 @@ const categories: ClubCategory[] = [
 ];
 
 function ClubCategoryButtonSection() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const active = searchParams.get('category') ?? '';
-
-  const changeCategory = (value: string) => {
-    const params = new URLSearchParams(searchParams);
-
-    if (value === '') {
-      params.delete('category');
-    } else {
-      params.set('category', value);
-    }
-
-    params.set('page', '1');
-
-    router.push(`?${params.toString()}`);
-  };
+  const { active, handleChange: changeCategory } = useUrlParams('category');
 
   return (
     <div className="scrollbar-hide flex gap-1 overflow-x-auto pb-1 sm:gap-2">

--- a/src/entities/club/ui/clubpage-searchbar.tsx
+++ b/src/entities/club/ui/clubpage-searchbar.tsx
@@ -1,32 +1,31 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
+import { parseAsInteger, parseAsString, useQueryState } from 'nuqs';
 import { useState, useEffect } from 'react';
 
 function ClubPageSearchbar() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const [keyword, setKeyword] = useState('');
+  const [keyword, setKeyword] = useQueryState(
+    'keyword',
+    parseAsString
+      .withDefault('')
+      .withOptions({ shallow: false, history: 'push' }),
+  );
+  const [, setPage] = useQueryState(
+    'page',
+    parseAsInteger.withOptions({ shallow: false, history: 'push' }),
+  );
+  const [inputValue, setInputValue] = useState(keyword);
 
   useEffect(() => {
-    setKeyword(searchParams.get('keyword') ?? '');
-  }, [searchParams]);
+    setInputValue(keyword);
+  }, [keyword]);
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    const params = new URLSearchParams(searchParams);
-
-    const q = keyword.trim();
-    if (!q) {
-      params.delete('keyword');
-    } else {
-      params.set('keyword', q);
-    }
-
-    params.set('page', '1');
-
-    router.push(`?${params.toString()}`);
+    const q = inputValue.trim();
+    setKeyword(q || null);
+    setPage(1);
   };
 
   return (
@@ -38,8 +37,8 @@ function ClubPageSearchbar() {
         >
           <input
             type="text"
-            value={keyword}
-            onChange={(e) => setKeyword(e.target.value)}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
             name="keyword"
             placeholder="어떤 동아리를 찾고 계신가요?"
             className="w-[90%] text-xs placeholder-gray-300 outline-none sm:text-base"

--- a/src/features/search/ui/save-client-input.tsx
+++ b/src/features/search/ui/save-client-input.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
+import { parseAsString, useQueryState } from 'nuqs';
 
 function SaveClientInput() {
-  const searchParams = useSearchParams();
-  const query = searchParams.get('q') || '';
+  const [query] = useQueryState('q', parseAsString.withDefault(''));
 
   return (
     <input

--- a/src/shared/model/useUrlParams.tsx
+++ b/src/shared/model/useUrlParams.tsx
@@ -1,22 +1,24 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
+import { parseAsInteger, parseAsString, useQueryState } from 'nuqs';
 
 function useUrlParams(key: string) {
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const active = searchParams.get(key) ?? '';
+  const [rawActive, setRawActive] = useQueryState(
+    key,
+    parseAsString
+      .withDefault('')
+      .withOptions({ shallow: false, history: 'push' }),
+  );
+  const [, setPage] = useQueryState(
+    'page',
+    parseAsInteger.withOptions({ shallow: false, history: 'push' }),
+  );
+
+  const active = rawActive.toUpperCase();
 
   const handleChange = (value: string) => {
-    const newParams = new URLSearchParams(searchParams);
-
-    if (value === 'ALL' || value === '') {
-      newParams.delete(key);
-    } else {
-      newParams.set(key, value);
-    }
-
-    router.push(`?${newParams.toString()}`);
+    setRawActive(value === 'ALL' || value === '' ? null : value.toLowerCase());
+    setPage(1);
   };
 
   return { handleChange, active };

--- a/src/shared/ui/affiliation-nav-select.tsx
+++ b/src/shared/ui/affiliation-nav-select.tsx
@@ -2,32 +2,17 @@
 
 import React from 'react';
 import { ClubAffiliation, ClubAffiliationLabel } from '@/shared/model/type';
-import { useRouter, useSearchParams } from 'next/navigation';
+import useUrlParams from '@/shared/model/useUrlParams';
 
 function AffiliationNavSelect() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const active = searchParams.get('affiliation') ?? '';
+  const { active, handleChange: changeAffiliation } =
+    useUrlParams('affiliation');
 
   const affiliations = [
     ClubAffiliation.CENTRAL_CLUB,
     ClubAffiliation.DEPARTMENT_CLUB,
     ClubAffiliation.SMALL_GROUP,
   ];
-
-  const changeAffiliation = (value: string) => {
-    const params = new URLSearchParams(searchParams);
-
-    if (value === '') {
-      params.delete('affiliation');
-    } else {
-      params.set('affiliation', value);
-    }
-
-    params.set('page', '1');
-
-    router.push(`?${params.toString()}`);
-  };
 
   return (
     <div className="mb-5 flex gap-4 text-sm sm:mb-12 sm:text-base">

--- a/src/widgets/club/ui/club-item-list.tsx
+++ b/src/widgets/club/ui/club-item-list.tsx
@@ -9,8 +9,8 @@ import ClubItemClientList from './club-item-client-list';
 async function ClubItemList({ universityCode }: { universityCode: string }) {
   const page = Number(searchParamsCache.get('page') ?? 1);
   const size = 15;
-  const category = searchParamsCache.get('category');
-  const affiliation = searchParamsCache.get('affiliation');
+  const category = searchParamsCache.get('category').toUpperCase();
+  const affiliation = searchParamsCache.get('affiliation').toUpperCase();
   const keyword = searchParamsCache.get('keyword');
   const clubListResponse = await getClubList({
     page,

--- a/src/widgets/favorite/ui/favorite-item-section.tsx
+++ b/src/widgets/favorite/ui/favorite-item-section.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
+import { parseAsInteger, useQueryState } from 'nuqs';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import favoriteQueries from '../api/queries';
 import FavoriteItemList from './favorite-item-list';
 
 function FavoriteItemSection() {
-  const searchParams = useSearchParams();
-  const page = Number(searchParams.get('page')) || 1;
-  const size = Number(searchParams.get('size')) || 6;
+  const [page] = useQueryState('page', parseAsInteger.withDefault(1));
+  const [size] = useQueryState('size', parseAsInteger.withDefault(6));
 
   const { data } = useSuspenseQuery(favoriteQueries.list({ page, size }));
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #650

## 📝작업 내용

nuqs가 서버 쪽(searchParamsCache)에만 쓰이고 클라이언트에서는 `useSearchParams` + 수동 `URLSearchParams` 조합으로 중복 구현되어 있던 부분을 `useQueryState` 기반으로 통일했습니다.

- 앱 전체를 `NuqsAdapter`로 감싸서 nuqs 클라이언트 훅을 쓸 수 있도록 설정 (`layout.tsx`)
- `useUrlParams`(공용 훅), `ClubCategoryButtonSection`, `AffiliationNavSelect`, `ClubPageSearchbar`를 `useQueryState` 기반으로 리팩토링하고, 미사용 상태였던 `useUrlParams`를 실제로 재사용하도록 연결
- `category`/`affiliation` 필터 값을 URL에 소문자로 저장하도록 통일 (검색 페이지가 이미 소문자 컨벤션을 쓰고 있어서 일관성 맞춤) — 서버(`club-item-list.tsx`)에서는 다시 대문자로 변환해 백엔드로 전달
- `SaveClientInput`, `FavoriteItemSection`도 동일하게 전환

각 페이지(`useSearchParams` → `useQueryState` 전환 시) RSC 재요청이 정상적으로 트리거되도록 `shallow: false`, 기존과 동일하게 새 history entry가 쌓이도록 `history: 'push'` 옵션을 명시했습니다.

### 스크린샷 (선택)

UI 변경 없음 (내부 상태 관리 방식 변경)

## 💬리뷰 요구사항(선택)

`category`/`affiliation`을 URL에서 소문자로 바꾼 게 기존 북마크된 링크(대문자 값)와의 호환성에 문제 없는지 봐주시면 좋겠습니다.