### PR TITLE
feat: 이미지 업로드 시 클라이언트 WebP 변환 및 리사이즈 적용

### DIFF
--- a/src/features/admin-club-description/ui/edit/edit-flow-container.tsx
+++ b/src/features/admin-club-description/ui/edit/edit-flow-container.tsx
@@ -6,6 +6,9 @@ import { toast } from 'react-toastify';
 import ky from 'ky';
 import { ClubInfoType } from '@/shared/model/type';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
+import convertImageToWebp, {
+  LOGO_MAX_DIMENSION,
+} from '@/shared/lib/convertImageToWebp';
 import { Button } from '@/shared/ui/button';
 import DotsPulseLoader from '@/shared/ui/DotsPulseLoader';
 import SharedLoading from '@/shared/ui/loading';
@@ -50,14 +53,15 @@ function EditFlowContent({ clubInfo, clubId }: ClubEditFlowContainerProps) {
   const [logoFile, setLogoFile] = useState<File | null>(null);
   const [completedClubId, setCompletedClubId] = useState<number | null>(null);
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
-    const imageUrl = URL.createObjectURL(file);
+    const webpFile = await convertImageToWebp(file, LOGO_MAX_DIMENSION);
+    const imageUrl = URL.createObjectURL(webpFile);
     setPreview(imageUrl);
-    setLogoFile(file);
-    handleChange('logo', file.name);
+    setLogoFile(webpFile);
+    handleChange('logo', webpFile.name);
   };
 
   const handleLogoClick = () => {

--- a/src/features/club-create/ui/club-crete-form.tsx
+++ b/src/features/club-create/ui/club-crete-form.tsx
@@ -8,6 +8,9 @@ import { toast } from 'react-toastify';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
 import { useSession } from '@/shared/lib/session-context';
 import { urlCodeToApiCode } from '@/shared/lib/universityMeta';
+import convertImageToWebp, {
+  LOGO_MAX_DIMENSION,
+} from '@/shared/lib/convertImageToWebp';
 import type { University } from '@/entities/university/model/type';
 import postCreateClubApplication from '../api/postCreateClubApplication';
 import type { ClubCreateFormData } from '../model/type';
@@ -42,12 +45,14 @@ function ClubCreateForm({ universities }: ClubCreateFormProps) {
   const [step, setStep] = useState<Step>('basic');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleLogoChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    setLogoPreview(URL.createObjectURL(file));
-    setLogoFile(file);
-    setFormData((prev) => ({ ...prev, logo: file.name }));
+
+    const webpFile = await convertImageToWebp(file, LOGO_MAX_DIMENSION);
+    setLogoPreview(URL.createObjectURL(webpFile));
+    setLogoFile(webpFile);
+    setFormData((prev) => ({ ...prev, logo: webpFile.name }));
   };
 
   const handleNext = () => {

--- a/src/features/club-register/ui/club-edit-form.tsx
+++ b/src/features/club-register/ui/club-edit-form.tsx
@@ -12,6 +12,9 @@ import {
   ClubInfoType,
 } from '@/shared/model/type';
 import getKeyByValue from '@/shared/lib/getKeyByValue';
+import convertImageToWebp, {
+  LOGO_MAX_DIMENSION,
+} from '@/shared/lib/convertImageToWebp';
 import { useRouter } from 'next/navigation';
 import SafeForm from '@/shared/ui/safe-form';
 import ClubInput from './club-input';
@@ -114,16 +117,17 @@ function ClubEditForm({ clubInfo, clubId }: ClubInfoProp) {
     dispatch({ type: 'UPDATE_FIELD', name, value });
   };
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
-    const imageUrl = URL.createObjectURL(file);
+    const webpFile = await convertImageToWebp(file, LOGO_MAX_DIMENSION);
+    const imageUrl = URL.createObjectURL(webpFile);
     setPreview(imageUrl);
 
-    setLogoFile(file);
+    setLogoFile(webpFile);
 
-    dispatch({ type: 'UPDATE_FIELD', name: 'logo', value: file.name });
+    dispatch({ type: 'UPDATE_FIELD', name: 'logo', value: webpFile.name });
   };
 
   const handleClick = () => {

--- a/src/shared/lib/convertImageToWebp.ts
+++ b/src/shared/lib/convertImageToWebp.ts
@@ -1,0 +1,44 @@
+export const LOGO_MAX_DIMENSION = 256;
+export const RECRUITMENT_IMAGE_MAX_DIMENSION = 1200;
+
+const WEBP_QUALITY = 0.8;
+
+async function convertImageToWebp(
+  file: File,
+  maxDimension: number,
+): Promise<File> {
+  if (file.type === 'image/webp') return file;
+
+  try {
+    const bitmap = await createImageBitmap(file);
+    const scale = Math.min(
+      1,
+      maxDimension / Math.max(bitmap.width, bitmap.height),
+    );
+
+    const canvas = document.createElement('canvas');
+    canvas.width = Math.round(bitmap.width * scale);
+    canvas.height = Math.round(bitmap.height * scale);
+
+    const context = canvas.getContext('2d');
+    if (!context) return file;
+
+    context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+    bitmap.close();
+
+    const blob = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob(resolve, 'image/webp', WEBP_QUALITY);
+    });
+
+    // webp 인코딩을 지원하지 않는 브라우저는 toBlob이 png를 대신 반환한다
+    if (!blob || blob.type !== 'image/webp') return file;
+
+    return new File([blob], `${file.name.replace(/\.[^.]+$/, '')}.webp`, {
+      type: 'image/webp',
+    });
+  } catch {
+    return file;
+  }
+}
+
+export default convertImageToWebp;

