### PR TITLE
[#696] perf: 프로덕션 번들에서 to-do-pin, msw 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "require-in-the-middle": "^7.5.2",
     "sanitize-html": "^2.17.6",
     "tailwind-merge": "^3.3.1",
-    "to-do-pin": "0.0.41",
     "web-vitals": "^5.1.0"
   },
   "devDependencies": {
@@ -114,6 +113,7 @@
     "prettier-plugin-tailwindcss": "0.6.11",
     "storybook": "8.6.14",
     "tailwindcss": "^4",
+    "to-do-pin": "0.0.41",
     "tsx": "^4.20.5",
     "tw-animate-css": "^1.3.5",
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,9 +140,6 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
-      to-do-pin:
-        specifier: 0.0.41
-        version: 0.0.41(lucide-react@0.548.0(react@19.1.2))(react-dom@19.1.2(react@19.1.2))(react-router-dom@7.8.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2))(react@19.1.2)
       web-vitals:
         specifier: ^5.1.0
         version: 5.1.0
@@ -276,6 +273,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.1.11
+      to-do-pin:
+        specifier: 0.0.41
+        version: 0.0.41(lucide-react@0.548.0(react@19.1.2))(react-dom@19.1.2(react@19.1.2))(react-router-dom@7.8.2(react-dom@19.1.2(react@19.1.2))(react@19.1.2))(react@19.1.2)
       tsx:
         specifier: ^4.20.5
         version: 4.20.5

--- a/src/_providers/msw-provider.tsx
+++ b/src/_providers/msw-provider.tsx
@@ -7,10 +7,14 @@ function MSWProvider({ children }: { children: React.ReactNode }) {
   const [isReady, setIsReady] = useState(!isMockingEnabled);
 
   useEffect(() => {
-    if (!isMockingEnabled) return;
-    import('@/mocks/browser').then(({ startMockWorker }) => {
-      startMockWorker().then(() => setIsReady(true));
-    });
+    // webpack은 조기 return 뒤의 도달 불가 코드에서도 import를 구문 단위로 수집한다.
+    // 죽은 분기로 인식시켜 msw 청크를 걷어내려면 import가 이 블록 안에 있어야 하고,
+    // 조건은 빌드 시 치환되는 env 표현식을 그대로 써야 한다.
+    if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
+      import('@/mocks/browser').then(({ startMockWorker }) => {
+        startMockWorker().then(() => setIsReady(true));
+      });
+    }
   }, []);
 
   if (!isReady) return null;

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -1,7 +1,6 @@
 import 'react-toastify/dist/ReactToastify.css';
 import Header from '@/shared/ui/Header';
 import Footer from '@/shared/ui/Footer';
-import 'to-do-pin/index.css';
 import type { Metadata } from 'next';
 import BottomNav from '@/shared/ui/bottom-nav';
 import QueryProvider from '@/shared/lib/QueryProvider';

--- a/src/app/[universityCode]/(admin)/admin/(edit)/layout.tsx
+++ b/src/app/[universityCode]/(admin)/admin/(edit)/layout.tsx
@@ -1,6 +1,5 @@
 import 'react-toastify/dist/ReactToastify.css';
 import Footer from '@/shared/ui/Footer';
-import 'to-do-pin/index.css';
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import getCurrentUserRole from '@/shared/api/getCurrentUserRole';

--- a/src/app/[universityCode]/(admin)/admin/(main)/layout.tsx
+++ b/src/app/[universityCode]/(admin)/admin/(main)/layout.tsx
@@ -1,6 +1,5 @@
 import 'react-toastify/dist/ReactToastify.css';
 import Footer from '@/shared/ui/Footer';
-import 'to-do-pin/index.css';
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import getCurrentUserRole from '@/shared/api/getCurrentUserRole';

--- a/src/app/[universityCode]/(home)/layout.tsx
+++ b/src/app/[universityCode]/(home)/layout.tsx
@@ -1,7 +1,6 @@
 import 'react-toastify/dist/ReactToastify.css';
 import Header from '@/shared/ui/Header';
 import Footer from '@/shared/ui/Footer';
-import 'to-do-pin/index.css';
 import type { Metadata } from 'next';
 import BottomNav from '@/shared/ui/bottom-nav';
 import { getUniversityName } from '@/shared/lib/universityMeta';

