### PR TITLE
refactor: 동아리 목록 하이드레이션 축소 및 서드파티 스크립트 정리

### DIFF
--- a/src/_providers/clarity-provider.tsx
+++ b/src/_providers/clarity-provider.tsx
@@ -6,7 +6,7 @@ function ClarityProvider() {
   return (
     <Script
       id="microsoft-clarity-init"
-      strategy="afterInteractive"
+      strategy="lazyOnload"
       dangerouslySetInnerHTML={{
         __html: `
                 (function(c,l,a,r,i,t,y){

--- a/src/app/[universityCode]/(main)/favorite/page.tsx
+++ b/src/app/[universityCode]/(main)/favorite/page.tsx
@@ -1,7 +1,13 @@
 import FavoritePage from '@/views/favorite/ui/favorite-page';
 
-function Page() {
-  return <FavoritePage />;
+async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ page?: string; size?: string }>;
+}) {
+  const { page, size } = await searchParams;
+
+  return <FavoritePage page={Number(page) || 1} size={Number(size) || 6} />;
 }
 
 export default Page;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -60,11 +60,6 @@ export default function RootLayout({
     <html lang="ko">
       <head>
         <Script
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2782954397492984"
-          strategy="lazyOnload"
-          crossOrigin="anonymous"
-        />
-        <Script
           src="https://www.googletagmanager.com/gtag/js?id=G-85PSBEJKQ2"
           strategy="afterInteractive"
         />

--- a/src/entities/club/ui/club-item.tsx
+++ b/src/entities/club/ui/club-item.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
 import RadiusTag from '@/shared/ui/radius-tag';
 import { RecruitStatus } from '@/shared/model/type';

--- a/src/shared/lib/get-query-client.ts
+++ b/src/shared/lib/get-query-client.ts
@@ -1,0 +1,7 @@
+import 'server-only';
+import { cache } from 'react';
+import createQueryClient from './query-client';
+
+const getServerQueryClient = cache(() => createQueryClient());
+
+export default getServerQueryClient;

--- a/src/shared/ui/kakao-adfit.tsx
+++ b/src/shared/ui/kakao-adfit.tsx
@@ -1,21 +1,42 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export default function KakaoAdFit() {
+  const containerRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
-    const script = document.createElement('script');
-    script.src = '//t1.daumcdn.net/kas/static/ba.min.js';
-    script.async = true;
-    document.body.appendChild(script);
+    const container = containerRef.current;
+    if (!container) return undefined;
+
+    let script: HTMLScriptElement | null = null;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+
+        script = document.createElement('script');
+        script.src = '//t1.daumcdn.net/kas/static/ba.min.js';
+        script.async = true;
+        document.body.appendChild(script);
+
+        observer.disconnect();
+      },
+      { rootMargin: '200px' },
+    );
+
+    observer.observe(container);
 
     return () => {
-      document.body.removeChild(script);
+      observer.disconnect();
+      if (script) {
+        document.body.removeChild(script);
+      }
     };
   }, []);
 
   return (
-    <>
+    <div ref={containerRef}>
       <div className="flex justify-center py-2 sm:hidden">
         <ins
           className="kakao_ad_area"
@@ -34,6 +55,6 @@ export default function KakaoAdFit() {
           data-ad-height="90"
         />
       </div>
-    </>
+    </div>
   );
 }

--- a/src/views/favorite/ui/favorite-page.tsx
+++ b/src/views/favorite/ui/favorite-page.tsx
@@ -1,22 +1,37 @@
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import FavoriteDateSection from '@/widgets/favorite/ui/favorite-date-section';
 import FavoriteItemSection from '@/widgets/favorite/ui/favorite-item-section';
+import favoriteQueries from '@/widgets/favorite/api/queries';
+import getServerFavoriteList from '@/widgets/favorite/api/getServerFavoriteList';
 import ScrollTopButton from '@/shared/ui/scroll-top-button';
 import { getSession } from '@/shared/lib/cookie-session';
+import getServerQueryClient from '@/shared/lib/get-query-client';
 import LoginRequired from '@/shared/ui/login-required';
 import ScrollProgressBar from '@/shared/ui/scroll-progress-bar';
 import { AsyncBoundaryWithQuery } from '@/shared/ui/AsyncBoundary';
 import FavoriteListSkeletonLoading from '@/entities/favorite/ui/favorite-list-skeleton-loading';
 import ErrorBoundaryUi from '@/shared/ui/error-boundary-ui';
 
-async function FavoritePage() {
+interface FavoritePageProps {
+  page: number;
+  size: number;
+}
+
+async function FavoritePage({ page, size }: FavoritePageProps) {
   const session = await getSession();
 
   if (!session) {
     return <LoginRequired />;
   }
 
+  const queryClient = getServerQueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: favoriteQueries.list({ page, size }).queryKey,
+    queryFn: () => getServerFavoriteList({ page, size }),
+  });
+
   return (
-    <>
+    <HydrationBoundary state={dehydrate(queryClient)}>
       <ScrollProgressBar />
       <div className="mx-auto w-full px-4 pb-16 sm:w-4xl sm:px-5 lg:w-6xl">
         <AsyncBoundaryWithQuery
@@ -28,7 +43,7 @@ async function FavoritePage() {
         <FavoriteDateSection />
       </div>
       <ScrollTopButton />
-    </>
+    </HydrationBoundary>
   );
 }
 

--- a/src/widgets/club/ui/club-item-client-list.tsx
+++ b/src/widgets/club/ui/club-item-client-list.tsx
@@ -1,7 +1,3 @@
-'use client';
-
-import useUniversityCode from '@/shared/hooks/useUniversityCode';
-
 import Link from 'next/link';
 
 import ClubItem from '@/entities/club/ui/club-item';
@@ -12,10 +8,13 @@ const BANNER_INTERVAL = 4;
 
 interface ClubItemClientListProps {
   clubs: Club[];
+  universityCode: string;
 }
 
-function ClubItemClientList({ clubs }: ClubItemClientListProps) {
-  const universityCode = useUniversityCode();
+function ClubItemClientList({
+  clubs,
+  universityCode,
+}: ClubItemClientListProps) {
   const uniqueClubs = Array.from(
     new Map(clubs.map((club) => [club.id, club])).values(),
   );

--- a/src/widgets/club/ui/club-item-list.tsx
+++ b/src/widgets/club/ui/club-item-list.tsx
@@ -35,7 +35,10 @@ async function ClubItemList({ universityCode }: { universityCode: string }) {
 
   return (
     <div className="mb-8">
-      <ClubItemClientList clubs={clubListResponse.data.clubs} />
+      <ClubItemClientList
+        clubs={clubListResponse.data.clubs}
+        universityCode={universityCode}
+      />
       <FeedbackModal />
       <NumberPagination
         page={page}

--- a/src/widgets/favorite/api/getServerFavoriteList.ts
+++ b/src/widgets/favorite/api/getServerFavoriteList.ts
@@ -1,0 +1,22 @@
+import 'server-only';
+import api from '@/shared/api/auth-api';
+import type { FavoriteList } from '@/shared/model/type';
+
+interface GetServerFavoriteListParams {
+  page: number;
+  size: number;
+}
+
+async function getServerFavoriteList({
+  page,
+  size,
+}: GetServerFavoriteListParams): Promise<FavoriteList> {
+  const json = await api
+    .get('favorites', {
+      searchParams: { page: String(page), size: String(size) },
+    })
+    .json<{ data: FavoriteList }>();
+  return json.data;
+}
+
+export default getServerFavoriteList;

--- a/src/widgets/favorite/api/queries.ts
+++ b/src/widgets/favorite/api/queries.ts
@@ -7,6 +7,7 @@ const favoriteQueries = {
     queryOptions({
       queryKey: ['favorites', params.page, params.size],
       queryFn: () => getClientFavoriteList(params),
+      staleTime: 60 * 1000,
     }),
   recruit: (yearMonth: string) =>
     queryOptions({


### PR DESCRIPTION
## #️⃣연관된 이슈

> #655

## 📝작업 내용

동아리 목록 페이지의 LCP render delay와 TBT를 유발하던 메인스레드 부하를 줄였습니다.

### 1. 불필요한 클라이언트 하이드레이션 제거

`ClubItemClientList`가 `universityCode`를 얻으려고 `useUniversityCode()` 훅 하나를 쓰고 있었고, 그 때문에 `'use client'`가 붙어 하위 카드 트리 전체가 하이드레이션 대상이 되고 있었습니다.

- 서버 컴포넌트인 `ClubItemList`가 이미 알고 있는 값이라 prop으로 전달하도록 변경
- `ClubItem`도 훅 없이 props만 조합하는 순수 컴포넌트라 `'use client'` 제거
- 실제 인터랙션이 필요한 `Avatar` / `FavoriteButton`만 client island로 남김

### 2. 서드파티 스크립트 로딩 전략 개선

- **AdSense 삭제** — `<ins class="adsbygoogle">` 슬롯이 코드에 하나도 없어, 로드만 되고 아무것도 렌더링하지 않던 상태였습니다.
- **Kakao AdFit** — 마운트 즉시 주입하던 것을 `IntersectionObserver`로 전환. below-the-fold라 초기 페인트 구간에는 로드되지 않습니다.
- **Clarity** — `afterInteractive` → `lazyOnload`. 세션 레코딩은 첫 페인트에 불필요합니다.
- **GA는 유지** — `WebVitalProvider`가 `window.gtag`를 직접 호출해 LCP/CLS/INP를 보고하므로, 더 늦추면 지표 수집이 깨집니다.

### 측정 결과 (localhost 프로덕션 빌드)

| 지표 | Before | After |
|---|---|---|
| 1st party 총 CPU | 1,372 ms | 1,040 ms (-24%) |
| `/sejong/club` Script Evaluation | 144 ms | 22 ms (-85%) |
| 전체 JS 실행시간 | 2.0 s | 1.5 s |

<p align="center">
<img width="45%" height="353" alt="image" src="https://github.com/user-attachments/assets/1116e004-7f96-4aa5-8901-1df83d156ee9" />
<img width="45%" height="352" alt="image" src="https://github.com/user-attachments/assets/d7d5a2e9-a54a-4967-89ca-4b379a04a34e" />
</p>
<img width="699" height="612" alt="image" src="https://github.com/user-attachments/assets/6bdd49c2-0b69-4795-aecf-ff04db2a393c" />

### 참고

- `/favorite`는 `FavoriteItemSection`이 `useSuspenseQuery`를 쓰는 client 컴포넌트라, 부모가 client인 이상 하이드레이션 비용이 그대로입니다. 즐겨찾기 해제 시 `invalidateQueries`로 리스트를 갱신하는 구조라 이번엔 손대지 않았습니다.
- ⚠️ #656(`654-feat-favorite-ssr-prefetch`)이 이 브랜치에 머지돼 있어 해당 커밋이 diff에 포함됩니다. #656 머지 후 정리됩니다.

## 💬리뷰 요구사항(선택)