--- a/src/shared/model/useImageUpload.tsx
+++ b/src/shared/model/useImageUpload.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { arrayMove } from '@dnd-kit/sortable';
 import { toast } from 'react-toastify';
+import convertImageToWebp, {
+  RECRUITMENT_IMAGE_MAX_DIMENSION,
+} from '../lib/convertImageToWebp';
 
 interface ImageItem {
   id: string;
@@ -70,7 +73,7 @@ function useImageUpload(imageUrls: string[] = [], maxLength: number = 20) {
     });
   };
 
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = e.target;
     if (!files) return;
     const fileArray = Array.from(files);
@@ -80,12 +83,21 @@ function useImageUpload(imageUrls: string[] = [], maxLength: number = 20) {
       return;
     }
 
-    const newItems: ImageItem[] = fileArray.map((file) => ({
-      id: crypto.randomUUID(),
-      file,
-      previewUrl: URL.createObjectURL(file),
-      imageName: file.name,
-    }));
+    const newItems: ImageItem[] = await Promise.all(
+      fileArray.map(async (file) => {
+        const webpFile = await convertImageToWebp(
+          file,
+          RECRUITMENT_IMAGE_MAX_DIMENSION,
+        );
+
+        return {
+          id: crypto.randomUUID(),
+          file: webpFile,
+          previewUrl: URL.createObjectURL(webpFile),
+          imageName: webpFile.name,
+        };
+      }),
+    );
 
     setImageFiles((prev) => [...prev, ...newItems]);
   };

--- a/src/shared/model/useImageUpload.tsx
+++ b/src/shared/model/useImageUpload.tsx
@@ -5,6 +5,8 @@ import convertImageToWebp, {
   RECRUITMENT_IMAGE_MAX_DIMENSION,
 } from '../lib/convertImageToWebp';
 
+const CONVERT_CONCURRENCY = 3;
+
 interface ImageItem {
   id: string;
   file: File;
@@ -83,23 +85,33 @@ function useImageUpload(imageUrls: string[] = [], maxLength: number = 20) {
       return;
     }
 
-    const newItems: ImageItem[] = await Promise.all(
-      fileArray.map(async (file) => {
-        const webpFile = await convertImageToWebp(
-          file,
-          RECRUITMENT_IMAGE_MAX_DIMENSION,
-        );
+    for (
+      let index = 0;
+      index < fileArray.length;
+      index += CONVERT_CONCURRENCY
+    ) {
+      const batch = fileArray.slice(index, index + CONVERT_CONCURRENCY);
 
-        return {
-          id: crypto.randomUUID(),
-          file: webpFile,
-          previewUrl: URL.createObjectURL(webpFile),
-          imageName: webpFile.name,
-        };
-      }),
-    );
+      // 한 번에 전부 변환하면 원본 비트맵이 동시에 메모리에 올라와 모바일에서 탭이 죽는다
+      // eslint-disable-next-line no-await-in-loop
+      const convertedBatch: ImageItem[] = await Promise.all(
+        batch.map(async (file) => {
+          const webpFile = await convertImageToWebp(
+            file,
+            RECRUITMENT_IMAGE_MAX_DIMENSION,
+          );
 
-    setImageFiles((prev) => [...prev, ...newItems]);
+          return {
+            id: crypto.randomUUID(),
+            file: webpFile,
+            previewUrl: URL.createObjectURL(webpFile),
+            imageName: webpFile.name,
+          };
+        }),
+      );
+
+      setImageFiles((prev) => [...prev, ...convertedBatch]);
+    }
   };
 
   const handleImageRemove = (id: string) => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #664

## 📝작업 내용

