### PR TITLE
[#705] perf: Next 15 Data Cache 미적용 수정

### DIFF
--- a/src/entities/club-detail/api/getClubDetail.ts
+++ b/src/entities/club-detail/api/getClubDetail.ts
@@ -14,6 +14,7 @@ async function getClubDetail(id: number) {
     } else {
       response = await serverApi
         .get(`clubs/${id}`, {
+          cache: 'force-cache',
           next: { tags: ['clubs', String(id)] },
         })
         .json();

--- a/src/entities/university/api/getUniversities.ts
+++ b/src/entities/university/api/getUniversities.ts
@@ -6,7 +6,10 @@ import { UniversitiesResponse } from '../model/type';
 async function getUniversities() {
   try {
     const response = await serverApi
-      .get('universities', { next: { tags: ['universities'] } })
+      .get('universities', {
+        cache: 'force-cache',
+        next: { tags: ['universities'] },
+      })
       .json<ApiResponse<UniversitiesResponse>>();
 
     const responseData = response.data;

--- a/src/features/admin-club-description/api/postClubRegister.ts
+++ b/src/features/admin-club-description/api/postClubRegister.ts
@@ -27,6 +27,7 @@ export async function postClubRegister(data: ClubRegisterRequest) {
       json: data,
     });
     revalidateTag('clubs');
+    revalidateTag('clubs-search');
 
     return { ok: true, message: '등록이 완료되었습니다.', status: 200 };
   } catch (e) {
@@ -46,6 +47,7 @@ export async function patchClubInfo(
     const payload = await response.json<ClubEditResponse['data']>();
 
     revalidateTag('clubs');
+    revalidateTag('clubs-search');
 
     return {
       ok: true,

--- a/src/features/club-register/api/postClubRegister.ts
+++ b/src/features/club-register/api/postClubRegister.ts
@@ -27,6 +27,7 @@ export async function postClubRegister(data: ClubRegisterRequest) {
       json: data,
     });
     revalidateTag('clubs');
+    revalidateTag('clubs-search');
 
     return { ok: true, message: '등록이 완료되었습니다.', status: 200 };
   } catch (e) {
@@ -46,6 +47,7 @@ export async function patchClubInfo(
     const payload = await response.json<ClubEditResponse['data']>();
 
     revalidateTag('clubs');
+    revalidateTag('clubs-search');
 
     return {
       ok: true,

--- a/src/widgets/club/api/getClubList.ts
+++ b/src/widgets/club/api/getClubList.ts
@@ -48,7 +48,11 @@ async function getClubList({
     const client = isAuthenticated ? api : serverApi;
     const fetchOptions = isAuthenticated
       ? { searchParams, cache: 'no-store' as const }
-      : { searchParams, next: { tags: ['clubs'] } };
+      : {
+          searchParams,
+          cache: 'force-cache' as const,
+          next: { tags: ['clubs'] },
+        };
 
     const response = await client
       .get('clubs', fetchOptions)

--- a/src/widgets/search/api/searchClubs.ts
+++ b/src/widgets/search/api/searchClubs.ts
@@ -33,6 +33,7 @@ async function searchClubs(params: SearchClubsParams) {
     const response = await serverApi
       .get('clubs/search', {
         searchParams,
+        cache: 'force-cache',
         next: { tags: ['clubs-search'] },
       })
       .json<{ data: ClubSearchResponse }>();


### PR DESCRIPTION
## #️⃣연관된 이슈
> closes #705

## 📝작업 내용

### 문제
Next 15부터 `fetch` 기본값이 "캐시 안 함"으로 바뀌었는데, 비로그인 분기 fetch에는 `next: { tags }`만 지정돼 있어 Data Cache가 전혀 동작하지 않고 있었습니다.

`tags`는 캐시를 켜는 스위치가 아니라 **이미 캐시되는 요청에 라벨을 붙이는** 옵션입니다. Next 런타임의 캐시 판단 로직(`patch-fetch.js`)은 `cache`와 `revalidate` 두 값만 보고 `tags`는 보지 않습니다.

```js
const hasNoExplicitCacheConfig =
  pageFetchCacheMode == undefined &&
  (currentFetchCacheConfig == undefined || currentFetchCacheConfig === 'default') &&
  currentFetchRevalidate == undefined;
const autoNoCache = hasNoExplicitCacheConfig && !workStore.isPrerendering || ...
```

Next 14까지는 기본값이 `force-cache`라 `tags`만으로도 동작하던 코드가, 15 업그레이드 이후 조용히 캐싱을 잃은 상태였습니다.

### 변경 사항

**1. 비로그인 분기 fetch에 `cache: 'force-cache'` 추가** (`perf`)

| 파일 | 태그 |
|---|---|
| `widgets/club/api/getClubList.ts` | `clubs` |
| `entities/club-detail/api/getClubDetail.ts` | `clubs`, `{clubId}` |
| `entities/university/api/getUniversities.ts` | `universities` |
| `widgets/search/api/searchClubs.ts` | `clubs-search` |

로그인 분기의 `cache: 'no-store'`는 그대로 뒀습니다. `Authorization` 헤더가 붙는 요청이라 캐싱 대상이 아닙니다.

**2. `clubs-search` 태그 무효화 경로 추가** (`fix`)

캐싱이 실제로 켜지면서 드러나는 문제입니다. `clubs-search`를 무효화하는 곳이 없어 동아리를 등록·수정해도 검색 결과가 영원히 갱신되지 않습니다. `postClubRegister` / `patchClubInfo` 두 파일에 `revalidateTag('clubs-search')`를 추가했습니다.

### 검증

프로덕션 빌드 후 `.next/cache/fetch-cache`에 항목이 적재되는 것을 확인했습니다. 수정 전에는 생성되지 않던 항목들입니다.

```
tags   url                                                    revalidate
clubs  .../clubs?page=1&size=10&universityCode=SEJONG          31536000
clubs  .../clubs?page=1&size=15&universityCode=SEJONG          31536000
clubs  .../clubs?page=2&size=15&universityCode=SEJONG          31536000
```

같은 URL로 3회 연속 요청 후에도 캐시 파일의 수정 시각이 변하지 않는 것까지 확인했습니다 — 백엔드를 재호출하지 않고 캐시에서 응답했다는 뜻입니다.

### 참고

RSC 응답 헤더의 `cache-control: private, no-cache, no-store`는 이번 변경과 무관합니다. 해당 페이지는 `getSession()` → `cookies()`를 읽는 dynamic 라우트라 Next가 항상 붙이는 헤더이고, 로그인 여부에 따라 응답이 달라지므로 유지돼야 하는 동작입니다. 이번 PR이 개선하는 것은 **Next 서버 ↔ 백엔드 API 구간(Data Cache)**입니다.

## 💬리뷰 요구사항(선택)

`force-cache`는 `revalidate` 없이 쓰면 `revalidateTag` 호출 전까지 무기한 캐시됩니다. 현재 태그별 무효화 경로는 아래와 같은데, 시간 기반 만료(`revalidate: N`)를 함께 두는 게 나을지 의견 주시면 반영하겠습니다.

| 태그 | 무효화 호출처 |
|---|---|
| `clubs` | `postClubRegister`, `patchClubInfo` |
| `clubs-search` | `postClubRegister`, `patchClubInfo` (이번 PR에서 추가) |
| `{clubId}` | `patchRecruitment`, `deleteRecruitment` |
| `universities` | 없음 (사실상 정적 데이터) |
