### PR TITLE
fix: 학교 미설정 신규 유저의 첫 학교 선택 시 변경 경고 미노출

### DIFF
--- a/src/widgets/login/ui/university-select-modal-wrapper.tsx
+++ b/src/widgets/login/ui/university-select-modal-wrapper.tsx
@@ -57,6 +57,11 @@ function UniversitySelectModalWrapper({
       return;
     }
 
+    if (universityCode === null) {
+      applyUniversityChange(code);
+      return;
+    }
+
     setPendingCode(code);
     setIsConfirmOpen(true);
   };

--- a/src/widgets/login/ui/university-select-modal.tsx
+++ b/src/widgets/login/ui/university-select-modal.tsx
@@ -47,7 +47,9 @@ function UniversitySelectModal({
           학교 선택하기
         </h1>
         <p className="text-text-secondary mb-6 text-center text-xs">
-          학교를 변경하면 기존 즐겨찾기가 모두 삭제돼요.
+          {universityCode === null
+            ? '이용할 학교를 선택해주세요.'
+            : '학교를 변경하면 기존 즐겨찾기가 모두 삭제돼요.'}
         </p>
 
         <div className="mb-30 flex flex-wrap gap-3">


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #657

## 📝작업 내용

회원탈퇴 후 재로그인(재가입)한 신규 유저(universityCode=null)에게 학교 선택 모달이 "변경"으로 처리되어 "기존 즐겨찾기 삭제" 경고가 부적절하게 노출되던 문제를 수정했습니다.

- `university-select-modal-wrapper.tsx`: `handleConfirm`에 `universityCode === null`(첫 선택) 분기 추가 → 신규 유저는 변경 경고 다이얼로그 없이 선택 학교를 즉시 적용
- `university-select-modal.tsx`: 서브텍스트를 조건 분기 → universityCode가 null이면 "이용할 학교를 선택해주세요.", 아니면 기존 변경 경고 문구 유지

기존 학교 보유 유저의 변경 경고 흐름과 모달 자동 오픈(isNewUser/defaultOpen)은 그대로 유지됩니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 첫 선택 판별을 `universityCode === null` 기준으로 했는데, 빈 문자열 등 다른 미설정 케이스가 있을지 확인 부탁드립니다.