### PR TITLE
feat: 즐겨찾기 목록 서버 prefetch + dehydrate 적용

### DIFF
--- a/src/app/[universityCode]/(main)/favorite/page.tsx
+++ b/src/app/[universityCode]/(main)/favorite/page.tsx
@@ -1,7 +1,13 @@
 import FavoritePage from '@/views/favorite/ui/favorite-page';
 
-function Page() {
-  return <FavoritePage />;
+async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ page?: string; size?: string }>;
+}) {
+  const { page, size } = await searchParams;
+
+  return <FavoritePage page={Number(page) || 1} size={Number(size) || 6} />;
 }
 
 export default Page;

--- a/src/shared/lib/get-query-client.ts
+++ b/src/shared/lib/get-query-client.ts
@@ -1,0 +1,7 @@
+import 'server-only';
+import { cache } from 'react';
+import createQueryClient from './query-client';
+
+const getServerQueryClient = cache(() => createQueryClient());
+
+export default getServerQueryClient;

--- a/src/views/favorite/ui/favorite-page.tsx
+++ b/src/views/favorite/ui/favorite-page.tsx
@@ -1,22 +1,37 @@
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import FavoriteDateSection from '@/widgets/favorite/ui/favorite-date-section';
 import FavoriteItemSection from '@/widgets/favorite/ui/favorite-item-section';
+import favoriteQueries from '@/widgets/favorite/api/queries';
+import getServerFavoriteList from '@/widgets/favorite/api/getServerFavoriteList';
 import ScrollTopButton from '@/shared/ui/scroll-top-button';
 import { getSession } from '@/shared/lib/cookie-session';
+import getServerQueryClient from '@/shared/lib/get-query-client';
 import LoginRequired from '@/shared/ui/login-required';
 import ScrollProgressBar from '@/shared/ui/scroll-progress-bar';
 import { AsyncBoundaryWithQuery } from '@/shared/ui/AsyncBoundary';
 import FavoriteListSkeletonLoading from '@/entities/favorite/ui/favorite-list-skeleton-loading';
 import ErrorBoundaryUi from '@/shared/ui/error-boundary-ui';
 
-async function FavoritePage() {
+interface FavoritePageProps {
+  page: number;
+  size: number;
+}
+
+async function FavoritePage({ page, size }: FavoritePageProps) {
   const session = await getSession();
 
   if (!session) {
     return <LoginRequired />;
   }
 
+  const queryClient = getServerQueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: favoriteQueries.list({ page, size }).queryKey,
+    queryFn: () => getServerFavoriteList({ page, size }),
+  });
+
   return (
-    <>
+    <HydrationBoundary state={dehydrate(queryClient)}>
       <ScrollProgressBar />
       <div className="mx-auto w-full px-4 pb-16 sm:w-4xl sm:px-5 lg:w-6xl">
         <AsyncBoundaryWithQuery
@@ -28,7 +43,7 @@ async function FavoritePage() {
         <FavoriteDateSection />
       </div>
       <ScrollTopButton />
-    </>
+    </HydrationBoundary>
   );
 }
 

--- a/src/widgets/favorite/api/getServerFavoriteList.ts
+++ b/src/widgets/favorite/api/getServerFavoriteList.ts
@@ -1,0 +1,22 @@
+import 'server-only';
+import api from '@/shared/api/auth-api';
+import type { FavoriteList } from '@/shared/model/type';
+
+interface GetServerFavoriteListParams {
+  page: number;
+  size: number;
+}
+
+async function getServerFavoriteList({
+  page,
+  size,
+}: GetServerFavoriteListParams): Promise<FavoriteList> {
+  const json = await api
+    .get('favorites', {
+      searchParams: { page: String(page), size: String(size) },
+    })
+    .json<{ data: FavoriteList }>();
+  return json.data;
+}
+
+export default getServerFavoriteList;