이미지가 원본 포맷·용량 그대로 S3에 업로드되고 있어, 업로드 시점에 클라이언트에서 WebP로 변환하고 리사이즈하도록 했습니다.

**변환 시점을 "파일 선택 시점"으로 잡은 이유**
백엔드에 파일명을 업로드보다 먼저 전달하고 백엔드가 그 이름으로 S3 키를 생성합니다(`logo: file.name`, `imageNames`). 제출 시점에 변환하면 키는 `.jpg`인데 실제 내용은 webp인 불일치가 생기므로, 파일명이 백엔드로 가기 전에 변환을 끝내도록 했습니다.

**`shared/lib/convertImageToWebp.ts` 추가**
- `createImageBitmap` → canvas `drawImage` → `toBlob('image/webp')` 순으로 변환 후 `File`로 재포장
- 반환 타입이 `File`이라 기존 presigned URL PUT 코드는 그대로 동작
- 원본이 상한보다 작으면 확대하지 않음(`Math.min(1, ...)`)
- webp 인코딩 미지원 브라우저는 `toBlob`이 png를 대신 반환하므로, `blob.type`을 검사해 원본 File로 폴백

**최대 크기는 실제 화면 표시 크기 기준으로 산정**

두 상수 모두 **긴 변의 픽셀 상한**이며, 실제 화면에 표시되는 크기를 기준으로 잡았습니다. 표시 크기보다 큰 이미지는 브라우저가 어차피 축소해 그리므로, 화질 이득 없이 용량만 낭비됩니다.

```ts
// 로고 최대 표시 크기 72px(click-logo.tsx의 Avatar)의 약 3.5배.
// DPR 3 기기(216px)까지 커버하면서 추후 디자인 변경도 어느 정도 흡수하는 값.
export const LOGO_MAX_DIMENSION = 256;

// 모집공고 이미지 최대 표시 크기 800px(recruit-detail-view.tsx의 확대 다이얼로그)의 1.5배.
export const RECRUITMENT_IMAGE_MAX_DIMENSION = 1200;
```

| 용도 | 표시 최대 | 상한값 | 배수 |
|---|---|---|---|
| 모집공고 이미지 | 800px (확대 다이얼로그) | 1200 | 1.5x |
| 클럽 로고 | 72px (상세 헤더 Avatar) | 256 | 3.5x |

모집공고 이미지는 포스터라 글자가 포함되어 있어 로고만큼 배수를 낮게 가져가지 않았습니다.

**적용 지점**
- 모집공고 이미지(다중): `useImageUpload`의 `handleImageChange` — 이 훅을 쓰는 4개 폼에 일괄 적용
- 클럽 로고(단일): club-create, club-register, admin-club-description 3개 폼

**변환 동시 실행 개수 제한 (3개씩 배치)**

`Promise.all`로 선택한 이미지를 전부 동시에 변환하면 원본 비트맵이 한꺼번에 메모리에 올라옵니다. 3개씩 끊어서 순차 처리하도록 변경했습니다.

이미지 20장 동시 선택 기준, Chrome 작업 관리자의 탭 메모리 사용 공간 피크:

| | 피크 메모리 |
|---|---|
| 배치 처리 전 | 약 3.6GB |
| 배치 처리 후 | 약 0.13GB |

iOS Safari는 탭 메모리가 1~1.5GB 근처에 도달하면 탭을 종료시키기 때문에, 기존 구조로는 모바일에서 다량 업로드 시 페이지가 죽을 수 있었습니다.

**미리보기 점진적 렌더링**

기존에는 전체 변환이 끝날 때까지 `setImageFiles`를 호출하지 않아, 20장 선택 시 변환이 완료될 때까지 화면에 아무것도 표시되지 않았습니다. 배치 단위로 상태를 갱신하도록 바꿔 3장씩 순차로 미리보기가 나타납니다. `slice` 순서대로 이어붙이므로 이미지 순서는 유지됩니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

**백엔드 확인이 필요한 부분이 2가지 있습니다.**

1. presigned URL 서명에 Content-Type이 포함되어 있다면, `.webp` 파일명을 받았을 때 백엔드도 `image/webp`로 서명해야 PUT이 성공합니다. (파일명 기반으로 content-type을 추론한다면 자동 해결)
2. 백엔드에 확장자 화이트리스트(jpg/png만 허용) 검증이 있다면 webp가 거부될 수 있습니다.

그리고 `LOGO_MAX_DIMENSION = 256`이 적절한지 봐주시면 좋겠습니다. 현재 로고 최대 표시 크기가 72px(`click-logo.tsx`)라 3배 DPR 기기까지 커버되는 값인데, 추후 디자인에서 로고를 더 크게 쓰게 되면 이미 업로드된 이미지는 재업로드가 필요합니다.
