### PR TITLE
[#677] fix: url 대소문자 혼용 수정 및 코드 변환 컨버터 도입

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,22 @@ CSS tokens: `src/app/theme.css` / Animations: `src/app/globals.css`
 8. **Server/Client separation**: Default to Server Component if no interaction. Use `'use client'` if `useState`/`useEffect`/event handlers exist.
 9. **No raw fetch**: Always use ky for HTTP requests. Never use fetch directly.
 10. **No magic strings for fixed value sets**: When a value can only be one of a known fixed set (tab keys, status values, etc.), define it as an `as const` array/object and derive a union type from it, instead of typing the field as plain `string`. Prevents typos from silently passing type checks.
+11. **Lowercase URL codes, always via converter**: Codes appear in two casings — API/enum codes are uppercase (`SEJONG`, `CULTURAL_ART`), URL codes are lowercase (`/sejong/club?category=cultural_art`). Anything that ends up in a URL — path segment, query param, canonical/OG URL — must be lowercase. Never interpolate an API/enum code into a URL directly, and never call `toLowerCase()` / `toUpperCase()` on a code at the call site. Always go through `toUrlCode` / `toApiCode` from `@/shared/lib/urlCodeConverter` — this is the only place either casing conversion may happen.
+
+    ```ts
+    // Forbidden — enum code leaks into the URL
+    href={`/${universityCode}/club?category=${ClubCategoryToLabel[category]}`}
+    // Forbidden — ad-hoc conversion scattered across call sites
+    router.push(`/${university.code.toLowerCase()}`);
+
+    // Correct
+    href={`/${universityCode}/club?category=${toUrlCode(ClubCategoryToLabel[category])}`}
+    router.push(`/${toUrlCode(university.code)}`);
+    ```
+
+    This applies to every enum-backed code that travels through a URL — university codes, `ClubCategory`, `ClubAffiliation`, and any future one. Do not add domain-specific casing wrappers; they duplicate the converter.
+
+    Inside `[universityCode]` routes, `useUniversityCode()` already returns the URL code — use it as is. Convert only when handing the value to the API.
 
 ## Commit Rules
 

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -4,8 +4,8 @@ import { getUniversityName } from '@/shared/lib/universityMeta';
 function Page() {
   return (
     <HomePage
-      universityName={getUniversityName('SEJONG')}
-      universityCode="SEJONG"
+      universityName={getUniversityName('sejong')}
+      universityCode="sejong"
     />
   );
 }

--- a/src/app/[universityCode]/(admin)/admin/(edit)/layout.tsx
+++ b/src/app/[universityCode]/(admin)/admin/(edit)/layout.tsx
@@ -6,10 +6,8 @@ import { redirect } from 'next/navigation';
 import getCurrentUserRole from '@/shared/api/getCurrentUserRole';
 import { UserRole } from '@/shared/model/type';
 import AdminHeader from '@/shared/ui/AdminHeader';
-import {
-  getUniversityName,
-  urlCodeToApiCode,
-} from '@/shared/lib/universityMeta';
+import { getUniversityName } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 
 export async function generateMetadata({
   params,
@@ -17,7 +15,7 @@ export async function generateMetadata({
   params: Promise<{ universityCode: string }>;
 }): Promise<Metadata> {
   const { universityCode } = await params;
-  const universityName = getUniversityName(urlCodeToApiCode(universityCode));
+  const universityName = getUniversityName(universityCode);
 
   return {
     title: `모꼬지 | ${universityName} 동아리 모집 플랫폼`,

--- a/src/app/[universityCode]/(admin)/admin/(main)/layout.tsx
+++ b/src/app/[universityCode]/(admin)/admin/(main)/layout.tsx
@@ -6,10 +6,8 @@ import { redirect } from 'next/navigation';
 import getCurrentUserRole from '@/shared/api/getCurrentUserRole';
 import { UserRole } from '@/shared/model/type';
 import AdminHeader from '@/shared/ui/AdminHeader';
-import {
-  getUniversityName,
-  urlCodeToApiCode,
-} from '@/shared/lib/universityMeta';
+import { getUniversityName } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 
 export async function generateMetadata({
   params,
@@ -17,7 +15,7 @@ export async function generateMetadata({
   params: Promise<{ universityCode: string }>;
 }): Promise<Metadata> {
   const { universityCode } = await params;
-  const universityName = getUniversityName(urlCodeToApiCode(universityCode));
+  const universityName = getUniversityName(universityCode);
 
   return {
     title: `모꼬지 | ${universityName} 동아리 모집 플랫폼`,

--- a/src/app/[universityCode]/(home)/layout.tsx
+++ b/src/app/[universityCode]/(home)/layout.tsx
@@ -4,10 +4,8 @@ import Footer from '@/shared/ui/Footer';
 import 'to-do-pin/index.css';
 import type { Metadata } from 'next';
 import BottomNav from '@/shared/ui/bottom-nav';
-import {
-  getUniversityName,
-  urlCodeToApiCode,
-} from '@/shared/lib/universityMeta';
+import { getUniversityName } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 
 export async function generateMetadata({
   params,
@@ -15,7 +13,7 @@ export async function generateMetadata({
   params: Promise<{ universityCode: string }>;
 }): Promise<Metadata> {
   const { universityCode } = await params;
-  const universityName = getUniversityName(urlCodeToApiCode(universityCode));
+  const universityName = getUniversityName(universityCode);
 
   return {
     title: `모꼬지 | ${universityName} 동아리 모집 플랫폼`,

--- a/src/app/[universityCode]/(home)/page.tsx
+++ b/src/app/[universityCode]/(home)/page.tsx
@@ -1,8 +1,6 @@
 import HomePage from '@/views/home/ui/home-page';
-import {
-  getUniversityName,
-  urlCodeToApiCode,
-} from '@/shared/lib/universityMeta';
+import { getUniversityName } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 
 async function Page({
   params,
@@ -10,7 +8,7 @@ async function Page({
   params: Promise<{ universityCode: string }>;
 }) {
   const { universityCode } = await params;
-  const apiUniversityCode = urlCodeToApiCode(universityCode);
+  const apiUniversityCode = toApiCode(universityCode);
   const universityName = getUniversityName(apiUniversityCode);
 
   return (

--- a/src/app/[universityCode]/(main)/club-register/layout.tsx
+++ b/src/app/[universityCode]/(main)/club-register/layout.tsx
@@ -1,9 +1,7 @@
 import type { Metadata } from 'next';
 import { ReactNode } from 'react';
-import {
-  getUniversityName,
-  urlCodeToApiCode,
-} from '@/shared/lib/universityMeta';
+import { getUniversityName } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 
 export async function generateMetadata({
   params,
@@ -11,7 +9,7 @@ export async function generateMetadata({
   params: Promise<{ universityCode: string }>;
 }): Promise<Metadata> {
   const { universityCode } = await params;
-  const universityName = getUniversityName(urlCodeToApiCode(universityCode));
+  const universityName = getUniversityName(universityCode);
 
   return {
     title: `모꼬지 | ${universityName} 동아리 등록`,

--- a/src/app/[universityCode]/(main)/club/[id]/page.tsx
+++ b/src/app/[universityCode]/(main)/club/[id]/page.tsx
@@ -3,10 +3,8 @@ import { Suspense } from 'react';
 import ClubDetailSkeleton from '@/entities/club/ui/club-detail-skeleton';
 import { type Metadata } from 'next';
 import getClubDetail from '@/views/club/api/getClubDetail';
-import {
-  getUniversityName,
-  urlCodeToApiCode,
-} from '@/shared/lib/universityMeta';
+import { getUniversityName } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 
 interface PageProps {
   params: Promise<{ universityCode: string; id: string }>;
@@ -18,7 +16,7 @@ export async function generateMetadata({
 }: PageProps): Promise<Metadata> {
   const { universityCode, id } = await params;
   const result = await getClubDetail(Number(id));
-  const universityName = getUniversityName(urlCodeToApiCode(universityCode));
+  const universityName = getUniversityName(universityCode);
 
   if (!result.ok || !result.data) {
     return {

--- a/src/app/[universityCode]/(main)/club/layout.tsx
+++ b/src/app/[universityCode]/(main)/club/layout.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from 'next';
-import {
-  getUniversityName,
-  urlCodeToApiCode,
-} from '@/shared/lib/universityMeta';
+import { getUniversityName } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 
 export async function generateMetadata({
   params,
@@ -10,7 +8,7 @@ export async function generateMetadata({
   params: Promise<{ universityCode: string }>;
 }): Promise<Metadata> {
   const { universityCode } = await params;
-  const universityName = getUniversityName(urlCodeToApiCode(universityCode));
+  const universityName = getUniversityName(universityCode);
 
   return {
     title: `모꼬지 | ${universityName} 동아리`,

--- a/src/app/[universityCode]/(main)/club/page.tsx
+++ b/src/app/[universityCode]/(main)/club/page.tsx
@@ -1,6 +1,6 @@
 import ClubPage from '@/views/club/ui/club-page';
 import { type SearchParams } from 'nuqs/server';
-import { urlCodeToApiCode } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 import { searchParamsCache } from './search-params';
 
 type PageProps = {
@@ -11,7 +11,7 @@ type PageProps = {
 async function Page({ params, searchParams }: PageProps) {
   const { universityCode } = await params;
   await searchParamsCache.parse(searchParams);
-  return <ClubPage universityCode={urlCodeToApiCode(universityCode)} />;
+  return <ClubPage universityCode={toApiCode(universityCode)} />;
 }
 
 export default Page;

--- a/src/app/[universityCode]/(main)/favorite/layout.tsx
+++ b/src/app/[universityCode]/(main)/favorite/layout.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from 'next';
-import {
-  getUniversityName,
-  urlCodeToApiCode,
-} from '@/shared/lib/universityMeta';
+import { getUniversityName } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 
 export async function generateMetadata({
   params,
@@ -10,7 +8,7 @@ export async function generateMetadata({
   params: Promise<{ universityCode: string }>;
 }): Promise<Metadata> {
   const { universityCode } = await params;
-  const universityName = getUniversityName(urlCodeToApiCode(universityCode));
+  const universityName = getUniversityName(universityCode);
 
   return {
     title: `모꼬지 | ${universityName} 동아리 즐겨찾기`,

--- a/src/app/[universityCode]/(main)/layout.tsx
+++ b/src/app/[universityCode]/(main)/layout.tsx
@@ -6,10 +6,8 @@ import 'to-do-pin/index.css';
 import type { Metadata } from 'next';
 import BottomNav from '@/shared/ui/bottom-nav';
 import QueryProvider from '@/shared/lib/QueryProvider';
-import {
-  getUniversityName,
-  urlCodeToApiCode,
-} from '@/shared/lib/universityMeta';
+import { getUniversityName } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 
 export async function generateMetadata({
   params,
@@ -17,7 +15,7 @@ export async function generateMetadata({
   params: Promise<{ universityCode: string }>;
 }): Promise<Metadata> {
   const { universityCode } = await params;
-  const universityName = getUniversityName(urlCodeToApiCode(universityCode));
+  const universityName = getUniversityName(universityCode);
 
   return {
     title: `모꼬지 | ${universityName} 동아리 모집 플랫폼`,

--- a/src/app/[universityCode]/(main)/post-recruitment/[id]/layout.tsx
+++ b/src/app/[universityCode]/(main)/post-recruitment/[id]/layout.tsx
@@ -1,9 +1,7 @@
 import type { Metadata } from 'next';
 import { ReactNode } from 'react';
-import {
-  getUniversityName,
-  urlCodeToApiCode,
-} from '@/shared/lib/universityMeta';
+import { getUniversityName } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 
 export async function generateMetadata({
   params,
@@ -11,7 +9,7 @@ export async function generateMetadata({
   params: Promise<{ universityCode: string }>;
 }): Promise<Metadata> {
   const { universityCode } = await params;
-  const universityName = getUniversityName(urlCodeToApiCode(universityCode));
+  const universityName = getUniversityName(universityCode);
 
   return {
     title: `모꼬지 | ${universityName} 동아리 모집 공고 작성`,

--- a/src/app/[universityCode]/(main)/search/layout.tsx
+++ b/src/app/[universityCode]/(main)/search/layout.tsx
@@ -1,9 +1,7 @@
 import type { Metadata } from 'next';
 import { ReactNode } from 'react';
-import {
-  getUniversityName,
-  urlCodeToApiCode,
-} from '@/shared/lib/universityMeta';
+import { getUniversityName } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 
 export async function generateMetadata({
   params,
@@ -11,7 +9,7 @@ export async function generateMetadata({
   params: Promise<{ universityCode: string }>;
 }): Promise<Metadata> {
   const { universityCode } = await params;
-  const universityName = getUniversityName(urlCodeToApiCode(universityCode));
+  const universityName = getUniversityName(universityCode);
 
   return {
     title: `모꼬지 | ${universityName} 동아리 검색`,

--- a/src/app/[universityCode]/(main)/search/page.tsx
+++ b/src/app/[universityCode]/(main)/search/page.tsx
@@ -1,6 +1,6 @@
 import SearchPage from '@/views/search/ui/search-page';
 import { type SearchParams } from 'nuqs/server';
-import { urlCodeToApiCode } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 import { searchParamsCache } from './search-params';
 
 type PageProps = {
@@ -11,7 +11,7 @@ type PageProps = {
 async function Page({ params, searchParams }: PageProps) {
   const { universityCode } = await params;
   await searchParamsCache.parse(searchParams);
-  return <SearchPage universityCode={urlCodeToApiCode(universityCode)} />;
+  return <SearchPage universityCode={toApiCode(universityCode)} />;
 }
 
 export default Page;

--- a/src/app/[universityCode]/(main)/support/layout.tsx
+++ b/src/app/[universityCode]/(main)/support/layout.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from 'next';
-import {
-  getUniversityName,
-  urlCodeToApiCode,
-} from '@/shared/lib/universityMeta';
+import { getUniversityName } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 
 export async function generateMetadata({
   params,
@@ -10,7 +8,7 @@ export async function generateMetadata({
   params: Promise<{ universityCode: string }>;
 }): Promise<Metadata> {
   const { universityCode } = await params;
-  const universityName = getUniversityName(urlCodeToApiCode(universityCode));
+  const universityName = getUniversityName(universityCode);
 
   return {
     title: `모꼬지 | ${universityName} 동아리 고객센터`,

--- a/src/app/api/auth/callback/kakao/route.ts
+++ b/src/app/api/auth/callback/kakao/route.ts
@@ -8,7 +8,7 @@ import {
 import UserInfoType from '@/entities/my/model/type';
 import getTokenExpiration from '@/shared/lib/getTokenExpiration';
 import { buildSessionCookie, CookieSession } from '@/shared/lib/cookie-session';
-import { urlCodeToApiCode } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -50,7 +50,7 @@ export async function GET(request: NextRequest) {
       // role 조회 실패해도 로그인은 성공 처리
     }
 
-    const apiUniversityCode = urlCodeToApiCode(
+    const apiUniversityCode = toApiCode(
       userResponseBody.data.universityCode ?? 'SEJONG',
     );
 

--- a/src/entities/club-detail/ui/club-detail-header.tsx
+++ b/src/entities/club-detail/ui/club-detail-header.tsx
@@ -5,6 +5,7 @@ import useUniversityCode from '@/shared/hooks/useUniversityCode';
 import ClubDetailHeaderControl from '@/features/club-detail/ui/club-detail-header-control';
 import RadiusTag from '@/shared/ui/radius-tag';
 import { ClubCategoryToLabel, RecruitStatus } from '@/shared/model/type';
+import { toUrlCode } from '@/shared/lib/urlCodeConverter';
 import Link from 'next/link';
 import ClickLogo from '@/shared/ui/click-logo';
 
@@ -44,7 +45,7 @@ function ClubDetailHeader({
         <h1 className="text-xl font-bold lg:text-4xl">{title}</h1>
         <p className="text-lg font-bold text-[#9C9C9C] lg:text-3xl">
           <Link
-            href={`/${universityCode}/club?category=${ClubCategoryToLabel[category]}`}
+            href={`/${universityCode}/club?category=${toUrlCode(ClubCategoryToLabel[category])}`}
           >
             {category} 동아리
           </Link>

--- a/src/entities/club-detail/ui/recruit-detail-header.tsx
+++ b/src/entities/club-detail/ui/recruit-detail-header.tsx
@@ -13,6 +13,7 @@ import {
   ClubCategory,
 } from '@/shared/model/type';
 import ClickLogo from '@/shared/ui/click-logo';
+import { toUrlCode } from '@/shared/lib/urlCodeConverter';
 import PeriodSection from '@/entities/club-detail/ui/period-section';
 
 interface RecruitDetailHeaderProps {
@@ -57,7 +58,7 @@ function RecruitDetailHeader({
           </h1>
           <p className="truncate text-2xl font-bold whitespace-nowrap text-[#9C9C9C] lg:text-4xl">
             <Link
-              href={`/${universityCode}/club?category=${ClubCategoryToLabel[category]}`}
+              href={`/${universityCode}/club?category=${toUrlCode(ClubCategoryToLabel[category])}`}
             >
               {ClubCategoryToStringLabel[category as ClubCategory]} 동아리
             </Link>

--- a/src/entities/home/ui/home-keyword-list.tsx
+++ b/src/entities/home/ui/home-keyword-list.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
+import { toUrlCode } from '@/shared/lib/urlCodeConverter';
 
 import Image from 'next/image';
 import Link from 'next/link';
@@ -29,7 +30,7 @@ function HomeKeywordList() {
         {KEYWORDS.slice(0, 3).map((category) => (
           <Link
             key={category}
-            href={`/${universityCode}/search?category=${category.toLowerCase()}`}
+            href={`/${universityCode}/search?category=${toUrlCode(category)}`}
             className="flex w-fit items-center gap-1 rounded-full bg-[#F2F4F6] px-4 py-[10px] text-xs font-semibold transition-colors hover:bg-[#dadddf] lg:px-5 lg:py-2 lg:text-xl"
           >
             {ClubCategoryLabel[category]}
@@ -48,7 +49,7 @@ function HomeKeywordList() {
         {KEYWORDS.slice(3).map((category) => (
           <Link
             key={category}
-            href={`/${universityCode}/search?category=${category.toLowerCase()}`}
+            href={`/${universityCode}/search?category=${toUrlCode(category)}`}
             className="flex w-fit items-center gap-1 rounded-full bg-[#F2F4F6] px-4 py-[10px] text-xs font-semibold transition-colors hover:bg-[#dadddf] lg:px-5 lg:py-2 lg:text-xl"
           >
             {ClubCategoryLabel[category]}

--- a/src/features/club-create/ui/club-create-basic-step.tsx
+++ b/src/features/club-create/ui/club-create-basic-step.tsx
@@ -16,7 +16,7 @@ import {
   ClubCategoryToStringLabel,
 } from '@/shared/model/type';
 import type { University } from '@/entities/university/model/type';
-import { urlCodeToApiCode } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 import type { ClubCreateFormData } from './club-crete-form';
 
 interface ClubCreateBasicStepProps {
@@ -73,7 +73,7 @@ function ClubCreateBasicStep({
           onValueChange={(value) =>
             setFormData((prev) => ({
               ...prev,
-              universityCode: urlCodeToApiCode(value),
+              universityCode: toApiCode(value),
             }))
           }
         >

--- a/src/features/club-create/ui/club-crete-form.tsx
+++ b/src/features/club-create/ui/club-crete-form.tsx
@@ -7,7 +7,7 @@ import ky from 'ky';
 import { toast } from 'react-toastify';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
 import { useSession } from '@/shared/lib/session-context';
-import { urlCodeToApiCode } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 import convertImageToWebp, {
   LOGO_MAX_DIMENSION,
 } from '@/shared/lib/convertImageToWebp';
@@ -31,7 +31,7 @@ function ClubCreateForm({ universities }: ClubCreateFormProps) {
   const universityCode = useUniversityCode();
   const [formData, setFormData] = useState<ClubCreateFormData>({
     clubName: '',
-    universityCode: urlCodeToApiCode(universityCode),
+    universityCode: toApiCode(universityCode),
     clubCategory: '',
     clubAffiliation: '',
     logo: '',

--- a/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
+++ b/src/features/club-master-application/ui/ClubMasterApplicationForm.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
 import { useSession } from '@/shared/lib/session-context';
-import { urlCodeToApiCode } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 import { Button } from '@/shared/ui/button';
 import {
   Select,
@@ -33,14 +33,14 @@ function ClubMasterApplicationForm({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [selectedUniversityCode, setSelectedUniversityCode] = useState(
-    urlCodeToApiCode(universityCode),
+    toApiCode(universityCode),
   );
   const [selectedClubId, setSelectedClubId] = useState('');
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [clubs, setClubs] = useState<ClubSummary[]>([]);
 
   useEffect(() => {
-    getClubsByUniversity(urlCodeToApiCode(universityCode)).then((result) => {
+    getClubsByUniversity(toApiCode(universityCode)).then((result) => {
       setClubs(result);
       setIsClubsLoading(false);
     });

--- a/src/shared/lib/universityMeta.ts
+++ b/src/shared/lib/universityMeta.ts
@@ -1,16 +1,14 @@
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
+
 export const universityDisplayName: Record<string, string> = {
   SEJONG: '세종대학교',
   KONKUK: '건국대학교',
 };
 
 export function getUniversityName(code: string): string {
-  return universityDisplayName[code.toUpperCase()] ?? code;
-}
-
-export function urlCodeToApiCode(urlCode: string): string {
-  return urlCode.toUpperCase();
+  return universityDisplayName[toApiCode(code)] ?? code;
 }
 
 export function isValidUniversityCode(code: string): boolean {
-  return code.toUpperCase() in universityDisplayName;
+  return toApiCode(code) in universityDisplayName;
 }

--- a/src/shared/lib/urlCodeConverter.ts
+++ b/src/shared/lib/urlCodeConverter.ts
@@ -1,0 +1,12 @@
+/**
+ * URL에 노출되는 코드는 항상 소문자, API/enum 코드는 항상 대문자다.
+ * 호출부에서 toLowerCase()/toUpperCase()를 직접 쓰지 말고 이 두 함수만 거친다.
+ */
+
+export function toUrlCode(apiCode: string): string {
+  return apiCode.toLowerCase();
+}
+
+export function toApiCode(urlCode: string): string {
+  return urlCode.toUpperCase();
+}

--- a/src/shared/model/useUrlParams.tsx
+++ b/src/shared/model/useUrlParams.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { parseAsInteger, parseAsString, useQueryState } from 'nuqs';
+import { toApiCode, toUrlCode } from '@/shared/lib/urlCodeConverter';
 
 function useUrlParams(key: string) {
   const [rawActive, setRawActive] = useQueryState(
@@ -14,10 +15,10 @@ function useUrlParams(key: string) {
     parseAsInteger.withOptions({ shallow: false, history: 'push' }),
   );
 
-  const active = rawActive.toUpperCase();
+  const active = toApiCode(rawActive);
 
   const handleChange = (value: string) => {
-    setRawActive(value === 'ALL' || value === '' ? null : value.toLowerCase());
+    setRawActive(value === 'ALL' || value === '' ? null : toUrlCode(value));
     setPage(1);
   };
 

--- a/src/shared/ui/favorite-button.tsx
+++ b/src/shared/ui/favorite-button.tsx
@@ -6,7 +6,7 @@ import throttle from 'lodash/throttle';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSession } from '@/shared/lib/session-context';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
-import { urlCodeToApiCode } from '@/shared/lib/universityMeta';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 import FavoriteThread from './favorite-thread';
 import postFavorite from '../api/post-favorite';
 import deleteFavorite from '../api/delete-favorite';
@@ -36,10 +36,7 @@ function FavoriteButton({
           toast.error('로그인 후 이용하실 수 있습니다.');
           return;
         }
-        if (
-          !favorite &&
-          session.universityCode !== urlCodeToApiCode(universityCode)
-        ) {
+        if (!favorite && session.universityCode !== toApiCode(universityCode)) {
           toast.error('다른 학교의 동아리는 즐겨찾기할 수 없습니다.');
           return;
         }

--- a/src/widgets/admin/ui/use-admin-clubs.ts
+++ b/src/widgets/admin/ui/use-admin-clubs.ts
@@ -2,6 +2,7 @@
 
 import { useInfiniteQuery } from '@tanstack/react-query';
 import adminQueries from '@/entities/admin/api/queries';
+import { toUrlCode } from '@/shared/lib/urlCodeConverter';
 
 function useAdminClubs(universityCode?: string) {
   const infiniteQuery = useInfiniteQuery(adminQueries.clubs(universityCode));
@@ -10,7 +11,7 @@ function useAdminClubs(universityCode?: string) {
 
   return {
     clubs,
-    universityCode: universityCode?.toLowerCase() ?? '',
+    universityCode: universityCode ? toUrlCode(universityCode) : '',
     isLoading: infiniteQuery.isLoading,
     fetchNextPage: infiniteQuery.fetchNextPage,
     hasNextPage: infiniteQuery.hasNextPage,

--- a/src/widgets/club/ui/club-item-list.tsx
+++ b/src/widgets/club/ui/club-item-list.tsx
@@ -1,6 +1,7 @@
 import { ClubAffiliation, ClubCategory } from '@/shared/model/type';
 import ErrorBoundaryUi from '@/shared/ui/error-boundary-ui';
 import { searchParamsCache } from '@/shared/lib/club-search-params';
+import { toApiCode } from '@/shared/lib/urlCodeConverter';
 import NumberPagination from '@/shared/ui/numberPagination';
 import FeedbackModal from '@/widgets/feedback/ui/feedback-modal';
 import getClubList from '../api/getClubList';
@@ -9,8 +10,8 @@ import ClubItemClientList from './club-item-client-list';
 async function ClubItemList({ universityCode }: { universityCode: string }) {
   const page = Number(searchParamsCache.get('page') ?? 1);
   const size = 15;
-  const category = searchParamsCache.get('category').toUpperCase();
-  const affiliation = searchParamsCache.get('affiliation').toUpperCase();
+  const category = toApiCode(searchParamsCache.get('category'));
+  const affiliation = toApiCode(searchParamsCache.get('affiliation'));
   const keyword = searchParamsCache.get('keyword');
   const clubListResponse = await getClubList({
     page,

--- a/src/widgets/login/ui/university-select-modal-wrapper.tsx
+++ b/src/widgets/login/ui/university-select-modal-wrapper.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import { toast } from 'react-toastify';
 import type { University } from '@/entities/university/model/type';
 import patchUniversityCode from '@/features/my/api/patchUniversityCode';
+import { toUrlCode } from '@/shared/lib/urlCodeConverter';
 import { Button } from '@/shared/ui/button';
 import {
   Dialog,
@@ -47,7 +48,7 @@ function UniversitySelectModalWrapper({
     setIsConfirmOpen(false);
     setIsOpen(false);
 
-    router.push(`/${code}`);
+    router.push(`/${toUrlCode(code)}`);
     router.refresh();
   };
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> closes #677

## 📝작업 내용

### 문제

백엔드 학교 코드(`SEJONG`)와 동아리 카테고리 enum(`CULTURAL_ART`)이 url에 그대로 노출되어 `/SEJONG/club?category=CULTURAL_ART` 형태의 대문자 url이 생성되고 있었습니다.

대문자 url로 한번 진입하면 `useUniversityCode()`가 해당 세그먼트를 그대로 반환하므로 이후 모든 링크에 대문자가 전파됩니다. 또한 미들웨어의 `/^[a-z]+$/` 검사가 실패해 `stripUniversityCodePrefix`가 동작하지 않고, 그 결과 `publicRoutes` 매칭에 실패해 비로그인 상태에서 공개 경로도 로그인으로 리다이렉트됩니다.

### 대문자가 유입되던 지점

- `university-select-modal-wrapper` — api 코드(`SEJONG`)로 `router.push`
- `app/(home)/page.tsx` — 대문자 학교 코드 하드코딩
- `club-detail-header` / `recruit-detail-header` — 카테고리 enum을 그대로 쿼리 파라미터로 전달

### 해결

url 코드(소문자)와 api/enum 코드(대문자) 변환을 `shared/lib/urlCodeConverter`의 `toUrlCode` / `toApiCode` 한 곳으로 모았습니다.

호출부마다 `toLowerCase()` / `toUpperCase()`를 직접 붙이는 방식은 반복적으로 누락되어 왔기 때문에, 변환 지점을 하나로 통일하고 규칙으로 강제하는 방향을 택했습니다.

- `universityMeta`의 `urlCodeToApiCode`는 컨버터와 동일한 동작이라 제거하고 호출부를 일괄 정리했습니다
- `getUniversityName`이 내부에서 이미 대문자화하므로 `getUniversityName(urlCodeToApiCode(x))` 이중 변환도 함께 제거했습니다
- 학교 코드뿐 아니라 `ClubCategory` / `ClubAffiliation` 등 url을 타는 모든 enum에 동일하게 적용했습니다

### 규칙 추가

CLAUDE.md 개발 원칙에 11번 항목을 추가했습니다.

> url에 들어가는 모든 enum/api 코드는 소문자여야 하며, 변환은 `urlCodeConverter`를 거쳐야 한다. 호출부에서 `toLowerCase()` / `toUpperCase()`를 직접 호출하지 않는다. 도메인별 변환 래퍼를 새로 만들지 않는다.

## 💬리뷰 요구사항(선택)

- 이미 외부로 나간 대문자 url(북마크, 공유 링크, 검색엔진 색인)을 구제하려면 미들웨어에서 소문자로 리다이렉트하는 안전망이 추가로 필요합니다. 다만 소프트 내비게이션에서 하드 내비게이션으로 떨어져 화면 깜빡임이 생길 수 있어 이번 PR에서는 제외했습니다. 별도 이슈로 다룰지 의견 부탁드립니다.
- `useUrlParams`의 `active` 비교값이 대문자 기준이라 `toApiCode`를 적용했는데, 이 훅이 카테고리/제휴 외 다른 파라미터에도 쓰이는지 확인 부탁드립니다.