### PR TITLE
feat: presigned URL 업로드 시 Cache-Control 헤더 추가

### DIFF
--- a/src/features/admin-club-description/ui/edit/edit-flow-container.tsx
+++ b/src/features/admin-club-description/ui/edit/edit-flow-container.tsx
@@ -4,6 +4,7 @@ import { Suspense, useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import ky from 'ky';
+import uploadToPresignedUrl from '@/shared/api/uploadToPresignedUrl';
 import { ClubInfoType } from '@/shared/model/type';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
 import convertImageToWebp, {
@@ -90,12 +91,10 @@ function EditFlowContent({ clubInfo, clubId }: ClubEditFlowContainerProps) {
 
     if (logoFile && res.data && res.data.data?.updateLogo) {
       try {
-        const resUpdateLogo = await ky.put(res.data.data.updateLogo, {
-          body: logoFile,
-          headers: {
-            'Content-Type': logoFile.type,
-          },
-        });
+        const resUpdateLogo = await uploadToPresignedUrl(
+          res.data.data.updateLogo,
+          logoFile,
+        );
         if (!resUpdateLogo.ok) {
           toast.error('로고 업데이트 실패!');
           flow.setSubmitting(false);

--- a/src/features/admin-recruitment/ui/create/create-flow-container.tsx
+++ b/src/features/admin-recruitment/ui/create/create-flow-container.tsx
@@ -5,7 +5,7 @@ import useUniversityCode from '@/shared/hooks/useUniversityCode';
 import { Suspense, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
-import ky from 'ky';
+import uploadToPresignedUrl from '@/shared/api/uploadToPresignedUrl';
 import { ClubInfoType } from '@/shared/model/type';
 import useImageUpload from '@/shared/model/useImageUpload';
 import { Button } from '@/shared/ui/button';
@@ -64,10 +64,7 @@ function CreateFlowContent({ clubId, clubInfo }: CreateFlowContainerProps) {
       if (uploadUrls.length > 0) {
         await Promise.all(
           uploadUrls.map((url: string, i: number) =>
-            ky.put(url, {
-              body: imageUpload.imageFiles[i].file,
-              headers: { 'Content-Type': imageUpload.imageFiles[i].file.type },
-            }),
+            uploadToPresignedUrl(url, imageUpload.imageFiles[i].file),
           ),
         );
       }

--- a/src/features/admin-recruitment/ui/edit/edit-flow-container.tsx
+++ b/src/features/admin-recruitment/ui/edit/edit-flow-container.tsx
@@ -5,7 +5,7 @@ import useUniversityCode from '@/shared/hooks/useUniversityCode';
 import { Suspense, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
-import ky from 'ky';
+import uploadToPresignedUrl from '@/shared/api/uploadToPresignedUrl';
 import { ClubInfoType } from '@/shared/model/type';
 import useImageUpload from '@/shared/model/useImageUpload';
 import { Button } from '@/shared/ui/button';
@@ -125,10 +125,7 @@ function EditFlowContent({ clubInfo, recruitments }: EditFlowContainerProps) {
       if (uploadUrls.length > 0) {
         await Promise.all(
           uploadUrls.map((url: string, i: number) =>
-            ky.put(url, {
-              body: imageUpload.imageFiles[i].file,
-              headers: { 'Content-Type': imageUpload.imageFiles[i].file.type },
-            }),
+            uploadToPresignedUrl(url, imageUpload.imageFiles[i].file),
           ),
         );
       }

--- a/src/features/club-create/ui/club-crete-form.tsx
+++ b/src/features/club-create/ui/club-crete-form.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
-import ky from 'ky';
+import uploadToPresignedUrl from '@/shared/api/uploadToPresignedUrl';
 import { toast } from 'react-toastify';
 import useUniversityCode from '@/shared/hooks/useUniversityCode';
 import { useSession } from '@/shared/lib/session-context';
@@ -76,10 +76,10 @@ function ClubCreateForm({ universities }: ClubCreateFormProps) {
 
     const uploadLogoUrl = result.data?.data?.uploadLogoUrl;
     if (logoFile && uploadLogoUrl) {
-      const uploadLogoResult = await ky.put(uploadLogoUrl, {
-        body: logoFile,
-        headers: { 'Content-Type': logoFile.type },
-      });
+      const uploadLogoResult = await uploadToPresignedUrl(
+        uploadLogoUrl,
+        logoFile,
+      );
       if (!uploadLogoResult.ok) {
         setIsSubmitting(false);
         toast.error('로고 업로드에 실패했습니다.');

--- a/src/features/club-detail/ui/club-detail-recruitment-edit.tsx
+++ b/src/features/club-detail/ui/club-detail-recruitment-edit.tsx
@@ -11,7 +11,7 @@ import {
   RecruitmentFormState,
 } from '@/features/post-recruitment/model/type';
 import { toast } from 'react-toastify';
-import ky from 'ky';
+import uploadToPresignedUrl from '@/shared/api/uploadToPresignedUrl';
 import patchRecruitmentForm from '@/features/club-detail/api/patchRecruitment';
 import useImageUpload from '@/shared/model/useImageUpload';
 import ImageUploadSection from '@/shared/ui/image-upload-section';
@@ -95,10 +95,7 @@ function ClubDetailRecruitmentEdit({
       if (uploadUrls.length > 0) {
         await Promise.all(
           uploadUrls.map((url: string, i: number) =>
-            ky.put(url, {
-              body: imageFiles[i].file,
-              headers: { 'Content-Type': imageFiles[i].file.type },
-            }),
+            uploadToPresignedUrl(url, imageFiles[i].file),
           ),
         );
       }

--- a/src/features/club-register/ui/club-edit-form.tsx
+++ b/src/features/club-register/ui/club-edit-form.tsx
@@ -4,6 +4,7 @@ import useUniversityCode from '@/shared/hooks/useUniversityCode';
 
 import { useEffect, useReducer, useRef, useState } from 'react';
 import ky from 'ky';
+import uploadToPresignedUrl from '@/shared/api/uploadToPresignedUrl';
 import Image from 'next/image';
 import { toast } from 'react-toastify';
 import {
@@ -72,12 +73,10 @@ function ClubEditForm({ clubInfo, clubId }: ClubInfoProp) {
     }
 
     if (logoFile && res.data && res.data.data?.updateLogo) {
-      const resUpdateLogo = await ky.put(res.data.data.updateLogo, {
-        body: logoFile,
-        headers: {
-          'Content-Type': logoFile.type,
-        },
-      });
+      const resUpdateLogo = await uploadToPresignedUrl(
+        res.data.data.updateLogo,
+        logoFile,
+      );
       if (!resUpdateLogo.ok) {
         toast.error('로고 업데이트 실패!');
         return;

--- a/src/features/post-recruitment/ui/post-recruitment-form.tsx
+++ b/src/features/post-recruitment/ui/post-recruitment-form.tsx
@@ -9,7 +9,7 @@ import { ClubInfoType } from '@/shared/model/type';
 import Input from '@/shared/ui/input';
 import Textarea from '@/shared/ui/textarea';
 import DateRangePicker from '@/shared/ui/calendar/date-range-picker';
-import ky from 'ky';
+import uploadToPresignedUrl from '@/shared/api/uploadToPresignedUrl';
 import { useRouter } from 'next/navigation';
 import SafeForm from '@/shared/ui/safe-form';
 import useImageUpload from '@/shared/model/useImageUpload';
@@ -57,10 +57,7 @@ function PostRecruitmentForm({ clubInfo, clubId }: ClubInfoProp) {
         if (uploadUrls.length > 0) {
           await Promise.all(
             uploadUrls.map((url: string, index: number) =>
-              ky.put(url, {
-                body: imageFiles[index].file,
-                headers: { 'Content-Type': imageFiles[index].file.type },
-              }),
+              uploadToPresignedUrl(url, imageFiles[index].file),
             ),
           );
         }

--- a/src/shared/api/uploadToPresignedUrl.ts
+++ b/src/shared/api/uploadToPresignedUrl.ts
@@ -1,0 +1,15 @@
+import ky from 'ky';
+
+// 백엔드가 presigned 서명에 Cache-Control을 포함시키므로 동일한 값을 보내지 않으면 S3가 403을 반환한다.
+const IMAGE_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+
+const uploadToPresignedUrl = (presignedUrl: string, file: File) =>
+  ky.put(presignedUrl, {
+    body: file,
+    headers: {
+      'Content-Type': file.type,
+      'Cache-Control': IMAGE_CACHE_CONTROL,
+    },
+  });
+
+export default uploadToPresignedUrl;


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #692

## 📝작업 내용

이미지 캐싱 적용을 위해 백엔드에서 presigned URL 서명에 `Cache-Control: public, max-age=31536000, immutable` 을 포함시켰습니다. 현재 이미지는 백엔드를 거치지 않고 프론트가 presigned URL로 S3에 직접 업로드하므로, PUT 요청 시 프론트도 동일한 헤더를 보내야 합니다. 보내지 않으면 서명 불일치로 S3가 403을 반환합니다.

- `shared/api/uploadToPresignedUrl.ts` 추가 — `Content-Type` + `Cache-Control` 헤더를 담아 PUT 하는 공통 함수. 헤더 값이 백엔드 서명과 반드시 일치해야 하는 값이라 한 곳에서만 관리되도록 상수로 분리했습니다.
- 기존에 `ky.put`을 직접 호출하던 7개 지점을 공통 함수로 교체
  - `features/admin-recruitment/ui/create/create-flow-container.tsx`
  - `features/admin-recruitment/ui/edit/edit-flow-container.tsx`
  - `features/admin-club-description/ui/edit/edit-flow-container.tsx`
  - `features/club-create/ui/club-crete-form.tsx`
  - `features/club-detail/ui/club-detail-recruitment-edit.tsx`
  - `features/club-register/ui/club-edit-form.tsx`
  - `features/post-recruitment/ui/post-recruitment-form.tsx`

`club-edit-form.tsx`, `admin-club-description/edit-flow-container.tsx` 두 곳은 로고 삭제용 `ky.delete`가 남아있어 `ky` import를 유지했고, 나머지 5개 파일은 제거했습니다.

### 스크린샷 (선택)

UI 변경 없음

## 💬리뷰 요구사항(선택)

- 백엔드가 서명에 넣은 `Cache-Control` 값이 `public, max-age=31536000, immutable` 이 맞는지 확인 부탁드립니다. 한 글자라도 다르면 전체 이미지 업로드가 403으로 실패합니다.
- 배포 후 로고/모집공고 이미지 업로드가 실제로 성공하는지 확인이 필요합니다. 백엔드 배포와 순서가 맞아야 합니다.