--- a/src/app/[universityCode]/(main)/layout.tsx
+++ b/src/app/[universityCode]/(main)/layout.tsx
@@ -2,7 +2,6 @@ import 'react-toastify/dist/ReactToastify.css';
 import Header from '@/shared/ui/Header';
 import Footer from '@/shared/ui/Footer';
 import KakaoAdFit from '@/shared/ui/kakao-adfit';
-import 'to-do-pin/index.css';
 import type { Metadata } from 'next';
 import BottomNav from '@/shared/ui/bottom-nav';
 import QueryProvider from '@/shared/lib/QueryProvider';

--- a/src/app/[universityCode]/login/layout.tsx
+++ b/src/app/[universityCode]/login/layout.tsx
@@ -1,7 +1,6 @@
 import 'react-toastify/dist/ReactToastify.css';
 import Header from '@/shared/ui/Header';
 import Footer from '@/shared/ui/Footer';
-import 'to-do-pin/index.css';
 import BottomNav from '@/shared/ui/bottom-nav';
 
 export default function LoginLayout({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import WebVitalProvider from '@/_providers/webvital-provider';
 import ClarityProvider from '@/_providers/clarity-provider';
 import Script from 'next/script';
-import { ToDoPinProvider } from 'to-do-pin';
+import DevToDoPin from '@/shared/ui/DevToDoPin';
 import { AppSessionProvider } from '@/shared/lib/session-context';
 import { ToastContainer } from 'react-toastify';
 import MSWProvider from '@/_providers/msw-provider';
@@ -66,7 +66,7 @@ export default function RootLayout({
         <NuqsAdapter>
           <MSWProvider>
             <AppSessionProvider>
-              <ToDoPinProvider>
+              <DevToDoPin>
                 <WebVitalProvider />
                 <ToastContainer
                   autoClose={2000}
@@ -77,7 +77,7 @@ export default function RootLayout({
                   limit={1}
                 />
                 {children}
-              </ToDoPinProvider>
+              </DevToDoPin>
             </AppSessionProvider>
           </MSWProvider>
         </NuqsAdapter>

--- a/src/shared/ui/DevToDoPin.tsx
+++ b/src/shared/ui/DevToDoPin.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+export default function DevToDoPin({ children }: { children: ReactNode }) {
+  // CSS는 정적 import여야 Turbopack이 모듈 팩토리를 만든다. 컴포넌트 본문에서 직접
+  // require하면 dev가 깨지므로 정적 import는 Content 모듈에 두고, 그 모듈만 죽은
+  // 분기에서 require해 프로덕션 번들에서 JS/CSS를 통째로 걷어낸다.
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line global-require
+    const DevToDoPinContent = require('./DevToDoPinContent').default;
+
+    return <DevToDoPinContent>{children}</DevToDoPinContent>;
+  }
+
+  return children;
+}

--- a/src/shared/ui/DevToDoPinContent.tsx
+++ b/src/shared/ui/DevToDoPinContent.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+// to-do-pin은 개발 환경 전용이라 devDependencies에 있고, 이 모듈은 DevToDoPin의
+// 죽은 분기에서만 require되므로 프로덕션 번들에 포함되지 않는다.
+/* eslint-disable import/no-extraneous-dependencies */
+import 'to-do-pin/index.css';
+import { ToDoPinProvider } from 'to-do-pin';
+/* eslint-enable import/no-extraneous-dependencies */
+import type { ReactNode } from 'react';
+
+export default function DevToDoPinContent({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <ToDoPinProvider>{children}</ToDoPinProvider>;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> closes #696

## 📝작업 내용

`NEXT_PUBLIC_ANALYZE=true pnpm build` 번들 분석 결과, 개발 전용 패키지 두 개가 프로덕션 클라이언트 번들에 포함되고 있어 제거했다.

### 1. to-do-pin 제거

개발 도구인 `to-do-pin`이 루트 레이아웃과 6개 레이아웃에서 정적 import되어 프로덕션 번들에 그대로 들어가 있었다.

`NODE_ENV` 죽은 분기에서만 `require`하는 `DevToDoPin` 래퍼를 두어 webpack이 빌드 시점에 JS/CSS를 함께 걷어내도록 했다.

정적 import는 `DevToDoPinContent`로 분리했다. 컴포넌트 본문에서 CSS를 직접 `require`하면 Turbopack이 모듈 팩토리를 만들지 못해 dev가 깨지기 때문이다.

```
Module .../to-do-pin/dist/index.css [app-client] (css) was instantiated
because it was required from .../DevToDoPin.tsx, but the module factory is not available
```

`to-do-pin`은 개발 전용이므로 `devDependencies`로 이동했다.

### 2. msw 청크 미생성

`MSWProvider`가 조기 return 뒤에서 동적 import를 호출하고 있었다. webpack은 도달 불가 코드에서도 import를 구문 단위로 수집하므로, `NEXT_PUBLIC_API_MOCKING=disabled`인 프로덕션 빌드에서도 msw 청크가 그대로 생성됐다.

조기 return을 없애고, 빌드 시 치환되는 env 표현식을 조건으로 하는 양성 분기 안으로 import를 옮겼다. 모킹을 켠 환경의 동작은 그대로다.

## 📊수치 비교

`NEXT_PUBLIC_ANALYZE=true pnpm build` 기준 (parsed size).

| 패키지 | 변경 전 | 변경 후 |
|---|---|---|
| `msw` | 95.3KB | **ABSENT** |
| `tldts` | 81.2KB | **ABSENT** |
| `tough-cookie` | 37.6KB | **ABSENT** |
| `@mswjs/interceptors` | 16.0KB | **ABSENT** |
| `to-do-pin` | 18.2KB | **ABSENT** |

청크 단위로는 msw 전용 청크가 통째로 사라졌다.

| | 변경 전 | 변경 후 |
|---|---|---|
| msw 청크 | 266.8KB parsed / **87.4KB gzip** | **미생성** |
| 클라이언트 번들 총합 | 1.82MB parsed | 1.81MB parsed |

## ⚠️주의: 성능 지표는 개선되지 않는다

배포 산출물 크기는 줄었지만, **두 패키지 모두 홈에서 다운로드되던 것이 아니다.**

- msw는 async 청크라 초기 로드에 포함되지 않았음
- to-do-pin은 홈 초기 청크 밖에 있었음

홈 First Load JS는 변동 없다.

| | 변경 전 | 변경 후 |
|---|---|---|
| `/[universityCode]` First Load JS | 130 kB | 130 kB |
| 공유 청크 | 103 kB | 103 kB |

즉 이 PR은 **배포 크기와 의존성 위생을 고친 것이지 TBT/LCP를 고친 것이 아니다.** 이슈 #696의 원래 목표인 TBT 790ms 개선은 별도로 이어가야 한다.

참고로 홈의 130 kB 중 103 kB가 Next + React 공유 베이스라인이라 애플리케이션 코드로 깎을 여지는 27 kB뿐이다. 프로덕션 Lighthouse가 지목한 118 KiB짜리 `3416` 청크는 로컬 빌드에 존재하지 않는데, `.env.local`에 `NEXT_PUBLIC_SENTRY_DSN`이 없어 `withSentryConfig`가 적용되지 않기 때문으로 보인다. Sentry 여부 확인이 다음 단계다.

### 검토에서 제외한 것

react-toastify도 같이 다루려 했으나 효과가 없어 되돌렸다. `ToastContainer`와 CSS를 async로 분리해도 `toast()`를 정적 import하는 파일이 20곳 넘고 그중 `useServerAction.ts`, `header-admin-link.tsx`가 홈 트리에 있어 라이브러리 본체가 초기 청크에 그대로 남는다. 제대로 걷어내려면 호출부 전체를 래핑해야 해서 별도 작업으로 분리했다.

## 💬리뷰 요구사항(선택)

- `DevToDoPin`의 `require` 사용은 조건부이면서 동기인 유일한 형태라서 택했다. 동적 import는 앱 전체를 감싸는 래퍼라 로드될 때까지 트리 전체가 언마운트되어 쓸 수 없다.
- dev에서 `to-do-pin` 핀이 정상 동작하는지 확인 부탁드린다. 프로덕션에서만 걷히고 개발 환경 동작은 그대로여야 한다.