--- a/src/widgets/favorite/api/queries.ts
+++ b/src/widgets/favorite/api/queries.ts
@@ -7,6 +7,7 @@ const favoriteQueries = {
     queryOptions({
       queryKey: ['favorites', params.page, params.size],
       queryFn: () => getClientFavoriteList(params),
+      staleTime: 60 * 1000,
     }),
   recruit: (yearMonth: string) =>
     queryOptions({


### PR DESCRIPTION
- 요청별 격리 서버 QueryClient(getServerQueryClient) 추가
- auth-api 재사용한 서버 전용 목록 fetcher 추가
- favoriteQueries.list에 staleTime 부여로 hydrate 직후 재요청 억제
- favorite view에서 prefetch → dehydrate → HydrationBoundary 적용

## #️⃣연관된 이슈

#654 

## 📝작업 내용

이번 작업에서는 즐겨찾기 페이지를 대상으로한 csr fetching -> ssr 전환입니다.
유사한 페이지에 같은 형태로 적용할 수 있을 것 같습니다.

해당 작업을 진행하게 된 계기는 다음과 같습니다.
1. 정적 서버 패칭으로 인해 발생하는 갱신 버그를 해결하기 위해 csr 방식으로 전환함.
2. csr 방식에는 크게 두가지 단점이 있다. 첫째로 하이드레이션 이후 요청을 해야하는 워터폴현상. 두번째로는 프록시로 인한 2회의 요청 경로.
3. 이러한 문제를 해결하기 위해 최초 로드 시의 장점을 가진 SSR로의 재전환을 고려하게 되었고, 그 답을 prefetching을 이용해 쿼리 값을 교체해주는 방식을 설계하였습니다.

우선 csr로 전환할 수 밖에 없었던 원인을 파악했습니다. 즐겨찾기 버튼을 클릭할 경우 이에 따른 반응형 ui가 동작해야하는데 이때의 상태값을 관리해줄 도구가 존재하지 않았습니다. 이를 처리하기 위해 mutation을 사용하게 되었고, 요청의 처리 과정에서 Http-Only 쿠키의 문제로 클라이언트-서버-백엔드 로의 요청 구조가 자리잡게 되었습니다. 이 구조가 우리가 이해하는 csr 방식입니다.
이 상황을 저는 비효율적인 구조라고 생각되어 다른 방식을 고려해보게 되었습니다.

어떠한 요청에도 서버단에서 요청할 수 있게 해야하며, 동시에 현재 클라이언트에서 다루는 상태값에 대한 쿼리 데이터를 변경시켜주어야 하는 것이 주요한 포인트입니다.
그렇기에 이를 해결하려면 prefetching을 통해 데이터를 미리 가져오고, 가져온 데이터를 동일한 쿼리 데이터에 담아 dehydrate 과정을 통해 평탄화하여 클라이언트로 넘겨줍니다. 넘겨받은 json형태의 데이터를 클라이언트에서는 다시 hydrating 과정을 통해 쿼리 데이터로 변환하게 되고, 브라우저에서는 이 데이터가 존재하는 것으로 인지해 별도의 요청을 하지 않게 됩니다.
dehydrating 이라는 파이프라인을 통해 더이상 클라이언트단에서 api 요청을 할 이유가 없어지게 되어 프록시 요청 과정이 필요없어집니다.

대략적인 개념은 위와 같고, 이제 파일별로 내용을 다뤄보겠습니다.
- `page.tsx`: 파라미터에서 추출한 값을 넘겨줍니다. 이는 이후 서술할 쿼리 키에 주요하게 사용됩니다.
- `get-query-client.ts`: 서버에서 사용할 쿼리를 생성합니다. 여기서 cache 옵션은 서버에서 각 사용자에게 새로운 쿼리를 생성해주기 위함입니다.
- `favorite-page.tsx`: 서버 쿼리를 생성합니다. 쿼리키에는 받아온 props를 이용해 클라이언트와 동일한 쿼리키 값으로 생성하도록 하여 데이터를 그대로 덮어씌울 수 있도록 합니다. `dehydrate`메서드를 통해 캐시 데이터가 객체화 되고, 서버단에서 이 객체를 json형태로 직렬화하여 클라이언트에 전송합니다. 클라이언트에서 수신받은 이 객체는 다시 캐시 데이터의 형태로 복원되어 `HydrationBoundary`를 통해 쿼리 캐시에 주입되게 됩니다.

이러한 파이프라인을 형성함으로써 ssr의 장점을 살리고 csr에서의 프록시 요청 문제를 해결해보는 시도를 할 수 있습니다.

### 스크린샷 (선택)

이 pr의 도입을 하게되면 가지게 되는 트레이드 오프 입니다.

1. 하이드레이션 후 재요청

<p align="center">
  <img width="45%" height="253" alt="하이드레이션후요청_csr" src="https://github.com/user-attachments/assets/c9ae452b-5ba5-4c16-b933-c144fad7c143" />
  <img width="45%" height="267" alt="하이드레이션후요청_ssr" src="https://github.com/user-attachments/assets/cb2aaff6-e0f7-4a7e-9ad6-870d74706d15" />
</p>

더이상 클라이언트단에서 즐겨찾기 목록에 대한 요청을 하지 않습니다.

2. LightHouse

<p align="center">
  <img width="45%" height="357" alt="lighthouse_csr" src="https://github.com/user-attachments/assets/9cbf3950-7bfa-4689-926f-c96c26416c00" />
  <img width="45%" height="345" alt="lighthouse_ssr" src="https://github.com/user-attachments/assets/a6cb1636-89b7-47da-9682-b4e9e443995c" />
</p>

SI 지표 개선 - 하이드레이션 이후 프록시 요청을 통해 데이터가 주입되는 구조 개선으로 인한 상승
FCP 지표 개선 - 즐겨찾기의 경우 즐겨찾기 목록이 가장 먼저 뜨는 ui가 되는데, 이 ui가 그려지려면 프록시 요청 이후라 지표 상승

3. TTFB

<p align="center">
  <img width="45%" height="452" alt="TTFB_csr" src="https://github.com/user-attachments/assets/ec9bff05-1cde-42c7-8cc3-348791f7dc87" />
  <img width="45%" height="376" alt="TTFB_ssr" src="https://github.com/user-attachments/assets/ed7e8a16-c2d0-4c30-b3ff-55704ee72e0e" />
</p>

TBT의 하락과 연관된 내용입니다. 서버에서 처리하는 연산량이 늘어 클라이언트 단에서 전달받는 시점이 늦어집니다.

## 💬리뷰 요구사항(선택)

이러한 개선을 진행할 수 있지만, 이 전환으로 얻는 점이 있는만큼 잃는 점도 존재합니다. 현재 LightHouse에서 보이는 LCP, TBT의 개선을 다른 방향에서 진행하여 보완하면 좋을 듯 합니다.
https://github.com/greedy-team/mokkoji-fe-next/issues/655 제가 생각한 개선안에 대해서 이슈를 파두었으니 보완할 부분이 있다면 코멘트 달아주세요!