### PR TITLE
[#675] fix: 어드민 로딩 UI 정렬 및 스텝 전환 깜빡임 제거

### DIFF
--- a/src/app/(admin)/dashboard/login/page.tsx
+++ b/src/app/(admin)/dashboard/login/page.tsx
@@ -107,8 +107,8 @@ export default function DashboardLoginPage() {
           )}
 
           {isSubmitting ? (
-            <div className="flex h-11 items-center justify-center">
-              <DotsPulseLoader className="mr-3" text="로그인 중..." />
+            <div className="flex min-h-11 items-center justify-center">
+              <DotsPulseLoader text="로그인 중..." />
             </div>
           ) : (
             <Button

--- a/src/features/admin-recruitment/ui/edit/use-edit-flow.ts
+++ b/src/features/admin-recruitment/ui/edit/use-edit-flow.ts
@@ -1,74 +1,63 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
 import { ClubRecruitments } from '@/entities/club-detail/model/type';
 import { EditStep } from './types';
 
-const EDIT_STEPS: EditStep[] = [
+const EDIT_STEPS = [
   'selectPostEditStep',
   'basicInfoEditStep',
   'postInfoEditStep',
   'completeEditStep',
-];
+] as const satisfies readonly EditStep[];
 const DEFAULT_STEP: EditStep = 'selectPostEditStep';
 
+const stepParser = parseAsStringLiteral(EDIT_STEPS).withDefault(DEFAULT_STEP);
+
+// nuqs는 Next 라우터 대신 브라우저 history API로 URL을 바꾼다.
+// RSC 요청이 없으므로 스텝 전환이 즉시 일어난다.
 function useEditFlow() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
+  const [currentStep, setCurrentStep] = useQueryState('step', stepParser);
   const [selectedPost, setSelectedPost] = useState<
     ClubRecruitments | undefined
   >(undefined);
   const [isSubmitting, setSubmitting] = useState(false);
 
-  const currentStep = (searchParams.get('step') as EditStep) ?? DEFAULT_STEP;
+  const goToStep = (step: EditStep, history: 'push' | 'replace' = 'push') => {
+    setCurrentStep(step, { history });
+  };
 
   const startEdit = (post: ClubRecruitments) => {
     setSelectedPost(post);
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('step', 'basicInfoEditStep');
-    router.push(`?${params.toString()}`);
+    goToStep('basicInfoEditStep');
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   const nextStep = () => {
-    const idx = EDIT_STEPS.indexOf(currentStep);
-    if (idx < EDIT_STEPS.length - 1) {
-      const params = new URLSearchParams(searchParams.toString());
-      params.set('step', EDIT_STEPS[idx + 1]);
-      router.push(`?${params.toString()}`);
+    const index = EDIT_STEPS.indexOf(currentStep);
+    if (index < EDIT_STEPS.length - 1) {
+      goToStep(EDIT_STEPS[index + 1]);
       window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
 
   const prevStep = () => {
-    const idx = EDIT_STEPS.indexOf(currentStep);
-    if (idx > 0) {
-      const params = new URLSearchParams(searchParams.toString());
-      params.set('step', EDIT_STEPS[idx - 1]);
-      router.push(`?${params.toString()}`);
+    const index = EDIT_STEPS.indexOf(currentStep);
+    if (index > 0) {
+      goToStep(EDIT_STEPS[index - 1]);
       window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
 
   const goToSelectPost = () => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('step', 'selectPostEditStep');
-    router.push(`?${params.toString()}`);
+    goToStep('selectPostEditStep');
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
-  const complete = () => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('step', 'completeEditStep');
-    router.replace(`?${params.toString()}`);
-  };
+  const complete = () => goToStep('completeEditStep', 'replace');
 
-  const reset = () => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('step', DEFAULT_STEP);
-    router.replace(`?${params.toString()}`);
-  };
+  const reset = () => goToStep(DEFAULT_STEP, 'replace');
 
   return {
     currentStep,

--- a/src/shared/ui/DotsPulseLoader.tsx
+++ b/src/shared/ui/DotsPulseLoader.tsx
@@ -32,7 +32,7 @@ export default function DotsPulseLoader({
   } as React.CSSProperties;
 
   return (
-    <div className={wrapperClassName}>
+    <div className={`flex flex-col items-center ${wrapperClassName ?? ''}`}>
       <div
         className={`dots-loader ${className ?? ''}`}
         role="status"


### PR DESCRIPTION
## #️⃣연관된 이슈
> closes #675

## 📝작업 내용

### 1. 로딩 UI 정렬 (`adfec175` 이전 커밋)
`DotsPulseLoader`의 점 3개와 문구가 둘 다 인라인이라 한 줄로 나란히 붙어 렌더됐습니다. 호출부에서 `wrapperClassName`으로 `flex-col`을 넘긴 곳만 점이 문구 위에 왔고요.

- 래퍼에 세로 정렬을 기본 적용해 항상 점이 문구 위 중앙에 오도록 변경
- 가로 배치를 쓰던 어드민 로그인 페이지는 2줄이 잘리지 않도록 `h-11` → `min-h-11`

### 2. 스텝 전환 시 이전 화면 깜빡임 제거
모집글 수정 플로우에서 스텝을 넘기면 이전 화면이 잠깐 보였다가 전환됐습니다.

원인은 두 값의 반영 속도 차이였습니다.

| 코드 | 반영 시점 |
|---|---|
| `setSubmitting(false)` | React state → 즉시 |
| `router.replace('?step=...')` | 쿼리 변경 → RSC 재요청 왕복 후 |

로더가 먼저 꺼지고 화면은 나중에 바뀌니, 그 사이 이전 스텝 UI가 노출됐습니다.

이 라우트의 서버 트리(`page` → `admin-recruitment-widget` → `admin-recruitment-edit-widget`)는 `step`을 읽지 않습니다. `params.action` / `params.id` / `clubId`만 씁니다. 즉 스텝을 넘길 때마다 동일한 결과를 받으려고 API 두 개를 다시 호출하고 있었습니다.

- `useSearchParams` + `useRouter` → nuqs `useQueryState`로 교체
- nuqs는 브라우저 history API로 URL을 갱신하므로 RSC 재요청 없이 즉시 전환됩니다
- `parseAsStringLiteral` 적용 — 기존 `as EditStep` 캐스팅은 `?step=` 값이 잘못되면 어떤 분기에도 안 걸려 빈 화면이 떴는데, 이제 기본 스텝으로 떨어집니다

## 💬리뷰 요구사항(선택)

이번 PR은 `admin-recruitment/edit` 한 곳만 적용했습니다. 동일한 패턴이 아래 3곳에 남아 있어 검증 후 이어서 작업할 예정입니다.

- `admin-recruitment/create`
- `admin-club-description/create`
- `admin-club-description/edit`

별개로, 어드민 권한 가드가 `(edit)/layout.tsx`에서 매 요청마다 role API를 호출하고 있습니다. 미들웨어로 옮기는 게 맞아 보여 별도 이슈로 분리하려 합니다.