### PR TITLE
[#688] fix: 센트리 에러 보고 정상화 및 보고 범위 확장

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -51,10 +51,10 @@ let nextConfig: NextConfig = {
 if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
   nextConfig = withSentryConfig(nextConfig, {
     // Sentry 조직 슬러그 – Sentry 프로젝트가 속한 조직의 ID
-    org: 'sejong',
+    org: 'mokkoji-4m',
 
     // Sentry 프로젝트 이름 – 오류가 기록될 프로젝트
-    project: 'mokkoji-next-js',
+    project: 'mokkoji',
 
     // CI 환경이 아닐 때는 소스맵 업로드 관련 로그를 출력하지 않음 (로컬 빌드 시 출력 줄이기)
     silent: !process.env.CI,

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -4,10 +4,24 @@ if (process.env.NEXT_PUBLIC_SENTRY_REPLAY_DSN) {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_REPLAY_DSN,
 
-    integrations: [Sentry.replayIntegration()],
-    // Session Replay
-    replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-    replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+    integrations: [
+      // 세션 리플레이 녹화 시 개인정보가 그대로 찍히지 않도록 전부 가림
+      Sentry.replayIntegration({
+        maskAllText: true, // 모든 텍스트를 ●●● 형태로 마스킹
+        maskAllInputs: true, // 입력값(이메일, 비밀번호 등) 마스킹
+        blockAllMedia: true, // 이미지/영상은 녹화에서 제외 (용량 절감 + 유출 방지)
+      }),
+    ],
+
+    // 에러 직전 사용자 행동(클릭, URL 이동 등) 기록 개수.
+    // 재현은 세션 리플레이로 하므로 기본값 100에서 절반으로 줄여 전송량을 아낌
+    maxBreadcrumbs: 50,
+
+    // 에러 없는 일반 세션도 1%만 표본으로 녹화.
+    // 예외가 안 던져지는 문제(무한 로딩, 이탈 등)를 보기 위한 최소한의 표본
+    replaysSessionSampleRate: 0.01,
+    // 에러가 발생한 세션은 100% 녹화 (버그 재현용)
+    replaysOnErrorSampleRate: 1.0,
 
     beforeSend(event, hint) {
       const error = hint.originalException;

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,8 +1,8 @@
 import * as Sentry from '@sentry/nextjs';
 
-if (process.env.NEXT_PUBLIC_SENTRY_REPLAY_DSN) {
+if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
   Sentry.init({
-    dsn: process.env.NEXT_PUBLIC_SENTRY_REPLAY_DSN,
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
     integrations: [
       // 세션 리플레이 녹화 시 개인정보가 그대로 찍히지 않도록 전부 가림

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -9,6 +9,9 @@ if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
+    // 세션 리플레이는 브라우저 DOM을 녹화하는 기능이라 엣지에도 넣지 않음.
+    // replayIntegration은 sentry.client.config.ts에만 등록되어 있음
+
     // 요청 10개 중 1개만 성능 데이터 전송 (Sentry 전송량 절감)
     tracesSampleRate: 0.1,
 

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -8,6 +8,9 @@ if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
+    // 세션 리플레이는 브라우저 DOM을 녹화하는 기능이라 서버에는 넣지 않음.
+    // replayIntegration은 sentry.client.config.ts에만 등록되어 있음
+
     // 요청 10개 중 1개만 성능 데이터 전송 (Sentry 전송량 절감)
     tracesSampleRate: 0.1,
 

--- a/src/app/(admin)/dashboard/(main)/error.tsx
+++ b/src/app/(admin)/dashboard/(main)/error.tsx
@@ -1,7 +1,0 @@
-'use client';
-
-import ErrorPage from '@/entities/error/ui/error-page';
-
-export default function DashboardError() {
-  return <ErrorPage statusCode={500} showHomeButton={false} />;
-}

--- a/src/app/(admin)/dashboard/error.tsx
+++ b/src/app/(admin)/dashboard/error.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import ErrorBoundaryFallback, {
+  type ErrorBoundaryProps,
+} from '@/entities/error/ui/error-boundary-fallback';
+
+export default function DashboardError({ error }: ErrorBoundaryProps) {
+  return <ErrorBoundaryFallback error={error} showHomeButton={false} />;
+}

--- a/src/app/[universityCode]/(main)/error.tsx
+++ b/src/app/[universityCode]/(main)/error.tsx
@@ -1,7 +1,0 @@
-'use client';
-
-import ErrorPage from '@/entities/error/ui/error-page';
-
-export default function Error() {
-  return <ErrorPage statusCode={500} />;
-}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import ErrorBoundaryFallback, {
+  type ErrorBoundaryProps,
+} from '@/entities/error/ui/error-boundary-fallback';
+
+export default function RootError({ error }: ErrorBoundaryProps) {
+  return <ErrorBoundaryFallback error={error} />;
+}

--- a/src/entities/error/ui/error-boundary-fallback.tsx
+++ b/src/entities/error/ui/error-boundary-fallback.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import { useEffect } from 'react';
+
+import ErrorPage from './error-page';
+
+export interface ErrorBoundaryProps {
+  error: Error & { digest?: string };
+}
+
+interface ErrorBoundaryFallbackProps extends ErrorBoundaryProps {
+  showHomeButton?: boolean;
+}
+
+function ErrorBoundaryFallback({
+  error,
+  showHomeButton,
+}: ErrorBoundaryFallbackProps) {
+  useEffect(() => {
+    // digest가 있으면 서버에서 던져진 예외이고, instrumentation의
+    // onRequestError가 전체 스택과 함께 이미 보고했다. 여기서 또 보내면
+    // digest만 담긴 중복 이벤트가 쌓인다.
+    if (error.digest) return;
+
+    Sentry.captureException(error);
+  }, [error]);
+
+  return <ErrorPage statusCode={500} showHomeButton={showHomeButton} />;
+}
+
+export default ErrorBoundaryFallback;

--- a/src/shared/lib/error-message.ts
+++ b/src/shared/lib/error-message.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs';
 import { HTTPError } from 'ky';
 
 function getHttpErrorMessage(status: number) {
@@ -39,6 +40,12 @@ async function createErrorResponse(
 ) {
   if (error instanceof HTTPError) {
     const { status } = error.response;
+
+    // 4xx는 비로그인·없는 리소스처럼 정상 흐름인 경우가 대부분이라 제외한다
+    if (status >= 500) {
+      Sentry.captureException(error);
+    }
+
     const serverMessage = await readServerMessage(error);
     if (serverMessage) {
       return { ok: false, message: serverMessage, data: undefined, status };
@@ -53,6 +60,8 @@ async function createErrorResponse(
       status,
     };
   }
+  // HTTPError가 아니면 네트워크 단절, JSON 파싱 실패 등 예상하지 못한 상황이다
+  Sentry.captureException(error);
   return {
     ok: false,
     message: '알 수 없는 오류가 발생했습니다.',


### PR DESCRIPTION
## #️⃣연관된 이슈
> closes #688

## 📝작업 내용

센트리 설정을 살펴보다 **프로덕션에서 클라이언트 SDK가 아예 초기화되지 않고 있다는 것**을 발견해, 그 수정과 함께 보고 범위 전반을 정리했습니다.

### 1. 프로덕션 클라이언트 센트리 미동작 수정 (`d5514205`)

`sentry.client.config.ts`만 `NEXT_PUBLIC_SENTRY_REPLAY_DSN`을 보고 있었는데, 배포 환경에는 `NEXT_PUBLIC_SENTRY_DSN`만 설정되어 있었습니다.
`NEXT_PUBLIC_*`는 빌드 타임에 인라인되므로 값이 없으면 `Sentry.init` 자체가 실행되지 않습니다. 그 결과 다음이 전부 동작하지 않고 있었습니다.

- 세션 리플레이 녹화
- 클라이언트 렌더링 예외 보고
- 전역 핸들러(`window.onerror`) 보고

DSN을 나누면 에러와 리플레이가 서로 다른 프로젝트로 흩어져 "이 에러가 난 세션 녹화 보기" 연결이 끊기고, 소스맵도 한쪽에만 올라갑니다. 하나로 통일했습니다.

함께 소스맵 업로드 대상 `org` / `project` 슬러그도 실제 값으로 정정했습니다. 기존 값이 존재하지 않는 조직을 가리키고 있어 업로드가 실패해왔을 것으로 보입니다.

### 2. 보고 범위 확장 및 에러 바운더리 정리 (`7541779e`)

기존에는 렌더링 중 던져진 예외만 잡혔습니다. API 호출은 `createErrorResponse`가 `{ ok: false }` 값으로 바꾸기 때문에 **백엔드 5xx와 네트워크 실패가 흔적 없이 사라지고** 있었습니다.

- `createErrorResponse`에서 5xx와 `HTTPError`가 아닌 예외를 보고합니다. 41개 호출부가 모두 이 함수를 거치므로 한 곳에서 커버됩니다. 4xx는 비로그인·없는 리소스처럼 정상 흐름이라 제외했습니다.
- 경계가 `(main)` 하위에만 있어 홈·로그인·동아리신청·어드민에서 예외가 나면 `global-error`로 직행해 레이아웃까지 날아갔습니다. `app/error.tsx`와 `dashboard/error.tsx` 둘로 올려 **21개 페이지를 전부** 덮습니다. 상위가 덮으므로 `(main)` 하위 2개는 제거해 경계 수는 그대로입니다.
- 보고 로직을 `ErrorBoundaryFallback`으로 공통화했습니다. `digest`가 있으면 서버에서 던져진 예외이고 `onRequestError`가 전체 스택과 함께 이미 보고했으므로, digest만 담긴 중복 이벤트를 건너뜁니다.

### 3. 리플레이 마스킹 및 전송량 축소 (`ee96961c`)

- `maskAllText` / `maskAllInputs` / `blockAllMedia` — 녹화본 개인정보 노출 차단
- `maxBreadcrumbs` 100 → 50 — 재현은 리플레이로 하므로 축소
- `replaysSessionSampleRate` 0.1 → 0.01 — 에러 없는 세션의 녹화 쿼터 절감
- 서버/엣지에 리플레이를 두지 않는 이유를 주석으로 명시

## 💬리뷰 요구사항(선택)

**배포 후 확인 부탁드립니다.**

1. 브라우저 콘솔에 `🧩 Sentry disabled in dev mode`가 더 이상 뜨지 않는지
2. Vercel 빌드 로그에서 소스맵 업로드가 성공하는지 (`silent: !process.env.CI`라 CI에서는 로그가 보입니다)
3. 클라이언트 에러가 실제로 센트리에 올라오는지

**남겨둔 것**

- `deploy-docker.yml` / `docker-compose.yml`의 `NEXT_PUBLIC_SENTRY_REPLAY_DSN` 4곳 — 이제 아무도 읽지 않는 값입니다. Docker 배포를 유지하실 계획이면 같이 정리하는 게 좋겠습니다.
- 이슈에 적어둔 `environment`, `tracePropagationTargets`, `beforeSendTransaction`, `instrumentation-client.ts` 마이그레이션은 이번 PR에 넣지 않았습니다.