### PR TITLE
style: 마이페이지 글자 굵기 통일 및 로그아웃 로직 훅 추출

### DIFF
--- a/src/entities/my/ui/info-row.tsx
+++ b/src/entities/my/ui/info-row.tsx
@@ -8,11 +8,11 @@ type InfoRowProps = {
 
 export default function InfoRow({ label, value, children }: InfoRowProps) {
   return (
-    <div className="grid grid-cols-[80px_1fr] items-center py-2">
+    <div className="grid grid-cols-[80px_1fr] items-start py-2">
       <span className="text-text-secondary flex text-sm font-bold">
         {label}
       </span>
-      <div className="flex flex-col items-start justify-start text-sm lg:flex lg:gap-2">
+      <div className="flex flex-col items-start justify-start gap-2 text-sm">
         {value}
         {children}
       </div>

--- a/src/entities/my/ui/my-page.tsx
+++ b/src/entities/my/ui/my-page.tsx
@@ -74,7 +74,9 @@ async function MyPage({
       <ScrollProgressBar />
       <div className="mx-auto w-full px-4 sm:w-lg">
         <div className="mb-8 flex flex-col gap-2">
-          <div className="text-text-secondary">{user.name}</div>
+          <div className="text-text-secondary text-sm font-bold">
+            {user.name}
+          </div>
           <div className="flex w-[130px] items-center gap-2 rounded-full bg-[#FEE500] px-3 py-2.5">
             <Image src="/chatIcon.svg" alt="챗아이콘" width={16} height={16} />
             <span className="text-sm text-neutral-900">카카오 로그인</span>
@@ -128,7 +130,10 @@ async function MyPage({
             </InfoRow>
             {isAdmin && (
               <div className="mt-6 flex items-center gap-2">
-                <HeaderAdminLink isLoggedIn={!!session} />
+                <HeaderAdminLink
+                  isLoggedIn={!!session}
+                  className="text-sm font-bold"
+                />
                 <Image src="/nextBlack.svg" alt="" width={8} height={12} />
               </div>
             )}

--- a/src/features/header/ui/header-admin-link.tsx
+++ b/src/features/header/ui/header-admin-link.tsx
@@ -6,9 +6,11 @@ import Link from 'next/link';
 import { toast } from 'react-toastify';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
 import { ApiResponse, UserRole } from '@/shared/model/type';
+import cn from '@/shared/lib/utils';
 
 interface HeaderAdminLinkProps {
   isLoggedIn: boolean;
+  className?: string;
 }
 
 const ALLOWED_ROLES = [
@@ -17,7 +19,7 @@ const ALLOWED_ROLES = [
   UserRole.CLUB_MASTER,
 ];
 
-function HeaderAdminLink({ isLoggedIn }: HeaderAdminLinkProps) {
+function HeaderAdminLink({ isLoggedIn, className }: HeaderAdminLinkProps) {
   const universityCode = useUniversityCode();
   const router = useRouter();
   const [isChecking, setIsChecking] = useState(false);
@@ -53,7 +55,7 @@ function HeaderAdminLink({ isLoggedIn }: HeaderAdminLinkProps) {
   return (
     <Link
       href={`/${universityCode}/admin`}
-      className="flex items-center font-semibold"
+      className={cn('flex items-center font-semibold', className)}
       onClick={handleClick}
     >
       동아리 관리

--- a/src/features/header/ui/header-login.tsx
+++ b/src/features/header/ui/header-login.tsx
@@ -9,6 +9,7 @@ import ConfirmDialog from '@/shared/ui/ConfirmDialog';
 import Image from 'next/image';
 import useClickOutside from '@/shared/model/useClickOutside';
 import { useSession } from '@/shared/lib/session-context';
+import useLogout from '@/shared/hooks/useLogout';
 import {
   ChevronIcon,
   UserIcon,
@@ -27,12 +28,13 @@ function HeaderLogin({ userName }: HeaderLoginProps) {
     status === 'authenticated' || (status === 'loading' && !!userName);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const universityCode = useUniversityCode();
+  const logout = useLogout();
 
   useClickOutside(dropdownRef, () => setIsDropdownOpen(false));
 
   const handleSignOut = async () => {
-    await fetch('/api/auth/logout', { method: 'POST' });
-    window.location.href = `/${universityCode}`;
+    setIsLogoutDialogOpen(false);
+    await logout();
   };
 
   return (

--- a/src/features/my/ui/club-application-status.tsx
+++ b/src/features/my/ui/club-application-status.tsx
@@ -53,7 +53,7 @@ function ClubApplicationStatus({
 
   return (
     <div className="mb-10 flex flex-col gap-3">
-      <div className="font-semibold">신청 현황</div>
+      <div className="text-sm font-bold">신청 현황</div>
       <div className="flex flex-col gap-5">
         <ApplicationSection
           title={APPLICATION_SECTION.master.title}

--- a/src/features/my/ui/club-master-transfer-section.tsx
+++ b/src/features/my/ui/club-master-transfer-section.tsx
@@ -64,7 +64,7 @@ function ClubMasterTransferSection({ clubs }: ClubMasterTransferSectionProps) {
           onClick={() => setSelectedClub(club)}
           className="bg-gray4 flex items-center justify-between rounded-lg px-4 py-3.5 text-left"
         >
-          <span className="text-text-secondary text-sm font-medium">
+          <span className="text-text-secondary text-sm font-bold">
             {`'${club.clubName}' 동아리장 위임하기`}
           </span>
           <Image src="/nextBlack.svg" alt="" width={8} height={12} />

--- a/src/features/my/ui/logout-link.tsx
+++ b/src/features/my/ui/logout-link.tsx
@@ -27,7 +27,7 @@ export default function LogoutLink() {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="mt-2 flex items-center gap-2 text-sm text-[#FF383C] hover:underline"
+        className="mt-2 flex items-center gap-2 text-sm font-bold text-[#FF383C] hover:underline"
       >
         로그아웃
         <Image src="/nextBlack.svg" alt="arrow" width={8} height={12} />

--- a/src/features/my/ui/logout-link.tsx
+++ b/src/features/my/ui/logout-link.tsx
@@ -1,25 +1,18 @@
 'use client';
 
 import { useState } from 'react';
-import useUniversityCode from '@/shared/hooks/useUniversityCode';
-import { useSession } from '@/shared/lib/session-context';
+import useLogout from '@/shared/hooks/useLogout';
 import ConfirmDialog from '@/shared/ui/ConfirmDialog';
 
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
 
 export default function LogoutLink() {
-  const router = useRouter();
-  const { refresh } = useSession();
-  const universityCode = useUniversityCode();
+  const logout = useLogout();
   const [open, setOpen] = useState(false);
 
   const handleLogout = async () => {
-    await fetch('/api/auth/logout', { method: 'POST' });
-    refresh();
     setOpen(false);
-    router.push(`/${universityCode}`);
-    router.refresh();
+    await logout();
   };
 
   return (

--- a/src/features/my/ui/withdraw-button.tsx
+++ b/src/features/my/ui/withdraw-button.tsx
@@ -31,7 +31,7 @@ export default function WithdrawButton() {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="text-gray mt-2 flex items-center gap-2 text-sm hover:underline"
+        className="text-gray mt-2 flex items-center gap-2 text-sm font-bold hover:underline"
       >
         회원 탈퇴
         <Image src="/nextBlack.svg" alt="arrow" width={8} height={12} />

--- a/src/features/my/ui/withdraw-button.tsx
+++ b/src/features/my/ui/withdraw-button.tsx
@@ -1,26 +1,19 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import useServerAction from '@/shared/hooks/useServerAction';
-import useUniversityCode from '@/shared/hooks/useUniversityCode';
-import { useSession } from '@/shared/lib/session-context';
+import useLogout from '@/shared/hooks/useLogout';
 import ConfirmDialog from '@/shared/ui/ConfirmDialog';
 import deleteUser from '../api/deleteUser';
 
 export default function WithdrawButton() {
-  const router = useRouter();
-  const { refresh } = useSession();
-  const universityCode = useUniversityCode();
+  const logout = useLogout();
   const [open, setOpen] = useState(false);
   const { mutate, isPending } = useServerAction(deleteUser, {
     onSuccess: async () => {
-      await fetch('/api/auth/logout', { method: 'POST' });
-      refresh();
       setOpen(false);
-      router.push(`/${universityCode}`);
-      router.refresh();
+      await logout();
     },
   });
 

--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import clientApi from '@/shared/api/client-api';
+import { useSession } from '@/shared/lib/session-context';
+import useUniversityCode from '@/shared/hooks/useUniversityCode';
+
+export default function useLogout() {
+  const router = useRouter();
+  const { refresh } = useSession();
+  const universityCode = useUniversityCode();
+
+  return useCallback(async () => {
+    await clientApi.post('api/auth/logout');
+    refresh();
+    router.replace(`/${universityCode}`);
+    router.refresh();
+  }, [router, refresh, universityCode]);
+}

--- a/src/views/login/kakao-login-page.tsx
+++ b/src/views/login/kakao-login-page.tsx
@@ -14,7 +14,7 @@ export default function KakaoLoginPage() {
   };
 
   return (
-    <div className="flex h-full flex-col bg-white">
+    <div className="mx-auto flex h-full w-full flex-col bg-white sm:w-lg">
       <main className="flex flex-1 flex-col items-center justify-center gap-6 px-8">
         <Image
           src="/header/mokkojiLogoPrimary.svg"


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #666

## 📝작업 내용

### style: 마이페이지 글자 굵기 통일 · 로그인 페이지 폭 제한

마이페이지의 제목·라벨 굵기가 `font-bold` / `font-semibold` / `font-medium` / 굵기 없음으로 제각각이라 위계가 정리되지 않아 통일했습니다.

- 제목·라벨류를 `text-sm font-bold`로 통일 — 사용자 이름, 신청 현황, 권한 위임 코드, InfoRow 라벨, 동아리장 위임 버튼, 동아리 관리, 로그아웃, 회원 탈퇴
- `내 정보` 섹션 제목은 기존 크기·굵기 유지, 값·설명 등 본문/보조 텍스트도 그대로
- `HeaderAdminLink`는 헤더에서도 쓰이는 공용 컴포넌트라 전역 변경 대신 `className` prop을 추가해 마이페이지에서만 override
- 이메일 행이 값(이메일 주소) 아래로 수정/삭제 버튼이 쌓이는 구조라, 라벨이 스택 중앙이 아닌 첫 줄에 정렬되도록 `items-start` 적용
- 로그인 페이지가 데스크톱에서 화면 전체로 늘어나던 것을 마이페이지와 같은 `mx-auto w-full sm:w-lg` 패턴으로 모바일 폭 중앙 정렬

### refactor: 로그아웃 로직 `useLogout` 훅 추출

로그아웃 흐름(API 호출 → 세션 갱신 → 홈 이동)이 세 곳에 중복돼 있고 동작도 서로 달라서 하나로 합쳤습니다.

- `logout-link`, `withdraw-button`, `header-login`의 중복 로직을 `useLogout`으로 통합
- `features/my`와 `features/header` 양쪽에서 쓰이므로 같은 레이어 교차 임포트를 피해 `shared/hooks`에 배치
- raw `fetch('/api/auth/logout')` → `clientApi.post('api/auth/logout')` (프로젝트 규칙: raw fetch 금지)
- 로그아웃 후 뒤로가기로 이전 화면에 돌아가지 않도록 `router.push` → `router.replace`
- 헤더만 `window.location.href`로 하드 리로드하고 있어 클라이언트 네비게이션으로 전환. 전체 번들 재실행·재하이드레이션 없이 `router.refresh()`로 서버 컴포넌트만 갱신됩니다. 하드 리로드가 사라지면서 다이얼로그가 자동으로 닫히지 않게 되어 명시적으로 닫도록 추가

## 💬리뷰 요구사항(선택)

- `useLogout` 위치를 `shared/hooks`로 잡았는데, 인증 도메인 성격이라 다른 자리가 더 맞다고 보시면 의견 주세요.
- `clientApi`는 `prefixUrl: '/'`라 최종 URL은 기존 raw fetch와 동일한 `/api/auth/logout`입니다. 다만 ky는 non-2xx에서 throw하므로, 로그아웃 요청 실패 시 리다이렉트가 중단됩니다. 이 경우에도 홈으로 보내는 게 맞다면 try/catch를 감싸는 쪽으로 조정하겠습니다.
- `/my`가 `publicRoutes`에 포함돼 있어 미들웨어가 막지 않고, 페이지 자체의 `!session → LoginRequired` 가드가 유일한 서버 방어선입니다. 의도된 구성인지 확인 부탁드립니다.